### PR TITLE
SessionControllerFactory now launches with noShellExecute

### DIFF
--- a/src/Tgstation.Server.Host/Components/Watchdog/SessionControllerFactory.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/SessionControllerFactory.cs
@@ -186,7 +186,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 							parameters);
 
 						//launch dd
-						var process = processExecutor.LaunchProcess(byondLock.DreamDaemonPath, basePath, arguments);
+						var process = processExecutor.LaunchProcess(byondLock.DreamDaemonPath, basePath, arguments, noShellExecute: true);
 						try
 						{
 							//return the session controller for it


### PR DESCRIPTION
This fixes DreamDaemon being unable to run on linux