### PR TITLE
Gets the interface working on Mono

### DIFF
--- a/TGS.Interface/AuthenticationHeaderApplicator.cs
+++ b/TGS.Interface/AuthenticationHeaderApplicator.cs
@@ -1,4 +1,6 @@
-﻿using System.ServiceModel;
+﻿using System.Collections.Generic;
+using System.Reflection;
+using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Dispatcher;
 using System.ServiceModel.Description;
@@ -16,7 +18,16 @@ namespace TGS.Interface
 
 		public void ApplyClientBehavior(ServiceEndpoint endpoint, ClientRuntime clientRuntime)
 		{
-			clientRuntime.ClientMessageInspectors.Add(this);
+#if __MonoCS__
+			var prop = clientRuntime.GetType()
+									.GetTypeInfo()
+									.GetDeclaredProperty("MessageInspectors");
+			var inspectors = (ICollection<IClientMessageInspector>)prop
+						.GetValue(clientRuntime);
+#else
+			var inspectors = clientRuntime.ClientMessageInspectors;
+#endif
+			inspectors.Add(this);
 		}
 
 		public object BeforeSendRequest(ref Message request, IClientChannel channel)

--- a/TGS.Interface/AuthenticationHeaderApplicator.cs
+++ b/TGS.Interface/AuthenticationHeaderApplicator.cs
@@ -1,0 +1,49 @@
+﻿using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Dispatcher;
+using System.ServiceModel.Description;
+
+namespace TGS.Interface
+{
+	sealed class AuthenticationHeaderApplicator : IEndpointBehavior, IClientMessageInspector
+	{
+		readonly RemoteLoginInfo remoteLoginInfo;
+			
+		public AuthenticationHeaderApplicator(RemoteLoginInfo loginInfo)
+		{
+			remoteLoginInfo = loginInfo;
+		}
+
+		public void ApplyClientBehavior(ServiceEndpoint endpoint, ClientRuntime clientRuntime)
+		{
+			clientRuntime.ClientMessageInspectors.Add(this);
+		}
+
+		public object BeforeSendRequest(ref Message request, IClientChannel channel)
+		{
+			request.Headers.Add(MessageHeader.CreateHeader("Username", "http://tempuri.org", remoteLoginInfo.Username));
+			request.Headers.Add(MessageHeader.CreateHeader("Password", "http://tempuri.org", remoteLoginInfo.Password));
+			return null;
+		}
+
+		public void AddBindingParameters(ServiceEndpoint endpoint, BindingParameterCollection bindingParameters)
+		{
+			//intentionally left blank
+		}
+
+		public void AfterReceiveReply(ref Message reply, object correlationState)
+		{
+			//intentionally left blank
+		}
+
+		public void ApplyDispatchBehavior(ServiceEndpoint endpoint, EndpointDispatcher endpointDispatcher)
+		{
+			//intentionally left blank
+		}
+
+		public void Validate(ServiceEndpoint endpoint)
+		{
+			//intentionally left blank
+		}
+	}
+}

--- a/TGS.Interface/AuthenticationHeaderApplicator.cs
+++ b/TGS.Interface/AuthenticationHeaderApplicator.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Reflection;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
@@ -18,15 +19,18 @@ namespace TGS.Interface
 
 		public void ApplyClientBehavior(ServiceEndpoint endpoint, ClientRuntime clientRuntime)
 		{
-#if __MonoCS__
-			var prop = clientRuntime.GetType()
+			var t = Type.GetType("Mono.Runtime");
+			ICollection<IClientMessageInspector> inspectors;
+			if (t != null)
+			{
+				var prop = clientRuntime.GetType()
 									.GetTypeInfo()
 									.GetDeclaredProperty("MessageInspectors");
-			var inspectors = (ICollection<IClientMessageInspector>)prop
-						.GetValue(clientRuntime);
-#else
-			var inspectors = clientRuntime.ClientMessageInspectors;
-#endif
+				inspectors = (ICollection<IClientMessageInspector>)prop
+							.GetValue(clientRuntime);
+			}
+			else
+				inspectors = clientRuntime.ClientMessageInspectors;
 			inspectors.Add(this);
 		}
 

