### PR TITLE
Overhaul of CompileJob database insertion and consumption

### DIFF
--- a/src/Tgstation.Server.Host/Components/Compiler/DmbFactory.cs
+++ b/src/Tgstation.Server.Host/Components/Compiler/DmbFactory.cs
@@ -169,7 +169,7 @@ namespace Tgstation.Server.Host.Components.Compiler
 		public Task StartAsync(CancellationToken cancellationToken) => databaseContextFactory.UseContext(async (db) =>
 		{
 			//where complete clause not necessary, only successful COMPILEjobs get in the db
-			var cj = await db.CompileJobs.Where(x => x.Job.Instance.Id == instance.Id && !x.Job.Cancelled.Value && x.Job.ExceptionDetails == null && x.Job.StoppedAt != null)
+			var cj = await db.CompileJobs.Where(x => x.Job.Instance.Id == instance.Id)
 				.Include(x => x.Job).ThenInclude(x => x.StartedBy)
 				.Include(x => x.RevisionInformation).ThenInclude(x => x.PrimaryTestMerge).ThenInclude(x => x.MergedBy)
 				.Include(x => x.RevisionInformation).ThenInclude(x => x.ActiveTestMerges).ThenInclude(x => x.TestMerge).ThenInclude(x => x.MergedBy)
@@ -245,7 +245,7 @@ namespace Tgstation.Server.Host.Components.Compiler
 			//find the uids of locked directories
 			await databaseContextFactory.UseContext(async db =>
 			{
-				jobUidsToNotErase = await db.CompileJobs.Where(x => x.Job.Instance.Id == instance.Id && jobIdsToSkip.Contains(x.Id) && x.DirectoryName.HasValue).Select(x => x.DirectoryName.Value.ToString().ToUpperInvariant()).ToListAsync(cancellationToken).ConfigureAwait(false);
+				jobUidsToNotErase = await db.CompileJobs.Where(x => x.Job.Instance.Id == instance.Id && jobIdsToSkip.Contains(x.Id)).Select(x => x.DirectoryName.Value.ToString().ToUpperInvariant()).ToListAsync(cancellationToken).ConfigureAwait(false);
 			}).ConfigureAwait(false);
 
 			//add the other exemption

--- a/src/Tgstation.Server.Host/Components/IInstance.cs
+++ b/src/Tgstation.Server.Host/Components/IInstance.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Hosting;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Tgstation.Server.Host.Components.Byond;
 using Tgstation.Server.Host.Components.Chat;
@@ -75,5 +76,15 @@ namespace Tgstation.Server.Host.Components
 		/// <param name="newInterval">The new auto update inteval</param>
 		/// <returns>A <see cref="Task"/> representing the running operation</returns>
 		Task SetAutoUpdateInterval(uint newInterval);
+
+		/// <summary>
+		/// Run the compile job and insert it into the database. Meant to be called by a <see cref="Core.IJobManager"/>
+		/// </summary>
+		/// <param name="job">The running <see cref="Job"/></param>
+		/// <param name="serviceProvider">The <see cref="IServiceProvider"/> for the operation</param>
+		/// <param name="progressReporter">The <see cref="Action{T1}"/> to report compilation progress</param>
+		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
+		/// <returns>A <see cref="Task"/> representing the running operation</returns>
+		Task CompileProcess(Job job, IServiceProvider serviceProvider, Action<int> progressReporter, CancellationToken cancellationToken);
 	}
 }

--- a/src/Tgstation.Server.Host/Components/IInstance.cs
+++ b/src/Tgstation.Server.Host/Components/IInstance.cs
@@ -26,12 +26,7 @@ namespace Tgstation.Server.Host.Components
 		/// The <see cref="IByondManager"/> for the <see cref="IInstance"/>
 		/// </summary>
 		IByondManager ByondManager { get; }
-
-		/// <summary>
-		/// The <see cref="IDreamMaker"/> for the <see cref="IInstance"/>
-		/// </summary>
-		IDreamMaker DreamMaker { get; }
-
+		
 		/// <summary>
 		/// The <see cref="IWatchdog"/> for the <see cref="IInstance"/>
 		/// </summary>
@@ -43,11 +38,6 @@ namespace Tgstation.Server.Host.Components
 		IChat Chat { get; }
 
 		/// <summary>
