### PR TITLE
Push Changelogs before Testmerging.

### DIFF
--- a/TGServerService/InterfaceBase.cs
+++ b/TGServerService/InterfaceBase.cs
@@ -73,7 +73,7 @@ namespace TGServerService
 				if (testmerge_pr != 0)
 				{
 					//Regen changelog so test merge changelogs are included on-server
-					GenerateChangelog(out res);
+					GenerateChangelog();
 					res = MergePullRequestImpl(testmerge_pr, true);
 					if (res != null && res != RepoErrorUpToDate)
 						return res;

--- a/TGServerService/InterfaceBase.cs
+++ b/TGServerService/InterfaceBase.cs
@@ -73,7 +73,7 @@ namespace TGServerService
 				if (testmerge_pr != 0)
 				{
 					//Regen changelog so test merge changelogs are included on-server
-					GenerateChangelog();
+					GenerateChangelog(out res);
 					res = MergePullRequestImpl(testmerge_pr, true);
 					if (res != null && res != RepoErrorUpToDate)
 						return res;


### PR DESCRIPTION
@Cyberboss 
@MrStonedOne 

fixes #130 

Seems right?

Not sure what to do with that out param ```res```, it shouldn't stop the testmerge but it's also completely unneeded at that point. Optional output params when? (C#7 actually, it lets you ignore them with ```out _```)