### PR TITLE
Seals the interface class

### DIFF
--- a/TGServiceInterface/Interface.cs
+++ b/TGServiceInterface/Interface.cs
@@ -14,7 +14,7 @@ namespace TGServiceInterface
 	/// <summary>
 	/// Main inteface class for the service
 	/// </summary>
-	public class Interface : IDisposable
+	public sealed class Interface : IDisposable
 	{
 		/// <summary>
 		/// List of <see langword="interface"/>s that can be used with <see cref="GetComponent{T}"/> and <see cref="CreateChannel{T}"/>


### PR DESCRIPTION
Seems like a good idea after reading https://blogs.msdn.microsoft.com/ericlippert/2004/01/22/why-are-so-many-of-the-framework-classes-sealed/