### PR TITLE
Fixes being unable to cancel compiles

### DIFF
--- a/TGServerService/Compiler.cs
+++ b/TGServerService/Compiler.cs
@@ -403,7 +403,8 @@ namespace TGServerService
 						
 						DM.Start();
 						DM.BeginOutputReadLine();
-						DM.WaitForExit();
+						while (!DM.HasExited)
+							DM.WaitForExit(100);
 						DM.CancelOutputRead();
 
 						lock (CompilerLock)


### PR DESCRIPTION
Fixes #95 

Was blocking on a native call so the managed ThreadAbortException wasn't being thrown