### PR TITLE
Fixes missing project coverages in tests

### DIFF
--- a/TGServiceTests/ControlPanel/TestInstanceSelector.cs
+++ b/TGServiceTests/ControlPanel/TestInstanceSelector.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System.Collections.Generic;
+using TGServiceInterface;
+using TGServiceInterface.Components;
+
+namespace TGControlPanel.Tests
+{
+	/// <summary>
+	/// Tests for <see cref="InstanceSelector"/>
+	/// </summary>
+	[TestClass]
+	public class TestInstanceSelector
+	{
+		/// <summary>
+		/// Test that an <see cref="InstanceSelector"/> can be created without issue
+		/// </summary>
+		[TestMethod]
+		public void TestInstatiation()
+		{
+			var mockLanding = new Mock<ITGLanding>();
+			mockLanding.Setup(x => x.ListInstances()).Returns(new List<InstanceMetadata>());
+			var mockInter = new Mock<IInterface>();
+			mockInter.Setup(x => x.GetComponent<ITGLanding>()).Returns(mockLanding.Object);
+		
+			new InstanceSelector(mockInter.Object).Dispose();
+		}
+	}
+}

--- a/TGServiceTests/TGServiceTests.csproj
+++ b/TGServiceTests/TGServiceTests.csproj
@@ -84,6 +84,14 @@
       <Project>{89191f69-b18e-4b59-b72e-e12f9b6811a0}</Project>
       <Name>TGCommandLine</Name>
     </ProjectReference>
+    <ProjectReference Include="..\TGControlPanel\TGControlPanel.csproj">
+      <Project>{394e7643-6b8c-416f-ab18-95ac12648cdc}</Project>
+      <Name>TGControlPanel</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\TGInstallerWrapper\TGInstallerWrapper.csproj">
+      <Project>{8956d4c3-bfb9-448e-bf5f-ee7e6f9996f9}</Project>
+      <Name>TGInstallerWrapper</Name>
+    </ProjectReference>
     <ProjectReference Include="..\TGServerService\TGServerService.csproj">
       <Project>{f32eda25-0855-411c-af5e-f0d042917e2d}</Project>
       <Name>TGServerService</Name>

--- a/TGServiceTests/TGServiceTests.csproj
+++ b/TGServiceTests/TGServiceTests.csproj
@@ -57,11 +57,13 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.ServiceProcess" />
+    <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CommandLine\Commands\Repository\RepositoryCommandTest.cs" />
     <Compile Include="CommandLine\Commands\Repository\TestRepoSetPushTestmergeCommitsCommand.cs" />
     <Compile Include="CommandLine\Commands\Repository\TestRepoStatusCommand.cs" />
+    <Compile Include="ControlPanel\TestInstanceSelector.cs" />
     <Compile Include="Interface\TestHelpers.cs" />
     <Compile Include="Interface\TestInterface.cs" />
     <Compile Include="OutputProcOverriderTest.cs" />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ before_build:
   - nuget restore TGStationServer3.sln
 build:
   project: TGStationServer3.sln
-  parallel: true
+  parallel: false
   verbosity: minimal
   publish_nuget: true
 after_build:


### PR DESCRIPTION
codecov statuses won't pass but that's fine. We also can't test TGDreamDaemonBridge with the same project because it converts it to x86 which fucks with LibGit2Sharp for some reason. Parallel builds need to be disabled because it makes building the .resx for TGInstallerWrapper come before TGServiceInstaller