### PR TITLE
Investigation into why the CI integration tests hit GitHub rate limits so much

### DIFF
--- a/tests/Tgstation.Server.Tests/TestingServer.cs
+++ b/tests/Tgstation.Server.Tests/TestingServer.cs
@@ -38,6 +38,9 @@ namespace Tgstation.Server.Tests
 			if (String.IsNullOrEmpty(connectionString))
 				Assert.Fail("No connection string configured in env var TGS4_TEST_CONNECTION_STRING!");
 
+			if (String.IsNullOrEmpty(gitHubAccessToken))
+				Console.WriteLine("WARNING: No GitHub access token configured, test may fail due to rate limits!");
+			
 			var args = new List<string>()
 			{
 				String.Format(CultureInfo.InvariantCulture, "Kestrel:EndPoints:Http:Url={0}", Url),


### PR DESCRIPTION
~~Closes. #746~~

Doesn't work, can't figure out why, we need this logging
