### PR TITLE
Fixes PopulateApi() and CompileJob retrieval not retuning TestMerge.MergedBy. Version 4.0.0.4 bump

### DIFF
--- a/src/Tgstation.Server.Host.Console/Tgstation.Server.Host.Console.csproj
+++ b/src/Tgstation.Server.Host.Console/Tgstation.Server.Host.Console.csproj
@@ -4,8 +4,8 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <DebugType>Full</DebugType>
-    <FileVersion>4.0.0.3</FileVersion>
-    <AssemblyVersion>4.0.0.3</AssemblyVersion>
+    <FileVersion>4.0.0.4</FileVersion>
+    <AssemblyVersion>4.0.0.4</AssemblyVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Tgstation.Server.Host.Service/Properties/AssemblyInfo.cs
+++ b/src/Tgstation.Server.Host.Service/Properties/AssemblyInfo.cs
@@ -7,5 +7,5 @@ using System.Runtime.InteropServices;
 [assembly: Guid("29927416-3b78-49a7-a560-5ccaa638b6b4")]
 [assembly: InternalsVisibleTo("Tgstation.Server.Host.Service.Tests")]
 
-[assembly: AssemblyVersion("4.0.0.3")]
-[assembly: AssemblyFileVersion("4.0.0.3")]
+[assembly: AssemblyVersion("4.0.0.4")]
+[assembly: AssemblyFileVersion("4.0.0.4")]

--- a/src/Tgstation.Server.Host.Watchdog/Tgstation.Server.Host.Watchdog.csproj
+++ b/src/Tgstation.Server.Host.Watchdog/Tgstation.Server.Host.Watchdog.csproj
@@ -4,8 +4,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <DebugType>Full</DebugType>
     <AddSyntheticProjectReferencesForSolutionDependencies>false</AddSyntheticProjectReferencesForSolutionDependencies>
-    <AssemblyVersion>4.0.0.3</AssemblyVersion>
-    <FileVersion>4.0.0.3</FileVersion>
+    <AssemblyVersion>4.0.0.4</AssemblyVersion>
+    <FileVersion>4.0.0.4</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Tgstation.Server.Host/Components/Compiler/DmbFactory.cs
+++ b/src/Tgstation.Server.Host/Components/Compiler/DmbFactory.cs
@@ -158,9 +158,6 @@ namespace Tgstation.Server.Host.Components.Compiler
 		{
 			//where complete clause not necessary, only successful COMPILEjobs get in the db
 			var cj = await db.CompileJobs.Where(x => x.Job.Instance.Id == instance.Id)
-				.Include(x => x.Job).ThenInclude(x => x.StartedBy)
-				.Include(x => x.RevisionInformation).ThenInclude(x => x.PrimaryTestMerge).ThenInclude(x => x.MergedBy)
-				.Include(x => x.RevisionInformation).ThenInclude(x => x.ActiveTestMerges).ThenInclude(x => x.TestMerge).ThenInclude(x => x.MergedBy)
 				.OrderByDescending(x => x.Job.StoppedAt).FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
 			if (cj == default(CompileJob))
 				return;

--- a/src/Tgstation.Server.Host/Controllers/DreamMakerController.cs
+++ b/src/Tgstation.Server.Host/Controllers/DreamMakerController.cs
@@ -61,8 +61,8 @@ namespace Tgstation.Server.Host.Controllers
 			var compileJob = await DatabaseContext.CompileJobs
 				.Where(x => x.Id == id && x.Job.Instance.Id == Instance.Id)
 				.Include(x => x.Job).ThenInclude(x => x.StartedBy)
-				.Include(x => x.RevisionInformation).ThenInclude(x => x.PrimaryTestMerge)
-				.Include(x => x.RevisionInformation).ThenInclude(x => x.ActiveTestMerges).ThenInclude(x => x.TestMerge)
+				.Include(x => x.RevisionInformation).ThenInclude(x => x.PrimaryTestMerge).ThenInclude(x => x.MergedBy)
+				.Include(x => x.RevisionInformation).ThenInclude(x => x.ActiveTestMerges).ThenInclude(x => x.TestMerge).ThenInclude(x => x.MergedBy)
 				.FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
 			if (compileJob == default)
 				return NotFound();

--- a/src/Tgstation.Server.Host/Controllers/ModelController.cs
+++ b/src/Tgstation.Server.Host/Controllers/ModelController.cs
@@ -1,9 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Tgstation.Server.Api;
 using Tgstation.Server.Host.Models;
 using Tgstation.Server.Host.Security;
 

--- a/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
+++ b/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <DebugType>Full</DebugType>
-    <AssemblyVersion>4.0.0.3</AssemblyVersion>
-    <FileVersion>4.0.0.3</FileVersion>
+    <AssemblyVersion>4.0.0.4</AssemblyVersion>
+    <FileVersion>4.0.0.4</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">


### PR DESCRIPTION
Fixes #754 