### PR TITLE
Temp branch name is now derived from Instance name

### DIFF
--- a/TGS.Server/Instance/Repository.cs
+++ b/TGS.Server/Instance/Repository.cs
@@ -608,7 +608,7 @@ namespace TGS.Server
 				try
 				{
 					//now try and push the commit to the remote so they can be referenced
-					NewB = Repo.CreateBranch(RemoteTempBranchName).CanonicalName;
+					NewB = Repo.CreateBranch(RemoteTempBranchName + Config.Name).CanonicalName;
 					Repo.Network.Push(targetRemote, NewB, options); //push the branch
 					Repo.Branches.Remove(NewB);
 					var removalString = String.Format(":{0}", NewB);


### PR DESCRIPTION
This should fix the race conditions

@lzimann you might want to add `___TGS3TempBranchBagil`, `___TGS3TempBranchSybil`, and `___TGS3TempBranchTerry` to Zbots ignore list