### PR TITLE
Fix last miniscule watchdog issues. Fully comment it

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Note although `/app/lib` is specified as a volume mount point in the `Dockerfile
 
 ### Configuring
 
-Create an `appsettings.Production.json` file next to `appsettings.json`. This will override the default settings in appsettings.json with your production settings. There are a few keys meant to be changed by hosts. Note these are all case-sensitive: 
+Create an `appsettings.Production.json` file next to `appsettings.json`. This will override the default settings in appsettings.json with your production settings. There are a few keys meant to be changed by hosts. Modifying any config files while the server is running will trigger a safe restart (Keeps DreamDaemon's running). Note these are all case-sensitive: 
 
 - `General:MinimumPasswordLength`: Minimum password length requirement for database users
 

--- a/src/Tgstation.Server.Host/Components/Watchdog/MonitorAction.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/MonitorAction.cs
@@ -5,9 +5,21 @@
 	/// </summary>
 	enum MonitorAction
 	{
+		/// <summary>
+		/// The monitor should continue as normal
+		/// </summary>
 		Continue,
+		/// <summary>
+		/// The monitor should kill and restart both servers
+		/// </summary>
 		Restart,
+		/// <summary>
+		/// The monitor should stop checking actions for this iteration and continue its loop
+		/// </summary>
 		Break,
+		/// <summary>
+		/// The monitor should exit. Does not kill servers
+		/// </summary>
 		Exit
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Watchdog/MonitorActivationReason.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/MonitorActivationReason.cs
@@ -1,13 +1,37 @@
 ﻿namespace Tgstation.Server.Host.Components.Watchdog
 {
+	/// <summary>
+	/// Reasons for the monitor to wake up
+	/// </summary>
 	enum MonitorActivationReason
 	{
+		/// <summary>
+		/// The active server crashed or exited
+		/// </summary>
 		ActiveServerCrashed,
+		/// <summary>
+		/// The inactive server crashed or exited
+		/// </summary>
 		InactiveServerCrashed,
+		/// <summary>
+		/// The active server called /world/Reboot()
+		/// </summary>
 		ActiveServerRebooted,
+		/// <summary>
+		/// The inactive server called /world/Reboot()
+		/// </summary>
 		InactiveServerRebooted,
+		/// <summary>
+		/// The inactive server is past that point where DD hangs when you press "Go"
+		/// </summary>
 		InactiveServerStartupComplete,
+		/// <summary>
+		/// A new .dmb was deployed
+		/// </summary>
 		NewDmbAvailable,
+		/// <summary>
+		/// Server launch parameters were changed
+		/// </summary>
 		ActiveLaunchParametersUpdated
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Watchdog/Watchdog.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/Watchdog.cs
@@ -475,7 +475,6 @@ namespace Tgstation.Server.Host.Components.Watchdog
 					}
 
 					//break either way because any issues past this point would be solved by the reboot
-					//TODO handle that elegantly somehow
 					if (restartOnceSwapped) 
 						//for one reason or another
 						//update and reboot


### PR DESCRIPTION
Issues being:
- DisposeAndNullControllers() not being called if a graceful shutdown happened due to the active server crashing
- Added verbosity to relaunch retry loop
- Discovered a tiny edge case where deploys would silently not be applied if the active server rebooted at exactly the right moment (TODO: Open issue)
- Removed a redundant assignment of ClosePortOnReboot
- Removed an unused CancellationTokenSource
- Fixed reattach dmbs not unlocking if the reattach failed

Closes #597