### PR TITLE
Warnings are no longer triggered if a preaction event doesn't exist

### DIFF
--- a/TGServerService/PreactionHandler.cs
+++ b/TGServerService/PreactionHandler.cs
@@ -23,8 +23,7 @@ namespace TGServerService
 		{
 			if (!EventHandlerExists(eventName))
 			{
-				// We don't need a handler, so let's just fail semi-silently.
-				TGServerService.WriteWarning(String.Format("Preaction Event: {0} not running due to missing event handler: {1}", eventName, GetPath(eventName)), TGServerService.EventID.PreactionFail);
+				// We don't need a handler, so let's just fail silently.
 				return true;
 			}
 


### PR DESCRIPTION
Only speak if you have something to say