### PR TITLE
Initializes DreamDaemon before the compiler

### DIFF
--- a/TGServerService/ServerInstance/ServerInstance.cs
+++ b/TGServerService/ServerInstance/ServerInstance.cs
@@ -37,8 +37,8 @@ namespace TGServerService
 			InitChat();
 			InitRepo();
 			InitByond();
-			InitCompiler();
 			InitDreamDaemon();
+			InitCompiler();
 		}
 
 		/// <summary>


### PR DESCRIPTION
This causes a bug in the 3.2 update that causes the compiler to detect the Live folder as being unintialized