-		/// The <see cref="ICompileJobConsumer"/> for the <see cref="IInstance"/>
-		/// </summary>
-		ICompileJobConsumer CompileJobConsumer { get; }
-
-		/// <summary>
 		/// The <see cref="StaticFiles.IConfiguration"/> for the <see cref="IInstance"/>
 		/// </summary>
 		IConfiguration Configuration { get; }
@@ -57,12 +47,6 @@ namespace Tgstation.Server.Host.Components
 		/// </summary>
 		/// <returns>The latest <see cref="CompileJob"/> if it exists</returns>
 		CompileJob LatestCompileJob();
-
-		/// <summary>
-		/// Get the <see cref="Api.Models.Instance"/> associated with the <see cref="IInstance"/>
-		/// </summary>
-		/// <returns>The <see cref="Api.Models.Instance"/> associated with the <see cref="IInstance"/></returns>
-		Api.Models.Instance GetMetadata();
 
 		/// <summary>
 		/// Rename the <see cref="IInstance"/>

--- a/src/Tgstation.Server.Host/Components/Instance.cs
+++ b/src/Tgstation.Server.Host/Components/Instance.cs
@@ -49,6 +49,11 @@ namespace Tgstation.Server.Host.Components
 		readonly IDmbFactory dmbFactory;
 
 		/// <summary>
+		/// The <see cref="IJobManager"/> for the <see cref="Instance"/>
+		/// </summary>
+		readonly IJobManager jobManager;
+
+		/// <summary>
 		/// The <see cref="ILogger"/> for the <see cref="Instance"/>
 		/// </summary>
 		readonly ILogger<Instance> logger;
@@ -80,8 +85,9 @@ namespace Tgstation.Server.Host.Components
 		/// <param name="compileJobConsumer">The value of <see cref="CompileJobConsumer"/></param>
 		/// <param name="databaseContextFactory">The value of <see cref="databaseContextFactory"/></param>
 		/// <param name="dmbFactory">The value of <see cref="dmbFactory"/></param>
+		/// <param name="jobManager">The value of <see cref="jobManager"/></param>
 		/// <param name="logger">The value of <see cref="logger"/></param>
-		public Instance(Api.Models.Instance metadata, IRepositoryManager repositoryManager, IByondManager byondManager, IDreamMaker dreamMaker, IWatchdog watchdog, IChat chat, StaticFiles.IConfiguration configuration, ICompileJobConsumer compileJobConsumer, IDatabaseContextFactory databaseContextFactory, IDmbFactory dmbFactory, ILogger<Instance> logger)
+		public Instance(Api.Models.Instance metadata, IRepositoryManager repositoryManager, IByondManager byondManager, IDreamMaker dreamMaker, IWatchdog watchdog, IChat chat, StaticFiles.IConfiguration configuration, ICompileJobConsumer compileJobConsumer, IDatabaseContextFactory databaseContextFactory, IDmbFactory dmbFactory, IJobManager jobManager, ILogger<Instance> logger)
 		{
 			this.metadata = metadata ?? throw new ArgumentNullException(nameof(metadata));
 			RepositoryManager = repositoryManager ?? throw new ArgumentNullException(nameof(repositoryManager));
@@ -93,6 +99,7 @@ namespace Tgstation.Server.Host.Components
 			CompileJobConsumer = compileJobConsumer ?? throw new ArgumentNullException(nameof(compileJobConsumer));
 			this.databaseContextFactory = databaseContextFactory ?? throw new ArgumentNullException(nameof(databaseContextFactory));
 			this.dmbFactory = dmbFactory ?? throw new ArgumentNullException(nameof(dmbFactory));
+			this.jobManager = jobManager ?? throw new ArgumentNullException(nameof(jobManager));
 			this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
 		}
 

