### PR TITLE
Guards the interface DLL copy operation and no longer tries if the DLLs match

### DIFF
--- a/TGServerService/ServerService.cs
+++ b/TGServerService/ServerService.cs
@@ -70,6 +70,8 @@ namespace TGServerService
 			RepoPushFail = 5500,
 			RepoChangelog = 5600,
 			RepoChangelogFail = 5700,
+			InterfaceDLLUpdated = 5800,
+			InterfaceDLLUpdateFail = 5900,
 			ServiceShutdownFail = 6100,
 			WorldReboot = 6200,
 			ServerUpdateApplied = 6300,


### PR DESCRIPTION
Fixes #263. From what I can tell it's Windows being stupid and not truly releasing the DLL immediately. It's not the end of the world if the update fails but its still some bullshit. We'll wait 1 second then reattempt it before logging the error and continuing normally.