### PR TITLE
Convert a common exception to a JobException

### DIFF
--- a/src/Tgstation.Server.Host/Components/Byond/ByondManager.cs
+++ b/src/Tgstation.Server.Host/Components/Byond/ByondManager.cs
@@ -192,7 +192,7 @@ namespace Tgstation.Server.Host.Components.Byond
 		{
 			var versionToUse = requiredVersion ?? ActiveVersion;
 			if (versionToUse == null)
-				throw new InvalidOperationException("No BYOND versions installed!");
+				throw new JobException("No BYOND versions installed!");
 			await InstallVersion(versionToUse, cancellationToken).ConfigureAwait(false);
 
 			var versionKey = VersionKey(versionToUse);


### PR DESCRIPTION
This exception is easily thrown during jobs if the user forgot to install a BYOND version. So, let's pretify it for them.

Closes #739