### PR TITLE
Prevent the same test merge PR# from being merged multiple times in one commit chain

### DIFF
--- a/src/Tgstation.Server.Host/Controllers/RepositoryController.cs
+++ b/src/Tgstation.Server.Host/Controllers/RepositoryController.cs
@@ -609,6 +609,10 @@ namespace Tgstation.Server.Host.Controllers
 								{
 									Octokit.PullRequest pr = null;
 									string errorMessage = null;
+
+									if (lastRevisionInfo.ActiveTestMerges.Any(x => x.TestMerge.Number == I.Number.Value))
+										throw new JobException("Cannot test merge the same PR twice in one HEAD!");
+
 									try
 									{
 										//load from cache if possible


### PR DESCRIPTION
This is necessary to keep a sane database. Workaround is to checkout whatever base you want and then reapply test merges as desired