### PR TITLE
Fix GetRepositoryRemote

### DIFF
--- a/TGS.ControlPanel/Program.cs
+++ b/TGS.ControlPanel/Program.cs
@@ -115,6 +115,11 @@ namespace TGS.ControlPanel
 			}
 
 			//Assume standard gh format: [(git)|(https)]://github.com/owner/repo(.git)[0-1]
+			//Yes use .git twice in case it was weird
+			var toRemove = new string[] { ".git", "/", ".git" };
+			foreach (string item in toRemove)
+				if (remote.EndsWith(item))
+					remote = remote.Substring(0, remote.LastIndexOf(item));
 			var splits = remote.Split('/');
 			name = splits[splits.Length - 1];
 			owner = splits[splits.Length - 2].Split('.')[0];


### PR DESCRIPTION
If the repo was cloned with .git in the name, test merges would fail painfully