### PR TITLE
The watchdog will only restart the server if it exits with a non-zero exit code

### DIFF
--- a/TGS.Server/Instance/DreamDaemon.cs
+++ b/TGS.Server/Instance/DreamDaemon.cs
@@ -379,7 +379,7 @@ namespace TGS.Server
 						}
 					}
 					if (Proc.ExitCode == 0)  //intentional shutdown.
-						return
+						return;
 					WriteCurrentDDLog("Crash detected! Exit code: " + Proc.ExitCode);
 					var runtimeS = (DateTime.Now - starttime).TotalSeconds;
 					WriteWarning("DD crashed: Exit Code: " + Proc.ExitCode + " Seconds running: " + runtimeS, EventID.DDServerCrash);

--- a/TGS.Server/Instance/DreamDaemon.cs
+++ b/TGS.Server/Instance/DreamDaemon.cs
@@ -378,7 +378,8 @@ namespace TGS.Server
 							pcpu?.Dispose();
 						}
 					}
-
+					if (!Proc.ExitCode)  //intentional shutdown.
+						return
 					WriteCurrentDDLog("Crash detected! Exit code: " + Proc.ExitCode);
 					var runtimeS = (DateTime.Now - starttime).TotalSeconds;
 					WriteWarning("DD crashed: Exit Code: " + Proc.ExitCode + " Seconds running: " + runtimeS, EventID.DDServerCrash);

--- a/TGS.Server/Instance/DreamDaemon.cs
+++ b/TGS.Server/Instance/DreamDaemon.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -378,7 +378,7 @@ namespace TGS.Server
 							pcpu?.Dispose();
 						}
 					}
-					if (!Proc.ExitCode)  //intentional shutdown.
+					if (Proc.ExitCode == 0)  //intentional shutdown.
 						return
 					WriteCurrentDDLog("Crash detected! Exit code: " + Proc.ExitCode);
 					var runtimeS = (DateTime.Now - starttime).TotalSeconds;


### PR DESCRIPTION
:cl:
The watchdog will only restart the server if it exits with a non-zero exit code
/:cl:

[Why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

So we can make a shutdown server verb.