### PR TITLE
Fixes the 0 push bug again

### DIFF
--- a/TGServerService/Repository.cs
+++ b/TGServerService/Repository.cs
@@ -770,7 +770,7 @@ namespace TGServerService
 					var sum = status.Added.Count() + status.Removed.Count() + status.Modified.Count();
 
 					if (sum == 0)   //nothing to commit
-						return null;
+						return "No changes";
 
 					// Create the committer's signature and commit
 					var authorandcommitter = MakeSig();


### PR DESCRIPTION
This behavior was technically incorrect.

Null indicates a successful commit.