### PR TITLE
Version mismatch warning won't be triggered for service/interface versions within the same minor release number

### DIFF
--- a/TGServiceInterface/Interface.cs
+++ b/TGServiceInterface/Interface.cs
@@ -141,7 +141,7 @@ namespace TGServiceInterface
 			var splits = Interface.GetComponent<ITGSService>().Version().Split(' ');
 			var theirs = new Version(splits[splits.Length - 1].Substring(1));
 			var ours = new Version(FileVersionInfo.GetVersionInfo(System.Reflection.Assembly.GetExecutingAssembly().Location).FileVersion);
-			if(theirs != ours)
+			if(theirs.Major != ours.Major || theirs.Minor != ours.Minor || theirs.Revision != ours.Revision)	//don't care about the patch level
 			{
 				errorMessage = String.Format("Version mismatch between interface version ({0}) and service version ({1}). Some functionality may crash this program.", ours, theirs);
 				return true;


### PR DESCRIPTION
Patches never break the interface