### PR TITLE
Add `--init` to recommended docker command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ docker create \
 	--network="host" \ #if your sql server is on the same machine
 	--name="tgs" \ #or whatever else you wanna call it
 	--cap-add=sys_nice \ #allows tgs to schedule DreamDaemon as a higher priority process
+	--init \ #reaps potential zombie processes
 	-p <tgs port>:80 \
 	-p 0.0.0.0:<public game port>:<internal game port> \
 	-v /path/to/store/instances:/tgs4_instances \


### PR DESCRIPTION
Relevant blog post: https://blog.phusion.nl/2015/01/20/docker-and-the-pid-1-zombie-reaping-problem/

This basically runs a reap and signal forward only pid 1 for us