--- a/TGS.Interface/AuthenticationHeaderApplicator.cs
+++ b/TGS.Interface/AuthenticationHeaderApplicator.cs
@@ -8,15 +8,30 @@ using System.ServiceModel.Description;
 
 namespace TGS.Interface
 {
+	/// <summary>
+	/// Used to attach windows credential headers to SOAP messages
+	/// </summary>
 	sealed class AuthenticationHeaderApplicator : IEndpointBehavior, IClientMessageInspector
 	{
+		/// <summary>
+		/// The credentials to attach
+		/// </summary>
 		readonly RemoteLoginInfo remoteLoginInfo;
-			
+		
+		/// <summary>
+		/// Construct a <see cref="AuthenticationHeaderApplicator"/>
+		/// </summary>
+		/// <param name="loginInfo">The <see cref="RemoteLoginInfo"/> to use</param>
 		public AuthenticationHeaderApplicator(RemoteLoginInfo loginInfo)
 		{
 			remoteLoginInfo = loginInfo;
 		}
 
+		/// <summary>
+		/// Add <see langword="this"/> to the message inspectors for the channel
+		/// </summary>
+		/// <param name="endpoint">The <see cref="ServiceEndpoint"/></param>
+		/// <param name="clientRuntime">The <see cref="ClientRuntime"/></param>
 		public void ApplyClientBehavior(ServiceEndpoint endpoint, ClientRuntime clientRuntime)
 		{
 			var t = Type.GetType("Mono.Runtime");
@@ -34,6 +49,12 @@ namespace TGS.Interface
 			inspectors.Add(this);
 		}
 
+		/// <summary>
+		/// Attach <see cref="RemoteLoginInfo.Username"/> and <see cref="RemoteLoginInfo.Password"/> to the <paramref name="request"/>
+		/// </summary>
+		/// <param name="request">The outgoing request</param>
+		/// <param name="channel">The <see cref="IClientChannel"/></param>
+		/// <returns></returns>
 		public object BeforeSendRequest(ref Message request, IClientChannel channel)
 		{
 			request.Headers.Add(MessageHeader.CreateHeader("Username", "http://tempuri.org", remoteLoginInfo.Username));
@@ -41,21 +62,33 @@ namespace TGS.Interface
 			return null;
 		}
 
+		/// <summary>
+		/// Unused implementation of <see cref="IEndpointBehavior"/>
+		/// </summary>
 		public void AddBindingParameters(ServiceEndpoint endpoint, BindingParameterCollection bindingParameters)
 		{
 			//intentionally left blank
 		}
 
+		/// <summary>
+		/// Unused implementation of <see cref="IClientMessageInspector"/>
+		/// </summary>
 		public void AfterReceiveReply(ref Message reply, object correlationState)
 		{
 			//intentionally left blank
 		}
 
+		/// <summary>
+		/// Unused implementation of <see cref="IEndpointBehavior"/>
+		/// </summary>
 		public void ApplyDispatchBehavior(ServiceEndpoint endpoint, EndpointDispatcher endpointDispatcher)
 		{
 			//intentionally left blank
 		}
 
+		/// <summary>
+		/// Unused implementation of <see cref="IEndpointBehavior"/>
+		/// </summary>
 		public void Validate(ServiceEndpoint endpoint)
 		{
 			//intentionally left blank

--- a/TGS.Interface/ServerInterface.cs
+++ b/TGS.Interface/ServerInterface.cs
@@ -393,24 +393,17 @@ namespace TGS.Interface
 			}
 
 			//okay we're going over
-			var binding = new WSHttpBinding()
+			var binding = new BasicHttpsBinding()
 			{
 				SendTimeout = new TimeSpan(0, 0, 40),
 				MaxReceivedMessageSize = TransferLimitRemote
 			};
 			var requireAuth = InterfaceName != typeof(ITGConnectivity).Name;
-			binding.Security.Transport.ClientCredentialType = HttpClientCredentialType.None;
-			binding.Security.Mode = requireAuth ? SecurityMode.TransportWithMessageCredential : SecurityMode.Transport;    //do not require auth for a connectivity check
-			binding.Security.Message.ClientCredentialType = requireAuth ? MessageCredentialType.UserName : MessageCredentialType.None;
 			var url = String.Format("https://{0}:{1}/{2}/{3}", LoginInfo.IP, LoginInfo.Port, accessPath, InterfaceName);
 			var address = new EndpointAddress(url);
 			var res = new ChannelFactory<T>(binding, address);
 			if (requireAuth)
-			{
-				res.Credentials.UserName.UserName = LoginInfo.Username;
-				res.Credentials.UserName.Password = LoginInfo.Password;
-				res.Credentials.Windows.AllowedImpersonationLevel = TokenImpersonationLevel.Impersonation;
-			}
+				res.Endpoint.EndpointBehaviors.Add(new AuthenticationHeaderApplicator(LoginInfo));
 			return res;
 		}
 

--- a/TGS.Interface/ServerInterface.cs
+++ b/TGS.Interface/ServerInterface.cs
@@ -284,7 +284,6 @@ namespace TGS.Interface
 					var cf = I.Value;
 					try
 					{
-						cf.Closed += ChannelFactory_Closed;
 						cf.Close();
 					}
 					catch
@@ -308,16 +307,6 @@ namespace TGS.Interface
 			}
 			errorMessage = null;
 			return false;
