### PR TITLE
Adds GitHubOwner and GitHubName fields to Repository model. Removes IsGitHub field

### DIFF
--- a/src/Tgstation.Server.Api/Models/Repository.cs
+++ b/src/Tgstation.Server.Api/Models/Repository.cs
@@ -23,9 +23,14 @@ namespace Tgstation.Server.Api.Models
 		public RevisionInformation RevisionInformation { get; set; }
 
 		/// <summary>
-		/// If the repository was cloned from GitHub.com. If <see langword="true"/> this enables test merge functionality
+		/// If the repository was cloned from GitHub.com this will be set with the owner of the repository
 		/// </summary>
-		public bool? IsGitHub { get; set; }
+		public string GitHubOwner { get; set; }
+
+		/// <summary>
+		/// If the repository was cloned from GitHub.com this will be set with the name of the repository
+		/// </summary>
+		public string GitHubName { get; set; }
 
 		/// <summary>
 		/// The <see cref="Job"/> started by the <see cref="Repository"/> if any

--- a/src/Tgstation.Server.Api/Tgstation.Server.Api.csproj
+++ b/src/Tgstation.Server.Api/Tgstation.Server.Api.csproj
@@ -17,7 +17,7 @@
     <FileVersion>4.0.0.0</FileVersion>
     <PackageTags>json web api tgstation-server tgstation ss13 byond</PackageTags>
     <PackageReleaseNotes>Prototype release</PackageReleaseNotes>
-    <Version>4.0.0.0-preview6001</Version>
+    <Version>4.0.0.0-preview6002</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Tgstation.Server.Client/Tgstation.Server.Client.csproj
+++ b/src/Tgstation.Server.Client/Tgstation.Server.Client.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <DebugType>Full</DebugType>
-    <Version>4.0.0.0-preview9102</Version>
+    <Version>4.0.0.0-preview9103</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Cyberboss</Authors>
     <Company>/tg/station 13</Company>

--- a/src/Tgstation.Server.Host/Controllers/RepositoryController.cs
+++ b/src/Tgstation.Server.Host/Controllers/RepositoryController.cs
@@ -94,7 +94,11 @@ namespace Tgstation.Server.Host.Controllers
 
 		static async Task<bool> PopulateApi(Repository model, Components.Repository.IRepository repository, IDatabaseContext databaseContext, Models.Instance instance, CancellationToken cancellationToken)
 		{
-			model.IsGitHub = repository.IsGitHubRepository;
+			if (repository.IsGitHubRepository)
+			{
+				model.GitHubOwner = repository.GitHubOwner;
+				model.GitHubName = repository.GitHubRepoName;
+			}
 			model.Origin = repository.Origin;
 			model.Reference = repository.Reference;
 
@@ -187,7 +191,6 @@ namespace Tgstation.Server.Host.Controllers
 
 				api.Origin = model.Origin;
 				api.Reference = model.Reference;
-				api.IsGitHub = model.Origin.ToUpperInvariant().Contains(uiGitHub);
 				api.ActiveJob = job.ToApi();
 
 				return StatusCode((int)HttpStatusCode.Created, api);


### PR DESCRIPTION
Closes #621 

The clients must rely on fetching and checking the repo themselves, we provide the origin, github owner/name, reference, sha, and closest origin sha. That's more than enough for the client to do what it needs to without checking if it can.

Merge with `[NugetDeploy]` in commit message