### PR TITLE
Fixes installer warnings about components in the same feature

### DIFF
--- a/TGServiceInstaller/Product.wxs
+++ b/TGServiceInstaller/Product.wxs
@@ -47,11 +47,11 @@
         <Condition>INSTALLSHORTCUTSTART = 1</Condition>
         <Shortcut Id="StartMenuShortcutCL"
                   Name="TG Command Line"
-                  Target="[#TGCommandLine.exe]"
+                  Target="[!TGCommandLine.exe]"
                   WorkingDirectory="APPLICATIONROOTDIRECTORY"/>
         <Shortcut Id="StartMenuShortcutCP"
                   Name="TG Control Panel"
-                  Target="[#TGControlPanel.exe]"
+                  Target="[!TGControlPanel.exe]"
                   WorkingDirectory="APPLICATIONROOTDIRECTORY"/>
         <Shortcut Id="UninstallProduct"
 									Name="Uninstall TG Station Server"
@@ -68,11 +68,11 @@
         <Condition>INSTALLSHORTCUTDESK = 1</Condition>
         <Shortcut Id="DesktopShortcutCL"
                   Name="TG Command Line"
-                  Target="[#TGCommandLine.exe]"
+                  Target="[!TGCommandLine.exe]"
                   WorkingDirectory="APPLICATIONROOTDIRECTORY"/>
         <Shortcut Id="DesktopShortcutCP"
                   Name="TG Control Panel"
-                  Target="[#TGControlPanel.exe]"
+                  Target="[!TGControlPanel.exe]"
                   WorkingDirectory="APPLICATIONROOTDIRECTORY"/>
         <RemoveFolder Id="CleanUpDKShortCuts" Directory="ApplicationProgramsFolder" On="uninstall"/>
         <RegistryValue Root="HKCU" Key="Software\TGStation\Server" Name="DesktopShortcuts" Type="integer" Value="1" KeyPath="yes"/>


### PR DESCRIPTION
Courtesy of this thread https://stackoverflow.com/questions/21320334/wix-ice60-and-ice69-warnings. We are now warning free.