### PR TITLE
Don't crash the watchdog if the process priority can't be raised

### DIFF
--- a/src/Tgstation.Server.Host/Core/Process.cs
+++ b/src/Tgstation.Server.Host/Core/Process.cs
@@ -103,7 +103,10 @@ namespace Tgstation.Server.Host.Core
 				handle.PriorityClass = System.Diagnostics.ProcessPriorityClass.AboveNormal;
 				logger.LogTrace("Set to above normal priority", handle.Id);
 			}
-			catch (InvalidOperationException) { }
+			catch (InvalidOperationException e)
+			{
+				logger.LogWarning("Unable to raise process priority! Exception: {0}", e);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Log a warning instead

Yet another linux fix