### PR TITLE
Expose 5000 by default in docker image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR /src/src/Tgstation.Server.Host
 RUN dotnet publish -c Release -o /app/lib/Default && mv /app/lib/Default/appsettings* /app
 
 FROM microsoft/dotnet:2.1-aspnetcore-runtime
-EXPOSE 80
+EXPOSE 5000
 
 WORKDIR /app
 

--- a/src/Tgstation.Server.Host/appsettings.Docker.json
+++ b/src/Tgstation.Server.Host/appsettings.Docker.json
@@ -4,6 +4,13 @@
     "MinimumPasswordLength": 15,
     "GitHubAccessToken": null
   },
+  "Kestrel": {
+    "Endpoints": {
+      "Http": {
+        "Url": "http://localhost:5000"
+      }
+    }
+  },
   "Database": {
     "DatabaseType": "SqlServer or MySQL or MariaDB",
     "ConnectionString": "<Your connection string>",


### PR DESCRIPTION
Missed this when adding .json ports