### PR TITLE
Fixes mistracking of most recent origin commit sha

### DIFF
--- a/docs/API.dox
+++ b/docs/API.dox
@@ -287,7 +287,7 @@ Modifications to the repository are done with the following request:
 
 I POST "/Repository" => @ref Tgstation.Server.Api.Models.Repository => @ref Tgstation.Server.Api.Models.Repository
 
-Each update creates a job specified in the @ref Tgstation.Server.Api.Models.Repository.ActiveJob field jobs will be queued in succession. See below for post examples.
+Each update that requires git changes creates a job specified in the @ref Tgstation.Server.Api.Models.Repository.ActiveJob field jobs will be queued in succession. See below for POST examples.
 
 @subsubsection api_repopost Repository Commands for Git Aliases
 

--- a/src/Tgstation.Server.Host/Components/Instance.cs
+++ b/src/Tgstation.Server.Host/Components/Instance.cs
@@ -186,6 +186,7 @@ namespace Tgstation.Server.Host.Components
 											Id = metadata.Id
 										}
 									};
+									logger.LogWarning(Repository.Repository.OriginTrackingErrorTemplate, currentSha);
 									db.Instances.Attach(revInfo.Instance);
 								}
 

--- a/src/Tgstation.Server.Host/Components/Repository/IRepository.cs
+++ b/src/Tgstation.Server.Host/Components/Repository/IRepository.cs
@@ -105,7 +105,7 @@ namespace Tgstation.Server.Host.Components.Repository
 		/// <param name="committerName">The name of the merge committer</param>
 		/// <param name="committerEmail">The e-mail of the merge committer</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
-		/// <returns>A <see cref="Task{TResult}"/> resulting in a <see cref="Nullable{T}"/> <see cref="bool"/> representing the merge result that is <see langword="true"/> after a fast forward or up to date, <see langword="false"/> on a merge, <see langword="null"/> on a conflict</returns>
+		/// <returns>A <see cref="Task{TResult}"/> resulting in a <see cref="Nullable{T}"/> <see cref="bool"/> representing the merge result that is <see langword="true"/> after a fast forward, <see langword="false"/> on a merge or up to date, <see langword="null"/> on a conflict</returns>
 		Task<bool?> MergeOrigin(string committerName, string committerEmail, CancellationToken cancellationToken);
 
 		/// <summary>

--- a/src/Tgstation.Server.Host/Components/Repository/Repository.cs
+++ b/src/Tgstation.Server.Host/Components/Repository/Repository.cs
@@ -18,12 +18,17 @@ namespace Tgstation.Server.Host.Components.Repository
 		/// </summary>
 		public const string GitHubUrl = "://github.com/";
 
-		const string UnknownReference = "<UNKNOWN>";
+		/// <summary>
+		/// Template error message for when tracking of the most recent origin commit fails
+		/// </summary>
+		public const string OriginTrackingErrorTemplate = "Unable to determine most recent origin commit of {0}. Marking it as an origin commit. This may result in invalid git metadata until the next hard reset to an origin reference.";
 
 		/// <summary>
 		/// The branch name used for publishing testmerge commits
 		/// </summary>
 		public const string RemoteTemporaryBranchName = "___TGSTempBranch";
+
+		const string UnknownReference = "<UNKNOWN>";
 
 		/// <inheritdoc />
 		public bool IsGitHubRepository { get; }

--- a/src/Tgstation.Server.Host/Components/Repository/Repository.cs
+++ b/src/Tgstation.Server.Host/Components/Repository/Repository.cs
@@ -371,7 +371,7 @@ namespace Tgstation.Server.Host.Components.Repository
 				return null;
 			}
 
-			return result.Status != MergeStatus.NonFastForward;
+			return result.Status == MergeStatus.FastForward;
 		}
 
 		/// <inheritdoc />

--- a/src/Tgstation.Server.Host/Controllers/DreamMakerController.cs
+++ b/src/Tgstation.Server.Host/Controllers/DreamMakerController.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Tgstation.Server.Api;
 using Tgstation.Server.Api.Rights;
 using Tgstation.Server.Host.Components;
+using Tgstation.Server.Host.Components.Repository;
 using Tgstation.Server.Host.Core;
 using Tgstation.Server.Host.Models;
 using Tgstation.Server.Host.Security;
@@ -179,6 +180,7 @@ namespace Tgstation.Server.Host.Controllers
 							Id = Instance.Id
 						}
 					};
+					Logger.LogWarning(Repository.OriginTrackingErrorTemplate, repoSha);
 					databaseContext.Instances.Attach(revInfo.Instance);
 				}
 

--- a/src/Tgstation.Server.Host/Controllers/RepositoryController.cs
+++ b/src/Tgstation.Server.Host/Controllers/RepositoryController.cs
@@ -401,9 +401,13 @@ namespace Tgstation.Server.Host.Controllers
 					x.PullRequestRevision != null ? String.Format(CultureInfo.InvariantCulture, " {0}", x.PullRequestRevision.Substring(0, 7)) : String.Empty))),
 					description != null ? String.Empty : " in repository");
 
+			if (description == null)
+				//no git changes
+				return Json(api);
+
 			var job = new Models.Job
 			{
-				Description = description ?? "Apply repository changes",
+				Description = description,
 				StartedBy = AuthenticationContext.User,
 				Instance = Instance,
 				CancelRightsType = RightsType.Repository,


### PR DESCRIPTION
The mistake was updating it to HEAD when a merge attempt returned "Up To Date" (r.e. e424586)

Fixes #627 