### PR TITLE
Update Repo URL in README and GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Requires python 2.7/3.6 to be installed for changelog generation
 ## Installing (GUI):
 1. Launch `TGControlPanel.exe` as an administrator. A shortcut can be found on your desktop
 1. Use the `Create Instance` button to create a new server instance
-1. Go to the `Repository` Tab and set the remote address and branch of the git you with to track
+1. Go to the `Repository` Tab and set the remote address and branch of the git you with to track. Note: To grab the tgstation repo, use the following URL: git://github.com/tgstation/tgstation.git
 1. Hit the clone button
 1. While waiting go to the `BYOND` tab and install the BYOND version you wish
 1. You may also configure an IRC and/or discord bot for the server on the chat tab
@@ -40,7 +40,7 @@ Requires python 2.7/3.6 to be installed for changelog generation
 ## Installing (CL example):
 This process is identical to the above steps in command line mode. You can always learn more about a command using `?` i.e. `repo ?`
 1. Launch TGCommandLine.exe as an administrator (running with no parameters puts you in interactive mode)
-1. `service set-python-path C:\Python27`
+1. `service set-python-path C:\Python27` (If Your Python Install is in Program Files, You must encase the path in Quotes, Ex: "C:\Program Files\Python36")
 1. `service create-instance "TGS" D:\tgstation`
 1. `instance` And enter `TGS`. If you aren't using interactive mode, the following commands must be suffixed with `--instance TGS`
 1. `repo setup https://github.com/tgstation/tgstation master`

--- a/TGS.ControlPanel/ControlPanel/RepoPage.cs
+++ b/TGS.ControlPanel/ControlPanel/RepoPage.cs
@@ -91,7 +91,7 @@ namespace TGS.ControlPanel
 			if (!Repo.Exists())
 			{
 				//repo unavailable
-				RepoRemoteTextBox.Text = "https://github.com/tgstation/tgstation";
+				RepoRemoteTextBox.Text = "git://github.com/tgstation/tgstation.git";
 				RepoBranchTextBox.Text = "master";
 				RepoProgressBarLabel.Text = "Unable to locate repository";
 				CloneRepositoryButton.Visible = true;


### PR DESCRIPTION
I've added the appropriate notes in the README about setting the python path, as well as the way a Repo URL needs to be inputted. I also changed the default repo URL in the Control Panel GUI to accurately reflect these changes.