### PR TITLE
Manual settings migration from 3.1/0 to 3.2

### DIFF
--- a/TGS.Installer.UI/TGS.Installer.UI.csproj
+++ b/TGS.Installer.UI/TGS.Installer.UI.csproj
@@ -53,6 +53,7 @@
     <Reference Include="Microsoft.Deployment.WindowsInstaller, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce35f76fcda82bad, processorArchitecture=MSIL" />
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.ServiceProcess" />
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>

--- a/TGS.Server/Instance/Chat.cs
+++ b/TGS.Server/Instance/Chat.cs
@@ -112,7 +112,7 @@ namespace TGS.Server
 			}
 			ChatProviders = null;
 
-			var rawdata = JsonConvert.SerializeObject(infosList);
+			var rawdata = JsonConvert.SerializeObject(infosList, Formatting.Indented);
 
 			Config.ChatProviderData = Interface.Helpers.EncryptData(rawdata, out string entrp);
 			Config.ChatProviderEntropy = entrp;

--- a/TGS.Server/Instance/Repository.cs
+++ b/TGS.Server/Instance/Repository.cs
@@ -860,7 +860,7 @@ namespace TGS.Server
 		/// <param name="list"></param>
 		void SetCurrentPRList(IDictionary<string, IDictionary<string, string>> list)
 		{
-			var rawdata = JsonConvert.SerializeObject(list);
+			var rawdata = JsonConvert.SerializeObject(list, Formatting.Indented);
 			File.WriteAllText(RelativePath(PRJobFile), rawdata);
 		}
 

--- a/TGS.Server/InstanceConfig.cs
+++ b/TGS.Server/InstanceConfig.cs
@@ -120,7 +120,7 @@ namespace TGS.Server
 	}
 
 	/// <inheritdoc />
-	class InstanceConfig : IInstanceConfig
+	public class InstanceConfig : IInstanceConfig
 	{
 		/// <summary>
 		/// The name the file is saved as in the <see cref="Directory"/>
@@ -210,7 +210,7 @@ namespace TGS.Server
 		/// <inheritdoc />
 		public void Save()
 		{
-			var data = JsonConvert.SerializeObject(this);
+			var data = JsonConvert.SerializeObject(this, Formatting.Indented);
 			var path = Path.Combine(Directory, JSONFilename);
 			File.WriteAllText(path, data);
 		}

--- a/TGS.Server/ServerConfig.cs
+++ b/TGS.Server/ServerConfig.cs
@@ -46,7 +46,7 @@ namespace TGS.Server
 		/// <param name="directory">The directory in which to save the <see cref="ServerConfig"/></param>
 		public void Save(string directory)
 		{
-			var data = JsonConvert.SerializeObject(this);
+			var data = JsonConvert.SerializeObject(this, Formatting.Indented);
 			var path = Path.Combine(directory, JSONFilename);
 			File.WriteAllText(path, data);
 		}


### PR DESCRIPTION
3.2 is basically the era of FUCK .NET SETTINGS JESUS CHRIST I SHOULD HAVE USED JSON FROM THE GET GO

Adds prompts to the installer to ensure the 3.2 configs are migrated properly from the 3.1 configs.