### PR TITLE
Add ServerStartupTimeout to instance config

### DIFF
--- a/TGS.Server/DeprecatedInstanceConfig.cs
+++ b/TGS.Server/DeprecatedInstanceConfig.cs
@@ -39,7 +39,13 @@ namespace TGS.Server
 		/// </summary>
 		void Migrate()
 		{
-			//Not needed so far
+			switch (Version)
+			{
+				//add this field
+				case 0:
+					ServerStartupTimeout = 60;
+					break;
+			}
 		}
 	}
 }

--- a/TGS.Server/Instance/DreamDaemon.cs
+++ b/TGS.Server/Instance/DreamDaemon.cs
@@ -30,10 +30,6 @@ namespace TGS.Server
 		/// </summary>
 		const string ResourceDiagnosticsDir = DiagnosticsDir + "/Resources";
 		/// <summary>
-		/// Time until DD is considered DOA on startup
-		/// </summary>
-		const int DDHangStartTime = 60;
-		/// <summary>
 		/// If DreamDaemon crashes before this time it is considered a bad startup
 		/// </summary>
 		const int DDBadStartTime = 10;
@@ -625,14 +621,15 @@ namespace TGS.Server
 					Proc.Start();
 					Proc.PriorityClass = ProcessPriorityClass.AboveNormal;
 
-					if (!Proc.WaitForInputIdle(DDHangStartTime * 1000))
+					var timeout = Config.ServerStartupTimeout;
+					if (!Proc.WaitForInputIdle(timeout * 1000))
 					{
 						Proc.Kill();
 						Proc.WaitForExit();
 						Proc.Close();
 						currentStatus = DreamDaemonStatus.Offline;
 						currentPort = 0;
-						return String.Format("Server start is taking more than {0}s! Aborting!", DDHangStartTime);
+						return String.Format("Server start is taking more than {0}s! Aborting!", timeout);
 					}
 					currentPort = Config.Port;
 					currentStatus = DreamDaemonStatus.Online;

--- a/TGS.Server/InstanceConfig.cs
+++ b/TGS.Server/InstanceConfig.cs
@@ -114,6 +114,11 @@ namespace TGS.Server
 		bool PushTestmergeCommits { get; set; }
 
 		/// <summary>
+		/// Time in seconds before DD is considered dead in the water
+		/// </summary>
+		int ServerStartupTimeout { get; set; }
+
+		/// <summary>
 		/// Saves the <see cref="IInstanceConfig"/> to it's <see cref="Instance"/> <see cref="Directory"/>
 		/// </summary>
 		void Save();
@@ -132,7 +137,7 @@ namespace TGS.Server
 		/// The current version of the config
 		/// </summary>
 		[JsonIgnore]
-		protected const ulong CurrentVersion = 0;   //Literally any time you add/deprecated a field, this number needs to be bumped
+		protected const ulong CurrentVersion = 1;   //Literally any time you add/deprecated a field, this number needs to be bumped
 
 		/// <inheritdoc />
 		[JsonIgnore]
@@ -197,6 +202,9 @@ namespace TGS.Server
 
 		/// <inheritdoc />
 		public bool PushTestmergeCommits { get; set; } = false;
+
+		/// <inheritdoc />
+		public int ServerStartupTimeout { get; set; } = 60;
 
 		/// <summary>
 		/// Construct a <see cref="InstanceConfig"/> for a <see cref="Instance"/> at <paramref name="path"/>


### PR DESCRIPTION
Requested by @deathride58

Adds a field to the instance json that can change the default startup timeout for DreamDaemon. No frontend b/c v3 is on life support