-		}
-
-		/// <summary>
-		/// Disposes a closed <see cref="ChannelFactory"/>
-		/// </summary>
-		/// <param name="sender">The channel factory that was closed</param>
-		/// <param name="e">The event arguments</param>
-		static void ChannelFactory_Closed(object sender, EventArgs e)
-		{
-			(sender as IDisposable).Dispose();
 		}
 
 		/// <inheritdoc />

--- a/TGS.Interface/ServerInterface.cs
+++ b/TGS.Interface/ServerInterface.cs
@@ -407,15 +407,18 @@ namespace TGS.Interface
 			if (requireAuth)
 			{
 				var applicator = new AuthenticationHeaderApplicator(LoginInfo);
-#if __MonoCS__
-				var prop = res.Endpoint.GetType()
-				 .GetTypeInfo()
-				 .GetDeclaredProperty("Behaviors");
-				var behaviours = (KeyedCollection<Type, IEndpointBehavior>)prop
-								 .GetValue(res.Endpoint);
-#else
-				var behaviours = res.Endpoint.EndpointBehaviors;
-#endif
+				var t = Type.GetType("Mono.Runtime");
+				KeyedCollection<Type, IEndpointBehavior> behaviours;
+				if (t != null)
+				{
+					var prop = res.Endpoint.GetType()
+					 .GetTypeInfo()
+					 .GetDeclaredProperty("Behaviors");
+					behaviours = (KeyedCollection<Type, IEndpointBehavior>)prop
+									 .GetValue(res.Endpoint);
+				}
+				else
+					behaviours = res.Endpoint.EndpointBehaviors;
 				behaviours.Add(applicator);
 			}
 			return res;

--- a/TGS.Interface/TGS.Interface.csproj
+++ b/TGS.Interface/TGS.Interface.csproj
@@ -47,6 +47,7 @@
     <Reference Include="System.Web.Extensions" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AuthenticationHeaderApplicator.cs" />
     <Compile Include="Components\Administration.cs" />
     <Compile Include="Components\Byond.cs" />
     <Compile Include="ChatSetupInfo.cs" />

