### PR TITLE
Update docs about creating the docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ docker create \
 	--restart=always \ #if you want maximum uptime
 	--network="host" \ #if your sql server is on the same machine
 	--name="tgs" \ #or whatever else you wanna call it
+	--cap-add=sys_nice \ #allows tgs to schedule DreamDaemon as a higher priority process
 	-p <tgs port>:80 \
 	-p 0.0.0.0:<public game port>:<internal game port> \
 	-v /path/to/store/instances:/tgs4_instances \


### PR DESCRIPTION
The `--cap-add=sys_nice` option allows `IProcess.SetHighPriority()` to not fail.

Closes #751 

This merely suppresses some warnings in the log. Plus, if you're using a dedicated Linux box for hosting, I'm sure the scheduler is smart enough to run DreamDaemon with 100% CPU as much as possible. So, this change is completely optional.

There is currently no way to update it without stopping the container. Easiest way is to, `rm`, `pull`, and re-`run` the container. If you're against that, you can modify a stopped containers configuration by following these instructions: https://stackoverflow.com/a/45752205