--- a/src/Tgstation.Server.Host/Components/Instance.cs
+++ b/src/Tgstation.Server.Host/Components/Instance.cs
@@ -286,7 +286,7 @@ namespace Tgstation.Server.Host.Components
 			CompileJob latestCompileJob = null;
 			await databaseContextFactory.UseContext(async db =>
 			{
-				latestCompileJob = await db.CompileJobs.Where(x => x.Job.Instance.Id == metadata.Id && x.Job.ExceptionDetails == null).OrderByDescending(x => x.Job.StoppedAt).FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+				latestCompileJob = await db.CompileJobs.Where(x => x.Job.Instance.Id == metadata.Id).OrderByDescending(x => x.Job.StoppedAt).FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
 			}).ConfigureAwait(false);
 			await dmbFactory.CleanUnusedCompileJobs(latestCompileJob, cancellationToken).ConfigureAwait(false);
 		}

--- a/src/Tgstation.Server.Host/Components/Instance.cs
+++ b/src/Tgstation.Server.Host/Components/Instance.cs
@@ -119,6 +119,14 @@ namespace Tgstation.Server.Host.Components
 		/// <inheritdoc />
 		public async Task CompileProcess(Job job, IServiceProvider serviceProvider, Action<int> progressReporter, CancellationToken cancellationToken)
 		{
+			//DO NOT FOLLOW THE SUGGESTION FOR A THROW EXPRESSION HERE
+			if (job == null)
+				throw new ArgumentNullException(nameof(job));
+			if (serviceProvider == null)
+				throw new ArgumentNullException(nameof(serviceProvider));
+			if (progressReporter == null)
+				throw new ArgumentNullException(nameof(progressReporter));
+
 			var databaseContext = serviceProvider.GetRequiredService<IDatabaseContext>();
 
 			var ddSettingsTask = databaseContext.DreamDaemonSettings.Where(x => x.InstanceId == metadata.Id).Select(x => new DreamDaemonSettings

--- a/src/Tgstation.Server.Host/Components/Instance.cs
+++ b/src/Tgstation.Server.Host/Components/Instance.cs
@@ -266,10 +266,7 @@ namespace Tgstation.Server.Host.Components
 					break;
 				}
 		}
