### PR TITLE
RootAuthorizationManager properly checks children

### DIFF
--- a/TGS.Server/RootAuthorizationManager.cs
+++ b/TGS.Server/RootAuthorizationManager.cs
@@ -26,7 +26,7 @@ namespace TGS.Server
 			//first allow admins
 			var authSuccess = wp.IsInRole(WindowsBuiltInRole.Administrator);
 			if(!authSuccess && contract == typeof(ITGLanding).Name)
-				return InstanceAuthManagers.FirstOrDefault(x => x.CheckAccess(operationContext)) != null;
+				return InstanceAuthManagers.Any(x => x.CheckAccess(operationContext));
 
 			var user = windowsIdent.Name;
 			if (LastSeenUser != user)


### PR DESCRIPTION
Using `Any<>(...)` instead of `FirstOrDefault<>(...) != null`