--- a/TGS.Server/Instance/Administration.cs
+++ b/TGS.Server/Instance/Administration.cs
@@ -5,6 +5,7 @@ using System.ServiceModel;
 using System.Threading;
 using TGS.Interface;
 using TGS.Interface.Components;
+using TGS.Server.Security;
 
 namespace TGS.Server
 {

--- a/TGS.Server/Instance/Config.cs
+++ b/TGS.Server/Instance/Config.cs
@@ -15,9 +15,9 @@ namespace TGS.Server
 		object configLock = new object();	//for atomic reads/writes
 
 		/// <inheritdoc />
-		[OperationBehavior(Impersonation = ImpersonationOption.Required)]
 		public string ReadText(string staticRelativePath, bool repo, out string error, out bool unauthorized)
 		{
+			Server.BeginImpersonation();
 			string path = null;
 			try
 			{
@@ -100,9 +100,9 @@ namespace TGS.Server
 		}
 
 		/// <inheritdoc />
-		[OperationBehavior(Impersonation = ImpersonationOption.Required)]
 		public string WriteText(string staticRelativePath, string data, out bool unauthorized)
 		{
+			Server.BeginImpersonation();
 			var path = RelativePath(StaticDirs) + '/' + staticRelativePath;   //do not use path.combine or it will try and take the root
 			try
 			{
@@ -152,9 +152,9 @@ namespace TGS.Server
 			}
 		}
 		/// <inheritdoc />
-		[OperationBehavior(Impersonation = ImpersonationOption.Required)]
 		public string DeleteFile(string staticRelativePath, out bool unauthorized)
 		{
+			Server.BeginImpersonation();
 			var path = RelativePath(StaticDirs + '/' + staticRelativePath);   //do not use path.combine or it will try and take the root
 			try
 			{
@@ -207,9 +207,9 @@ namespace TGS.Server
 		}
 
 		/// <inheritdoc />
-		[OperationBehavior(Impersonation = ImpersonationOption.Required)]
 		public IList<string> ListStaticDirectory(string subDir, out string error, out bool unauthorized)
 		{
+			Server.BeginImpersonation();
 			try
 			{
 				if (!Directory.Exists(RelativePath(StaticDirs)))

--- a/TGS.Server/Security/AuthenticationHeaderDecoder.cs
+++ b/TGS.Server/Security/AuthenticationHeaderDecoder.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Collections.Generic;
+using System.IdentityModel.Claims;
+using System.IdentityModel.Policy;
+using System.Runtime.InteropServices;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+
+namespace TGS.Server.Security
+{
+	sealed class AuthenticationHeaderDecoder : ServiceAuthenticationManager
+	{
+		[DllImport("advapi32.dll", SetLastError = true)]
+		static extern bool LogonUser(string lpszUsername, string lpszDomain, string lpszPassword, int dwLogonType, int dwLogonProvider, out IntPtr phToken);
+		[DllImport("kernel32.dll", SetLastError = true)]
+		static extern bool CloseHandle(IntPtr handle);
+
+		public ClaimSet Issuer => throw new NotImplementedException();
+
+		public string Id => throw new NotImplementedException();
+
+		public override ReadOnlyCollection<IAuthorizationPolicy> Authenticate(ReadOnlyCollection<IAuthorizationPolicy> authPolicy, Uri listenUri, ref Message message)
+		{
+			try
+			{
+				var userPosition = message.Headers.FindHeader("Username", "http://tempuri.org");
+				var passPosition = message.Headers.FindHeader("Password", "http://tempuri.org");
+
+				if (userPosition != -1 && passPosition != -1)
+				{
+
+					var user = message.Headers.GetHeader<string>(userPosition);
+					var pass = message.Headers.GetHeader<string>(passPosition);
+
+					var splits = user.Split('\\');
+
+					var res = LogonUser(splits.Length > 1 ? splits[1] : splits[0], splits.Length > 1 ? splits[0] : null, pass, 3 /*LOGON32_LOGON_NETWORK*/, 0 /*LOGON32_PROVIDER_DEFAULT*/, out IntPtr token);
+					if (res)
+					{
+						//IMPORTANT: logoff the user after all is said and done or they'll stay logged in on the system for as long as we are
+						OperationContext.Current.OperationCompleted += (a, b) => { CloseHandle(token); };
+						return new ReadOnlyCollection<IAuthorizationPolicy>(new List<IAuthorizationPolicy> { new WindowsAuthorizationPolicy(token) });
+					}
+				}
+			}
+			catch { }
+			return authPolicy;
+		}
+	}
+}

--- a/TGS.Server/Security/AuthenticationHeaderDecoder.cs
+++ b/TGS.Server/Security/AuthenticationHeaderDecoder.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Collections.ObjectModel;
 using System.Collections.Generic;
-using System.IdentityModel.Claims;
 using System.IdentityModel.Policy;
 using System.Runtime.InteropServices;
+using System.Security.Principal;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
 
@@ -11,15 +11,24 @@ namespace TGS.Server.Security
 {
 	sealed class AuthenticationHeaderDecoder : ServiceAuthenticationManager
 	{
+		/// <summary>
+		/// See https://msdn.microsoft.com/en-us/library/windows/desktop/aa378184(v=vs.85).aspx
+		/// </summary>
 		[DllImport("advapi32.dll", SetLastError = true)]
 		static extern bool LogonUser(string lpszUsername, string lpszDomain, string lpszPassword, int dwLogonType, int dwLogonProvider, out IntPtr phToken);
+		/// <summary>
+		/// See https://msdn.microsoft.com/en-us/library/windows/desktop/ms724211(v=vs.85).aspx
+		/// </summary>
 		[DllImport("kernel32.dll", SetLastError = true)]
 		static extern bool CloseHandle(IntPtr handle);
 
-		public ClaimSet Issuer => throw new NotImplementedException();
-
-		public string Id => throw new NotImplementedException();
-
+		/// <summary>
+		/// Authenticates a given <see cref="Message"/>
+		/// </summary>
+		/// <param name="authPolicy">The default <see cref="IAuthorizationPolicy"/>s</param>
+		/// <param name="listenUri">The <see cref="Uri"/> at which the message was received.</param>
+		/// <param name="message">The <see cref="Message"/> to be authenticated</param>
+		/// <returns>A <see cref="ReadOnlyCollection{T}"/> of <see cref="IAuthorizationPolicy"/>s. Either <paramref name="authPolicy"/> or one containing a single <see cref="WindowsAuthorizationPolicy"/> if this function successfully creates one</returns>
 		public override ReadOnlyCollection<IAuthorizationPolicy> Authenticate(ReadOnlyCollection<IAuthorizationPolicy> authPolicy, Uri listenUri, ref Message message)
 		{
 			try
@@ -29,7 +38,6 @@ namespace TGS.Server.Security
 
 				if (userPosition != -1 && passPosition != -1)
 				{
-
 					var user = message.Headers.GetHeader<string>(userPosition);
 					var pass = message.Headers.GetHeader<string>(passPosition);
 
@@ -38,9 +46,9 @@ namespace TGS.Server.Security
 					var res = LogonUser(splits.Length > 1 ? splits[1] : splits[0], splits.Length > 1 ? splits[0] : null, pass, 3 /*LOGON32_LOGON_NETWORK*/, 0 /*LOGON32_PROVIDER_DEFAULT*/, out IntPtr token);
 					if (res)
 					{
-						//IMPORTANT: logoff the user after all is said and done or they'll stay logged in on the system for as long as we are
+						//IMPORTANT: logoff the user after all is said and done or they'll stay logged in on the system for as long as we are running
 						OperationContext.Current.OperationCompleted += (a, b) => { CloseHandle(token); };
-						return new ReadOnlyCollection<IAuthorizationPolicy>(new List<IAuthorizationPolicy> { new WindowsAuthorizationPolicy(token) });
+						return new ReadOnlyCollection<IAuthorizationPolicy>(new List<IAuthorizationPolicy> { new WindowsAuthorizationPolicy(new WindowsIdentity(token)) });
 					}
 				}
 			}

--- a/TGS.Server/Security/RootAuthorizationManager.cs
+++ b/TGS.Server/Security/RootAuthorizationManager.cs
@@ -5,7 +5,7 @@ using System.Security.Principal;
 using System.ServiceModel;
 using TGS.Interface.Components;
 
-namespace TGS.Server
+namespace TGS.Server.Security
 {
 	/// <summary>
 	/// A <see cref="ServiceAuthorizationManager"/> used to determine only if the caller is an admin

--- a/TGS.Server/Security/WindowsAuthorizationPolicy.cs
+++ b/TGS.Server/Security/WindowsAuthorizationPolicy.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IdentityModel.Claims;
+using System.IdentityModel.Policy;
+using System.Security.Principal;
+
+namespace TGS.Server.Security
+{
+	sealed class WindowsAuthorizationPolicy : IAuthorizationPolicy
+	{
+		readonly WindowsIdentity identity;
+		public WindowsAuthorizationPolicy(IntPtr identityToken)
+		{
+			identity = new WindowsIdentity(identityToken);
+		}
+		public ClaimSet Issuer => throw new NotImplementedException();
+
+		public string Id => throw new NotImplementedException();
+
+		public bool Evaluate(EvaluationContext evaluationContext, ref object state)
+		{
+			evaluationContext.Properties["Identities"] = new List<IIdentity> { identity };
+			return true;
+		}
+	}
+}

--- a/TGS.Server/Security/WindowsAuthorizationPolicy.cs
+++ b/TGS.Server/Security/WindowsAuthorizationPolicy.cs
@@ -6,17 +6,41 @@ using System.Security.Principal;
 
 namespace TGS.Server.Security
 {
+	/// <summary>
+	/// Implements an <see cref="IAuthorizationPolicy"/> for <see cref="WindowsIdentity"/>
+	/// </summary>
 	sealed class WindowsAuthorizationPolicy : IAuthorizationPolicy
 	{
+		/// <summary>
+		/// The <see cref="WindowsIdentity"/> to use
+		/// </summary>
 		readonly WindowsIdentity identity;
-		public WindowsAuthorizationPolicy(IntPtr identityToken)
+
+		/// <summary>
+		/// Construct a <see cref="WindowsAuthorizationPolicy"/>
+		/// </summary>
+		/// <param name="ident">The value of <see cref="identity"/></param>
+		public WindowsAuthorizationPolicy(WindowsIdentity ident)
 		{
-			identity = new WindowsIdentity(identityToken);
+			identity = ident;
 		}
+
+		/// <summary>
+		/// Unused implementation of <see cref="IAuthorizationPolicy"/>
+		/// </summary>
 		public ClaimSet Issuer => throw new NotImplementedException();
 
+		/// <summary>
+		/// Unused implementation of <see cref="IAuthorizationPolicy"/>
+		/// </summary>
 		public string Id => throw new NotImplementedException();
 
+		/// <summary>
+		/// Attaches <see cref="identity"/> to <paramref name="evaluationContext"/>'s properties
+		/// </summary>
+		/// <param name="evaluationContext">The <see cref="EvaluationContext"/></param>
+		/// <param name="state">A state object</param>
+		/// <returns><see langword="true"/></returns>
 		public bool Evaluate(EvaluationContext evaluationContext, ref object state)
 		{
 			evaluationContext.Properties["Identities"] = new List<IIdentity> { identity };

--- a/TGS.Server/Server.cs
+++ b/TGS.Server/Server.cs
@@ -27,7 +27,7 @@ namespace TGS.Server
 		public const string MigrationConfigDirectory = "C:\\TGSSettingUpgradeTempDir";
 
 		/// <summary>
-		/// The service version <see cref="string"/> based on the <see cref="FileVersionInfo"/>
+		/// The service version <see cref="string"/> based on the <see cref="AssemblyName"/>'s <see cref="System.Version"/>
 		/// </summary>
 		public static readonly string VersionString = String.Format("/tg/station 13 Server v{0}", Assembly.GetExecutingAssembly().GetName().Version);
 

--- a/TGS.Server/TGS.Server.csproj
+++ b/TGS.Server/TGS.Server.csproj
@@ -71,6 +71,7 @@
     <Reference Include="System.configuration" />
     <Reference Include="System.Configuration.Install" />
     <Reference Include="System.DirectoryServices.AccountManagement" />
+    <Reference Include="System.IdentityModel" />
     <Reference Include="System.Interactive.Async, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Interactive.Async.3.1.1\lib\net45\System.Interactive.Async.dll</HintPath>
     </Reference>
@@ -80,6 +81,7 @@
     <Reference Include="System.Web" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Security\AuthenticationHeaderDecoder.cs" />
     <Compile Include="ChatCommands\ByondCommand.cs" />
     <Compile Include="ChatCommands\CommandInfo.cs" />
     <Compile Include="ChatCommands\ChatCommand.cs" />
@@ -91,7 +93,7 @@
     <Compile Include="ChatCommands\VersionCommand.cs" />
     <Compile Include="Helpers.cs" />
     <Compile Include="ILogger.cs" />
-    <Compile Include="RootAuthorizationManager.cs" />
+    <Compile Include="Security\RootAuthorizationManager.cs" />
     <Compile Include="DeprecatedInstanceConfig.cs" />
     <Compile Include="InstanceConfig.cs" />
     <Compile Include="MessageType.cs" />
@@ -111,6 +113,7 @@
     <Compile Include="Instance\PreactionHandler.cs" />
     <Compile Include="ProcessExtension.cs" />
     <Compile Include="Instance\Repository.cs" />
+    <Compile Include="Security\WindowsAuthorizationPolicy.cs" />
     <Compile Include="Server.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\AssemblyInfo.global.cs" />

--- a/TGS.Tests/ServiceInterface/TestInterface.cs
+++ b/TGS.Tests/ServiceInterface/TestInterface.cs
@@ -86,9 +86,9 @@ namespace TGS.Interface.Tests
 		}
 
 		[TestMethod]
-		public void TestRemoteAccessInterfaceAllowsWindowsImpersonation()
+		public void TestLocalAccessInterfaceAllowsWindowsImpersonation()
 		{
-			var inter = CreateFakeRemoteInterface();
+			var inter = new ServerInterface();
 			var po = new PrivateObject(inter);
 			var cf = (ChannelFactory<ITGConfig>)po.Invoke("CreateChannel", new Type[] { typeof(string) }, new object[] { TestInstanceName }, new Type[] { typeof(ITGConfig) });
 			Assert.AreEqual(cf.Credentials.Windows.AllowedImpersonationLevel, System.Security.Principal.TokenImpersonationLevel.Impersonation);


### PR DESCRIPTION
Fixes #312 

![untitled](https://user-images.githubusercontent.com/8171642/33340831-252c87be-d44b-11e7-9d0d-79f0cf49c0b7.png)

Let me explain what's going on here.

The problem in the current Interface on mono is that the TransportWithMessageCredential enum, which attaches Windows credentials to a SOAP header, is unimplemented. We can work around this by attaching the username and password to our own custom headers, which are also protected by SSL. Once that's done, we override the ServiceAuthenticationManagers server side to turn the username and passwords into WindowsIdentitys, which are released after the operation completes, and then inject them into the WCF security context.

TL;DR: Mono works, android is next