-
-		/// <inheritdoc />
-		public Api.Models.Instance GetMetadata() => metadata.CloneMetadata();
-
+		
 		/// <inheritdoc />
 		public void Rename(string newName)
 		{

--- a/src/Tgstation.Server.Host/Components/InstanceFactory.cs
+++ b/src/Tgstation.Server.Host/Components/InstanceFactory.cs
@@ -8,7 +8,6 @@ using Tgstation.Server.Host.Components.Chat;
 using Tgstation.Server.Host.Components.Chat.Commands;
 using Tgstation.Server.Host.Components.Compiler;
 using Tgstation.Server.Host.Components.Repository;
-using Tgstation.Server.Host.Components.StaticFiles;
 using Tgstation.Server.Host.Components.Watchdog;
 using Tgstation.Server.Host.Core;
 using Tgstation.Server.Host.IO;
@@ -90,6 +89,11 @@ namespace Tgstation.Server.Host.Components
 		readonly IWatchdogFactory watchdogFactory;
 
 		/// <summary>
+		/// The <see cref="IJobManager"/> for the <see cref="InstanceFactory"/>
+		/// </summary>
+		readonly IJobManager jobManager;
+
+		/// <summary>
 		/// Construct an <see cref="InstanceFactory"/>
 		/// </summary>
 		/// <param name="ioManager">The value of <see cref="ioManager"/></param>
@@ -106,7 +110,8 @@ namespace Tgstation.Server.Host.Components
 		/// <param name="processExecutor">The value of <see cref="processExecutor"/></param>
 		/// <param name="postWriteHandler">The value of <see cref="postWriteHandler"/></param>
 		/// <param name="watchdogFactory">The value of <see cref="watchdogFactory"/></param>
-		public InstanceFactory(IIOManager ioManager, IDatabaseContextFactory databaseContextFactory, IApplication application, ILoggerFactory loggerFactory, IByondTopicSender byondTopicSender, IServerControl serverUpdater, ICryptographySuite cryptographySuite, ISynchronousIOManager synchronousIOManager, ISymlinkFactory symlinkFactory, IByondInstaller byondInstaller, IProviderFactory providerFactory, IProcessExecutor processExecutor, IPostWriteHandler postWriteHandler, IWatchdogFactory watchdogFactory)
+		/// <param name="jobManager">The value of <see cref="jobManager"/></param>
+		public InstanceFactory(IIOManager ioManager, IDatabaseContextFactory databaseContextFactory, IApplication application, ILoggerFactory loggerFactory, IByondTopicSender byondTopicSender, IServerControl serverUpdater, ICryptographySuite cryptographySuite, ISynchronousIOManager synchronousIOManager, ISymlinkFactory symlinkFactory, IByondInstaller byondInstaller, IProviderFactory providerFactory, IProcessExecutor processExecutor, IPostWriteHandler postWriteHandler, IWatchdogFactory watchdogFactory, IJobManager jobManager)
 		{
 			this.ioManager = ioManager ?? throw new ArgumentNullException(nameof(ioManager));
 			this.databaseContextFactory = databaseContextFactory ?? throw new ArgumentNullException(nameof(databaseContextFactory));
@@ -122,6 +127,7 @@ namespace Tgstation.Server.Host.Components
 			this.processExecutor = processExecutor ?? throw new ArgumentNullException(nameof(processExecutor));
 			this.postWriteHandler = postWriteHandler ?? throw new ArgumentNullException(nameof(postWriteHandler));
 			this.watchdogFactory = watchdogFactory ?? throw new ArgumentNullException(nameof(watchdogFactory));
+			this.jobManager = jobManager ?? throw new ArgumentNullException(nameof(jobManager));
 		}
 
 		/// <inheritdoc />
@@ -162,7 +168,7 @@ namespace Tgstation.Server.Host.Components
 						{
 							var dreamMaker = new DreamMaker(byond, gameIoManager, configuration, sessionControllerFactory, dmbFactory, application, eventConsumer, chat, processExecutor, watchdog, loggerFactory.CreateLogger<DreamMaker>());
 
-							return new Instance(metadata.CloneMetadata(), repoManager, byond, dreamMaker, watchdog, chat, configuration, dmbFactory, databaseContextFactory, dmbFactory, loggerFactory.CreateLogger<Instance>());
+							return new Instance(metadata.CloneMetadata(), repoManager, byond, dreamMaker, watchdog, chat, configuration, dmbFactory, databaseContextFactory, dmbFactory, jobManager, loggerFactory.CreateLogger<Instance>());
 						}
 						catch
 						{

--- a/src/Tgstation.Server.Host/Components/Watchdog/Watchdog.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/Watchdog.cs
@@ -1,4 +1,5 @@
 ﻿using Byond.TopicSender;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
@@ -807,11 +808,14 @@ namespace Tgstation.Server.Host.Components.Watchdog
 			if (!autoStart)
 				return;
 
+			long? adminUserId = null;
+
+			await databaseContextFactory.UseContext(async db => adminUserId = await db.Users.Select(x => x.Id).FirstAsync(cancellationToken).ConfigureAwait(false)).ConfigureAwait(false);
 			var job = new Models.Job
 			{
 				StartedBy = new Models.User
 				{
-					Id = 1  //just use admin for this cause whatever
+					Id = adminUserId.Value
 				},
 				Instance = new Models.Instance
 				{

--- a/src/Tgstation.Server.Host/Controllers/DreamMakerController.cs
+++ b/src/Tgstation.Server.Host/Controllers/DreamMakerController.cs
@@ -76,7 +76,7 @@ namespace Tgstation.Server.Host.Controllers
 		[TgsAuthorize(DreamMakerRights.CompileJobs)]
 		public override async Task<IActionResult> List(CancellationToken cancellationToken)
 		{
-			var compileJobs = await DatabaseContext.CompileJobs.Where(x => x.Job.Instance.Id == Instance.Id).OrderByDescending(x => x.Job.StartedAt).Select(x => new Api.Models.CompileJob
+			var compileJobs = await DatabaseContext.CompileJobs.Where(x => x.Job.Instance.Id == Instance.Id).OrderByDescending(x => x.Job.StoppedAt).Select(x => new Api.Models.CompileJob
 			{
 				Id = x.Id
 			}).ToListAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Tgstation.Server.Host/Controllers/DreamMakerController.cs
+++ b/src/Tgstation.Server.Host/Controllers/DreamMakerController.cs
@@ -189,10 +189,9 @@ namespace Tgstation.Server.Host.Controllers
 
 			compileJob.Job = job;
 
-			databaseContext.CompileJobs.Add(compileJob);
-			await databaseContext.Save(cancellationToken).ConfigureAwait(false);
+			databaseContext.CompileJobs.Add(compileJob);	//will be saved by job context
 
-			await instance.CompileJobConsumer.LoadCompileJob(compileJob, cancellationToken).ConfigureAwait(false);
+			job.PostComplete = ct => instance.CompileJobConsumer.LoadCompileJob(compileJob, ct);
 		}
 	}
 }

--- a/src/Tgstation.Server.Host/Controllers/InstanceController.cs
+++ b/src/Tgstation.Server.Host/Controllers/InstanceController.cs
@@ -295,6 +295,7 @@ namespace Tgstation.Server.Host.Controllers
 			}
 
 			var originalOnline = originalModel.Online.Value;
+			var renamed = model.Name != null && originalModel.Name != model.Name;
 
 			if (CheckModified(x => x.AutoUpdateInterval, InstanceManagerRights.SetAutoUpdate)
 				|| CheckModified(x => x.ConfigurationType, InstanceManagerRights.SetConfiguration)
@@ -310,6 +311,9 @@ namespace Tgstation.Server.Host.Controllers
 				usersInstanceUser.InstanceUserRights |= InstanceUserRights.WriteUsers;
 
 			await DatabaseContext.Save(cancellationToken).ConfigureAwait(false);
+
+			if (renamed)
+				instanceManager.GetInstance(originalModel).Rename(originalModel.Name);
 
 			var oldAutoStart = originalModel.DreamDaemonSettings.AutoStart;
 			try

--- a/src/Tgstation.Server.Host/Core/IJobManager.cs
+++ b/src/Tgstation.Server.Host/Core/IJobManager.cs
@@ -26,6 +26,18 @@ namespace Tgstation.Server.Host.Core
 		Task RegisterOperation(Job job, Func<Job, IServiceProvider, Action<int>, CancellationToken, Task> operation, CancellationToken cancellationToken);
 
 		/// <summary>
+		/// Wait for a given <paramref name="job"/> to complete
+		/// </summary>
+		/// <param name="job">The <see cref="Job"/> to wait for </param>
+		/// <param name="canceller">The <see cref="User"/> to cancel the <paramref name="job"/></param>
+		/// <param name="jobCancellationToken">A <see cref="CancellationToken"/> that will cancel the <paramref name="job"/></param>
+		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
+		/// <returns>A <see cref="Task"/> representing the <see cref="Job"/></returns>
+#pragma warning disable CA1068 // CancellationToken parameters must come last https://github.com/dotnet/roslyn-analyzers/issues/1816
+		Task WaitForJobCompletion(Job job, User canceller, CancellationToken jobCancellationToken, CancellationToken cancellationToken);
+#pragma warning restore CA1068 // CancellationToken parameters must come last
+
+		/// <summary>
 		/// Cancels a give <paramref name="job"/>
 		/// </summary>
 		/// <param name="job">The <see cref="Job"/> to cancel</param>

--- a/src/Tgstation.Server.Host/Core/JobManager.cs
+++ b/src/Tgstation.Server.Host/Core/JobManager.cs
@@ -70,13 +70,35 @@ namespace Tgstation.Server.Host.Core
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="Task"/> representing the running operation</returns>
 		async Task RunJob(Job job, Func<Job, IServiceProvider, CancellationToken, Task> operation, CancellationToken cancellationToken)
-		{
+		{			
 			try
 			{
 				using (var scope = serviceProvider.CreateScope())
 				{
+					async Task HandleExceptions(Task task)
+					{
+						try
+						{
+							await task.ConfigureAwait(false);
+						}
+						catch (OperationCanceledException)
+						{
+							logger.LogDebug("Job {0} cancelled!", job.Id);
+							job.Cancelled = true;
+						}
+						catch (Exception e)
+						{
+							job.ExceptionDetails = e is JobException ? e.Message : e.ToString();
+							logger.LogDebug("Job {0} exited with error! Exception: {1}", job.Id, job.ExceptionDetails);
+						}
+						finally
+						{
+							job.StoppedAt = DateTimeOffset.Now;
+						}
+					}
+
 					IDatabaseContext databaseContext = null;
-					try
+					async Task RunJobInternal()
 					{
 						var oldJob = job;
 						job = new Job { Id = oldJob.Id };
@@ -86,19 +108,21 @@ namespace Tgstation.Server.Host.Core
 						await operation(job, scope.ServiceProvider, cancellationToken).ConfigureAwait(false);
 
 						logger.LogDebug("Job {0} completed!", job.Id);
-					}
-					catch (OperationCanceledException)
-					{
-						logger.LogDebug("Job {0} cancelled!", job.Id);
-						job.Cancelled = true;
-					}
-					catch (Exception e)
-					{
-						job.ExceptionDetails = e is JobException ? e.Message : e.ToString();
-						logger.LogDebug("Job {0} exited with error! Exception: {1}", job.Id, job.ExceptionDetails);
-					}
-					job.StoppedAt = DateTimeOffset.Now;
+					};
+
+					await HandleExceptions(RunJobInternal()).ConfigureAwait(false);
+
 					await databaseContext.Save(default).ConfigureAwait(false);
+
+					bool JobErroredOrCancelled() => job.ExceptionDetails != null || job.Cancelled.Value;
+
+					//ok so, now it's time for the post commit step if it exists
+					if (!JobErroredOrCancelled() && job.PostComplete != null)
+					{
+						await HandleExceptions(job.PostComplete(cancellationToken)).ConfigureAwait(false);
+						if (JobErroredOrCancelled())
+							await databaseContext.Save(default).ConfigureAwait(false);
+					}
 				}
 			}
 			finally

--- a/src/Tgstation.Server.Host/Core/JobManager.cs
+++ b/src/Tgstation.Server.Host/Core/JobManager.cs
@@ -247,6 +247,8 @@ namespace Tgstation.Server.Host.Core
 		/// <inheritdoc />
 		public int? JobProgress(Job job)
 		{
+			if (job == null)
+				throw new ArgumentNullException(nameof(job));
 			lock (this)
 			{
 				if (!jobs.TryGetValue(job.Id, out var handler))
@@ -258,6 +260,10 @@ namespace Tgstation.Server.Host.Core
 		/// <inheritdoc />
 		public async Task WaitForJobCompletion(Job job, User canceller, CancellationToken jobCancellationToken, CancellationToken cancellationToken)
 		{
+			if (job == null)
+				throw new ArgumentNullException(nameof(job));
+			if (canceller == null)
+				throw new ArgumentNullException(nameof(canceller));
 			JobHandler handler;
 			lock (this)
 			{

--- a/src/Tgstation.Server.Host/Models/Job.cs
+++ b/src/Tgstation.Server.Host/Models/Job.cs
@@ -1,4 +1,8 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Tgstation.Server.Host.Models
 {
@@ -21,6 +25,13 @@ namespace Tgstation.Server.Host.Models
 		/// </summary>
 		[Required]
 		public Instance Instance { get; set; }
+
+		/// <summary>
+		/// A <see cref="Task"/> to run after the job completes. This will not affect the <see cref="Api.Models.Internal.Job.StoppedAt"/> time, unless it is cancelled or errors
+		/// </summary>
+		/// <remarks>This should only be used where there are database dependencies that also rely on the Job itself completing A.K.A. manually initiated <see cref="CompileJob"/>s</remarks>
+		[NotMapped]
+		public Func<CancellationToken, Task> PostComplete { get; set; }
 
 		/// <summary>
 		/// Convert the <see cref="Job"/> to it's API form


### PR DESCRIPTION
Fixes #651 

`CompileJob`s had a weird spot right after they were completed where their `Job`s weren't but several things assumed they were and they existed in the database. This aims to remedy that

`Models.Job` now has an unmapped property called `PostComplete` that will fire after the `Job` has been committed to the db. The results of this call only affect `StoppedAt`, `Cancelled`, and `ExceptionDetails` if it was exceptional and won't run at all if the job before it was exceptional.

The JobManager itself was made responsible for calling the `IDatabaseContext.Save()` that commits `CompileJob`s and then runs a `PostComplete` task which sends it to the `ICompileJobConsumer`.

The `IInstance` auto update and `DreamMakerController` compile processes were merged into one function in `IInstance`

Auto updates now use the `IJobManager` for separate repository and compile steps.

The watchdog no longer tries to guess the admin user's ID

