### PR TITLE
Random stuff

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,6 +12,7 @@ build/**
 !build/analyzers.ruleset
 !build/tgs.docker.sh
 !build/tgs.ico
+!build/tgs.png
 !build/stylecop.json
 !build/Version.props
 */bin

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -75,7 +75,7 @@ test_script:
   - OpenCover.Console.exe -returntargetcode -register:user -target:"C:/Program Files/dotnet/dotnet.exe" -targetargs:"test -c %CONFIGURATION% --logger:trx;LogFileName=results.trx /p:DebugType=full tests/Tgstation.Server.Tests/Tgstation.Server.Tests.csproj" -filter:"+[Tgstation.Server*]* -[Tgstation.Server.Tests*]* -[Tgstation.Server.Host]Tgstation.Server.Host.Database.Migrations..*" -output:".\server_coverage.xml" -oldstyle
   - ps: $wc = New-Object 'System.Net.WebClient'
   - ps: $wc.UploadFile("https://ci.appveyor.com/api/testresults/mstest/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\tests\Tgstation.Server.Tests\TestResults\results.trx))
-  - lint-openapi -c build/OpenApiValidationSettings.json C:/swagger.json
+  - lint-openapi -p -c build/OpenApiValidationSettings.json C:/swagger.json
 after_test:
   - ps: build/UploadCoverage.ps1
   - ps: build/BuildDox.ps1

--- a/build/OpenApiValidationSettings.json
+++ b/build/OpenApiValidationSettings.json
@@ -6,7 +6,8 @@
       "no_summary": "error",
       "no_array_responses": "off",
       "parameter_order": "error",
-      "unused_tag": "error"
+      "unused_tag": "error",
+      "operation_id_naming_convention": "off"
     },
     "pagination": {
       "pagination_style": "error"
@@ -74,7 +75,8 @@
     },
     "responses": {
       "no_response_codes": "error",
-      "no_success_response_codes": "error"
+      "no_success_response_codes": "error",
+      "ibm_status_code_guidelines": "off"
     }
   }
 }

--- a/build/Version.props
+++ b/build/Version.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <TgsCoreVersion>4.0.2</TgsCoreVersion>
+    <TgsCoreVersion>4.0.2.1</TgsCoreVersion>
     <TgsApiVersion>4.0.2</TgsApiVersion>
     <TgsClientVersion>4.0.3</TgsClientVersion>
   </PropertyGroup>

--- a/docs/API.dox
+++ b/docs/API.dox
@@ -57,15 +57,16 @@ An Authentication header is also required. See @ref api_auth
 
 TGS will only every return the response codes listed here
 
-- 200: General OK status. Unless the HTTP DELETE verb was used to make the request (In which case the response body will be empty), the response body will contain a json model or array depending on the API called.
-- 201: Created: Returned when the request created an entity, 202 trumps this
+- 200: OK. The response body will contain a json model or array depending on the API called.
+- 201: Created. Returned when the request created an entity, 202 trumps this
 - 202: Accepted. Used when a response triggers a long running operation such as a @ref Tgstation.Server.Api.Models.Job or server restart
-- 400: Bad request made. The response body will contain an @ref Tgstation.Server.Api.Models.ErrorMessage model detailing the error
-- 401: User unauthorized. Invalid or expired credentials were provided. Check rights APIs for updates. See @ref api_auth for details
-- 403: Usage forbidden. User tried to make a request they were not allowed to perform. 
+- 204: No Content. Identical to 200 with no response body.
+- 400: Bad Request. The response body will contain an @ref Tgstation.Server.Api.Models.ErrorMessage model detailing the error
+- 401: Unauthorized. Invalid or expired credentials were provided. Check rights APIs for updates. See @ref api_auth for details
+- 403: Forbidden. User tried to make a request they were not allowed to perform. 
 - 404: Not found. A resource was requested that had never existed. In the case of retrieving a resource by ID, it could potentially exist in the future
-- 406: Not acceptable. Consequence of failing to provide an Accept header
-- 408: Request timeout. The client took to long to continue a request
+- 406: Not Acceptable. Consequence of failing to provide an Accept header
+- 408: Request Timeout. The client took to long to continue a request
 - 409: Conflict. Documented in the requests that use them
 - 410: Gone. Attempted to access/modify a resource that ideally should have been ready, but isn't or no longer is
 - 422: Unprocessable Entity: Used specifically when an operation that requires a server restart is unable to be performed due to the @ref Tgstation.Server.Host.Watchdog not being present in the deployment. Should not happen with a proper server configuration. Response body contains an @ref Tgstation.Server.Api.Models.ErrorMessage

--- a/src/Tgstation.Server.Api/Rights/RightsHelper.cs
+++ b/src/Tgstation.Server.Api/Rights/RightsHelper.cs
@@ -70,5 +70,20 @@ namespace Tgstation.Server.Api.Rights
 		/// <param name="rightsType">The <see cref="RightsType"/> to check</param>
 		/// <returns><see langword="true"/> if <paramref name="rightsType"/> is an instance right, <see langword="false"/> otherwise</returns>
 		public static bool IsInstanceRight(RightsType rightsType) => !(rightsType == RightsType.Administration || rightsType == RightsType.InstanceManager);
+
+		/// <summary>
+		/// Get all rights for a given <typeparamref name="TRight"/>.
+		/// </summary>
+		/// <typeparam name="TRight">The <see cref="RightsType"/>.</typeparam>
+		/// <returns>All rights for the given <typeparamref name="TRight"/>.</returns>
+		public static TRight AllRights<TRight>() where TRight : Enum
+		{
+			ulong rights = 0;
+			Type rightsType = typeof(TRight);
+			foreach (Enum J in Enum.GetValues(rightsType))
+				rights = rights | Convert.ToUInt64(J, CultureInfo.InvariantCulture);
+
+			return (TRight)Convert.ChangeType(rights, rightsType, CultureInfo.InvariantCulture);
+		}
 	}
 }

--- a/src/Tgstation.Server.Api/Rights/RightsHelper.cs
+++ b/src/Tgstation.Server.Api/Rights/RightsHelper.cs
@@ -79,11 +79,11 @@ namespace Tgstation.Server.Api.Rights
 		public static TRight AllRights<TRight>() where TRight : Enum
 		{
 			ulong rights = 0;
-			Type rightsType = typeof(TRight);
-			foreach (Enum J in Enum.GetValues(rightsType))
-				rights = rights | Convert.ToUInt64(J, CultureInfo.InvariantCulture);
+			foreach (Enum J in Enum.GetValues(typeof(TRight)))
+				rights |= Convert.ToUInt64(J, CultureInfo.InvariantCulture);
 
-			return (TRight)Convert.ChangeType(rights, rightsType, CultureInfo.InvariantCulture);
+			// cri evertim
+			return (TRight)(object)rights;
 		}
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Instance.cs
+++ b/src/Tgstation.Server.Host/Components/Instance.cs
@@ -346,7 +346,13 @@ namespace Tgstation.Server.Host.Components
 					try
 					{
 						Models.User user = null;
-						await databaseContextFactory.UseContext(async (db) => user = await db.Users.Where(x => x.CanonicalName == Api.Models.User.AdminName.ToUpperInvariant()).FirstAsync(cancellationToken).ConfigureAwait(false)).ConfigureAwait(false);
+						await databaseContextFactory.UseContext(
+							async (db) => user = await db
+								.Users
+								.Where(x => x.CanonicalName == Models.User.CanonicalizeName(Api.Models.User.AdminName))
+								.FirstAsync(cancellationToken)
+								.ConfigureAwait(false))
+							.ConfigureAwait(false);
 						var repositoryUpdateJob = new Job
 						{
 							Instance = new Models.Instance

--- a/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
@@ -559,7 +559,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 			long? adminUserId = null;
 
 			await databaseContextFactory.UseContext(async db => adminUserId = await db.Users
-			.Where(x => x.CanonicalName == Api.Models.User.AdminName.ToUpperInvariant())
+			.Where(x => x.CanonicalName == Models.User.CanonicalizeName(Api.Models.User.AdminName))
 			.Select(x => x.Id)
 			.FirstAsync(cancellationToken).ConfigureAwait(false)).ConfigureAwait(false);
 			var job = new Models.Job

--- a/src/Tgstation.Server.Host/Controllers/AdministrationController.cs
+++ b/src/Tgstation.Server.Host/Controllers/AdministrationController.cs
@@ -162,7 +162,11 @@ namespace Tgstation.Server.Host.Controllers
 						{
 							Message = "An update operation is already in progress!"
 						});
-					return Accepted(); // gtfo of here before all the cancellation tokens fire
+					return Accepted(new Administration
+					{
+						WindowsHost = platformIdentifier.IsWindows,
+						NewVersion = newVersion
+					}); // gtfo of here before all the cancellation tokens fire
 				}
 
 			return StatusCode((int)HttpStatusCode.Gone);
@@ -240,7 +244,7 @@ namespace Tgstation.Server.Host.Controllers
 		/// <response code="429">A GitHub API error occurred.</response>
 		[HttpPost]
 		[TgsAuthorize(AdministrationRights.ChangeVersion)]
-		[ProducesResponseType(202)]
+		[ProducesResponseType(typeof(Administration), 202)]
 		[ProducesResponseType(410)]
 		[ProducesResponseType(typeof(ErrorMessage), 422)]
 		[ProducesResponseType(424)]
@@ -269,11 +273,11 @@ namespace Tgstation.Server.Host.Controllers
 		/// Attempts to restart the server.
 		/// </summary>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> of the request</returns>
-		/// <response code="200">Restart begun successfully.</response>
+		/// <response code="204">Restart begun successfully.</response>
 		/// <response code="422">Restart operations are unavailable due to the launch configuration of TGS.</response>
 		[HttpDelete]
 		[TgsAuthorize(AdministrationRights.RestartHost)]
-		[ProducesResponseType(200)]
+		[ProducesResponseType(204)]
 		[ProducesResponseType(typeof(ErrorMessage), 422)]
 		public async Task<IActionResult> Delete()
 		{
@@ -289,7 +293,7 @@ namespace Tgstation.Server.Host.Controllers
 				}
 
 				await serverUpdater.Restart().ConfigureAwait(false);
-				return Ok();
+				return NoContent();
 			}
 			catch (InvalidOperationException)
 			{

--- a/src/Tgstation.Server.Host/Controllers/ChatController.cs
+++ b/src/Tgstation.Server.Host/Controllers/ChatController.cs
@@ -149,10 +149,10 @@ namespace Tgstation.Server.Host.Controllers
 		/// <param name="id">The <see cref="Api.Models.Internal.ChatBot.Id"/> to delete.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> for the operation.</returns>
-		/// <response code="200">Chat bot deleted or does not exist.</response>
+		/// <response code="204">Chat bot deleted or does not exist.</response>
 		[HttpDelete("{id}")]
 		[TgsAuthorize(ChatBotRights.Delete)]
-		[ProducesResponseType(200)]
+		[ProducesResponseType(204)]
 		public async Task<IActionResult> Delete(long id, CancellationToken cancellationToken)
 		{
 			var instance = instanceManager.GetInstance(Instance);

--- a/src/Tgstation.Server.Host/Controllers/ConfigurationController.cs
+++ b/src/Tgstation.Server.Host/Controllers/ConfigurationController.cs
@@ -255,11 +255,11 @@ namespace Tgstation.Server.Host.Controllers
 		/// <param name="directory">A <see cref="ConfigurationFile"/> representing the path to the directory to delete</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> of the operation</returns>
-		/// <response code="200">Empty directory deleted successfully.</response>
+		/// <response code="204">Empty directory deleted successfully.</response>
 		/// <response code="501">POSIX system impersonation requested but not implemented.</response>
 		[HttpDelete]
 		[TgsAuthorize(ConfigurationRights.Delete)]
-		[ProducesResponseType(200)]
+		[ProducesResponseType(204)]
 		[ProducesResponseType(501)]
 		public async Task<IActionResult> Delete([FromBody] ConfigurationFile directory, CancellationToken cancellationToken)
 		{
@@ -271,7 +271,7 @@ namespace Tgstation.Server.Host.Controllers
 
 			try
 			{
-				return await instanceManager.GetInstance(Instance).Configuration.DeleteDirectory(directory.Path, systemIdentity, cancellationToken).ConfigureAwait(false) ? (IActionResult)Ok() : Conflict(new ErrorMessage
+				return await instanceManager.GetInstance(Instance).Configuration.DeleteDirectory(directory.Path, systemIdentity, cancellationToken).ConfigureAwait(false) ? (IActionResult)NoContent() : Conflict(new ErrorMessage
 				{
 					Message = "Directory not empty!"
 				});

--- a/src/Tgstation.Server.Host/Controllers/DreamDaemonController.cs
+++ b/src/Tgstation.Server.Host/Controllers/DreamDaemonController.cs
@@ -86,7 +86,7 @@ namespace Tgstation.Server.Host.Controllers
 		/// </summary>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> of the operation.</returns>
-		/// <response code="202">Read <see cref="DreamDaemon"/> information successfully.</response>
+		/// <response code="200">Read <see cref="DreamDaemon"/> information successfully.</response>
 		[HttpGet]
 		[TgsAuthorize(DreamDaemonRights.ReadMetadata | DreamDaemonRights.ReadRevision)]
 		[ProducesResponseType(typeof(DreamDaemon), 200)]
@@ -150,15 +150,15 @@ namespace Tgstation.Server.Host.Controllers
 		/// </summary>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> of the operation.</returns>
-		/// <response code="200">Watchdog terminated.</response>
+		/// <response code="204">Watchdog terminated.</response>
 		[HttpDelete]
 		[TgsAuthorize(DreamDaemonRights.Shutdown)]
-		[ProducesResponseType(200)]
+		[ProducesResponseType(204)]
 		public async Task<IActionResult> Delete(CancellationToken cancellationToken)
 		{
 			var instance = instanceManager.GetInstance(Instance);
 			await instance.Watchdog.Terminate(false, cancellationToken).ConfigureAwait(false);
-			return Ok();
+			return NoContent();
 		}
 
 		/// <summary>

--- a/src/Tgstation.Server.Host/Controllers/DreamMakerController.cs
+++ b/src/Tgstation.Server.Host/Controllers/DreamMakerController.cs
@@ -137,12 +137,13 @@ namespace Tgstation.Server.Host.Controllers
 		/// <param name="model">The updated <see cref="DreamMaker"/> settings.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> of the request.</returns>
-		/// <response code="200">Changes applied successfully. The updated <see cref="DreamMaker"/> settings will be returned based on user permissions.</response>
+		/// <response code="200">Changes applied successfully. The updated <see cref="DreamMaker"/> settings will be returned.</response>
+		/// <response code="204">Changes applied successfully. The updated <see cref="DreamMaker"/> settings will be not be returned due to permissions.</response>
 		/// <response code="410">Instance no longer available.</response>
 		[HttpPost]
 		[TgsAuthorize(DreamMakerRights.SetDme | DreamMakerRights.SetApiValidationPort | DreamMakerRights.SetApiValidationPort)]
 		[ProducesResponseType(typeof(DreamMaker), 200)]
-		[ProducesResponseType(200)]
+		[ProducesResponseType(204)]
 		[ProducesResponseType(410)]
 		public async Task<IActionResult> Update([FromBody] DreamMaker model, CancellationToken cancellationToken)
 		{
@@ -186,7 +187,7 @@ namespace Tgstation.Server.Host.Controllers
 			await DatabaseContext.Save(cancellationToken).ConfigureAwait(false);
 
 			if ((AuthenticationContext.GetRight(RightsType.DreamMaker) & (ulong)DreamMakerRights.Read) == 0)
-				return Ok();
+				return NoContent();
 
 			return await Read(cancellationToken).ConfigureAwait(false);
 		}

--- a/src/Tgstation.Server.Host/Controllers/HomeController.cs
+++ b/src/Tgstation.Server.Host/Controllers/HomeController.cs
@@ -167,7 +167,7 @@ namespace Tgstation.Server.Host.Controllers
 			{
 				// Get the user from the database
 				IQueryable<User> query;
-				string canonicalName = ApiHeaders.Username.ToUpperInvariant();
+				string canonicalName = Models.User.CanonicalizeName(ApiHeaders.Username);
 				if (systemIdentity == null)
 					query = DatabaseContext.Users.Where(x => x.CanonicalName == canonicalName);
 				else
@@ -220,7 +220,7 @@ namespace Tgstation.Server.Host.Controllers
 					Logger.LogDebug("User ID {0}'s system identity needs a refresh, updating database.", user.Id);
 					DatabaseContext.Users.Attach(user);
 					user.Name = systemIdentity.Username;
-					user.CanonicalName = user.Name.ToUpperInvariant();
+					user.CanonicalName = Models.User.CanonicalizeName(user.Name);
 					await DatabaseContext.Save(cancellationToken).ConfigureAwait(false);
 				}
 

--- a/src/Tgstation.Server.Host/Controllers/InstanceController.cs
+++ b/src/Tgstation.Server.Host/Controllers/InstanceController.cs
@@ -240,11 +240,11 @@ namespace Tgstation.Server.Host.Controllers
 		/// <param name="id">The <see cref="Api.Models.Instance.Id"/> to detach.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> of the request.</returns>
-		/// <response code="200">Instance detatched successfully.</response>
+		/// <response code="204">Instance detatched successfully.</response>
 		/// <response code="410">Instance not available.</response>
 		[HttpDelete("{id}")]
 		[TgsAuthorize(InstanceManagerRights.Delete)]
-		[ProducesResponseType(200)]
+		[ProducesResponseType(204)]
 		[ProducesResponseType(410)]
 		public async Task<IActionResult> Delete(long id, CancellationToken cancellationToken)
 		{
@@ -275,7 +275,7 @@ namespace Tgstation.Server.Host.Controllers
 			var attachFileName = ioManager.ConcatPath(originalModel.Path, InstanceAttachFileName);
 			await ioManager.WriteAllBytes(attachFileName, Array.Empty<byte>(), default).ConfigureAwait(false);
 			await DatabaseContext.Save(cancellationToken).ConfigureAwait(false); // cascades everything
-			return Ok();
+			return NoContent();
 		}
 
 		/// <summary>
@@ -289,6 +289,7 @@ namespace Tgstation.Server.Host.Controllers
 		[HttpPost]
 		[TgsAuthorize(InstanceManagerRights.Relocate | InstanceManagerRights.Rename | InstanceManagerRights.SetAutoUpdate | InstanceManagerRights.SetConfiguration | InstanceManagerRights.SetOnline)]
 		[ProducesResponseType(typeof(Api.Models.Instance), 200)]
+		[ProducesResponseType(typeof(Api.Models.Instance), 202)]
 		[ProducesResponseType(410)]
 #pragma warning disable CA1502 // TODO: Decomplexify
 		public async Task<IActionResult> Update([FromBody] Api.Models.Instance model, CancellationToken cancellationToken)

--- a/src/Tgstation.Server.Host/Controllers/InstanceUserController.cs
+++ b/src/Tgstation.Server.Host/Controllers/InstanceUserController.cs
@@ -173,14 +173,14 @@ namespace Tgstation.Server.Host.Controllers
 		/// <param name="id">The <see cref="Api.Models.InstanceUser.UserId"/> to delete.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> of the request.</returns>
-		/// <response code="200"><see cref="Api.Models.InstanceUser"/> deleted or no longer exists.</response>
+		/// <response code="204"><see cref="Api.Models.InstanceUser"/> deleted or no longer exists.</response>
 		[HttpDelete("{id}")]
 		[TgsAuthorize(InstanceUserRights.WriteUsers)]
-		[ProducesResponseType(200)]
+		[ProducesResponseType(204)]
 		public async Task<IActionResult> Delete(long id, CancellationToken cancellationToken)
 		{
 			await DatabaseContext.Instances.Where(x => x.Id == Instance.Id).SelectMany(x => x.InstanceUsers).Where(x => x.UserId == id).DeleteAsync(cancellationToken).ConfigureAwait(false);
-			return Ok();
+			return NoContent();
 		}
 	}
 }

--- a/src/Tgstation.Server.Host/Controllers/JobController.cs
+++ b/src/Tgstation.Server.Host/Controllers/JobController.cs
@@ -83,7 +83,7 @@ namespace Tgstation.Server.Host.Controllers
 		/// <response code="410"><see cref="Api.Models.Job"/> already cancelled or completed.</response>
 		[HttpDelete("{id}")]
 		[TgsAuthorize]
-		[ProducesResponseType(202)]
+		[ProducesResponseType(typeof(Api.Models.Job), 202)]
 		[ProducesResponseType(404)]
 		[ProducesResponseType(410)]
 		public async Task<IActionResult> Delete(long id, CancellationToken cancellationToken)
@@ -99,8 +99,8 @@ namespace Tgstation.Server.Host.Controllers
 			if (job.CancelRight.HasValue && job.CancelRightsType.HasValue && (AuthenticationContext.GetRight(job.CancelRightsType.Value) & job.CancelRight.Value) == 0)
 				return Forbid();
 
-			var cancelled = await jobManager.CancelJob(job, AuthenticationContext.User, false, cancellationToken).ConfigureAwait(false);
-			return cancelled ? (IActionResult)Accepted() : StatusCode((int)HttpStatusCode.Gone);
+			job = await jobManager.CancelJob(job, AuthenticationContext.User, false, cancellationToken).ConfigureAwait(false);
+			return job != null ? (IActionResult)Accepted(job.ToApi()) : StatusCode((int)HttpStatusCode.Gone);
 		}
 
 		/// <summary>

--- a/src/Tgstation.Server.Host/Controllers/RepositoryController.cs
+++ b/src/Tgstation.Server.Host/Controllers/RepositoryController.cs
@@ -317,7 +317,7 @@ namespace Tgstation.Server.Host.Controllers
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> of the operation.</returns>
 		/// <response code="200">Updated the <see cref="Repository"/> settings successfully.</response>
-		/// <response code="201">Updated the <see cref="Repository"/> settings successfully and a <see cref="Api.Models.Job"/> was created to make the requested git changes.</response>
+		/// <response code="202">Updated the <see cref="Repository"/> settings successfully and a <see cref="Api.Models.Job"/> was created to make the requested git changes.</response>
 		/// <response code="410">Instance no longer available.</response>
 		[HttpPost]
 		[TgsAuthorize(RepositoryRights.ChangeAutoUpdateSettings | RepositoryRights.ChangeCommitter | RepositoryRights.ChangeCredentials | RepositoryRights.ChangeTestMergeCommits | RepositoryRights.MergePullRequest | RepositoryRights.SetReference | RepositoryRights.SetSha | RepositoryRights.UpdateBranch)]

--- a/src/Tgstation.Server.Host/Controllers/UserController.cs
+++ b/src/Tgstation.Server.Host/Controllers/UserController.cs
@@ -154,7 +154,7 @@ namespace Tgstation.Server.Host.Controllers
 					return result;
 			}
 
-			dbUser.CanonicalName = dbUser.Name.ToUpperInvariant();
+			dbUser.CanonicalName = Models.User.CanonicalizeName(dbUser.Name);
 
 			DatabaseContext.Users.Add(dbUser);
 
@@ -206,7 +206,7 @@ namespace Tgstation.Server.Host.Controllers
 					return result;
 			}
 
-			if (model.Name != null && model.Name.ToUpperInvariant() != originalUser.CanonicalName)
+			if (model.Name != null && Models.User.CanonicalizeName(model.Name) != originalUser.CanonicalName)
 				return BadRequest(new ErrorMessage { Message = "Can only change capitalization of a user's name!" });
 
 			originalUser.InstanceManagerRights = model.InstanceManagerRights ?? originalUser.InstanceManagerRights;

--- a/src/Tgstation.Server.Host/Core/SetupWizard.cs
+++ b/src/Tgstation.Server.Host/Core/SetupWizard.cs
@@ -366,7 +366,7 @@ namespace Tgstation.Server.Host.Core
 								databaseName = await ValidateNonExistantSqliteDBName(databaseName, cancellationToken).ConfigureAwait(false);
 						}
 						else
-							await PromptYesNo("Does this database already exist? (y/n): ", cancellationToken).ConfigureAwait(false);
+							dbExists = await PromptYesNo("Does this database already exist? (y/n): ", cancellationToken).ConfigureAwait(false);
 					}
 
 					if (String.IsNullOrWhiteSpace(databaseName))

--- a/src/Tgstation.Server.Host/Database/DatabaseSeeder.cs
+++ b/src/Tgstation.Server.Host/Database/DatabaseSeeder.cs
@@ -38,7 +38,7 @@ namespace Tgstation.Server.Host.Database
 				CreatedAt = DateTimeOffset.Now,
 				InstanceManagerRights = RightsHelper.AllRights<InstanceManagerRights>(),
 				Name = Api.Models.User.AdminName,
-				CanonicalName = Api.Models.User.AdminName.ToUpperInvariant(),
+				CanonicalName = User.CanonicalizeName(Api.Models.User.AdminName),
 				Enabled = true,
 			};
 			cryptographySuite.SetUserPassword(admin, Api.Models.User.DefaultAdminPassword, true);
@@ -89,7 +89,11 @@ namespace Tgstation.Server.Host.Database
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the admin <see cref="User"/> or <see langword="null"/>. If <see langword="null"/>, <see cref="IDatabaseContext.Save(CancellationToken)"/> must be called on <paramref name="databaseContext"/>.</returns>
 		async Task<User> GetAdminUser(IDatabaseContext databaseContext, CancellationToken cancellationToken)
 		{
-			var admin = await databaseContext.Users.Where(x => x.CanonicalName == Api.Models.User.AdminName.ToUpperInvariant()).FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+			var admin = await databaseContext
+				.Users
+				.Where(x => x.CanonicalName == User.CanonicalizeName(Api.Models.User.AdminName))
+				.FirstOrDefaultAsync(cancellationToken)
+				.ConfigureAwait(false);
 			if (admin == default)
 				SeedAdminUser(databaseContext);
 

--- a/src/Tgstation.Server.Host/Database/DatabaseSeeder.cs
+++ b/src/Tgstation.Server.Host/Database/DatabaseSeeder.cs
@@ -34,9 +34,9 @@ namespace Tgstation.Server.Host.Database
 		{
 			var admin = new User
 			{
-				AdministrationRights = ~AdministrationRights.None,
+				AdministrationRights = RightsHelper.AllRights<AdministrationRights>(),
 				CreatedAt = DateTimeOffset.Now,
-				InstanceManagerRights = ~InstanceManagerRights.None,
+				InstanceManagerRights = RightsHelper.AllRights<InstanceManagerRights>(),
 				Name = Api.Models.User.AdminName,
 				CanonicalName = Api.Models.User.AdminName.ToUpperInvariant(),
 				Enabled = true,
@@ -53,18 +53,47 @@ namespace Tgstation.Server.Host.Database
 		}
 
 		/// <inheritdoc />
+		public async Task SanitizeDatabase(IDatabaseContext databaseContext, CancellationToken cancellationToken)
+		{
+			var admin = await GetAdminUser(databaseContext, cancellationToken).ConfigureAwait(false);
+			if (admin != null)
+			{
+				// Fix the issue with ulong enums
+				// https://github.com/tgstation/tgstation-server/commit/db341d43b3dab74fe3681f5172ca9bfeaafa6b6d#diff-09f06ec4584665cf89bb77b97f5ccfb9R36-R39
+				// https://github.com/JamesNK/Newtonsoft.Json/issues/2301
+				admin.AdministrationRights = admin.AdministrationRights & RightsHelper.AllRights<AdministrationRights>();
+				admin.InstanceManagerRights = admin.InstanceManagerRights & RightsHelper.AllRights<InstanceManagerRights>();
+			}
+
+			await databaseContext.Save(cancellationToken).ConfigureAwait(false);
+		}
+
+		/// <inheritdoc />
 		public async Task ResetAdminPassword(IDatabaseContext databaseContext, CancellationToken cancellationToken)
 		{
-			var admin = await databaseContext.Users.Where(x => x.CanonicalName == Api.Models.User.AdminName.ToUpperInvariant()).FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
-			if (admin == default)
-				SeedAdminUser(databaseContext);
-			else
+			var admin = await GetAdminUser(databaseContext, cancellationToken).ConfigureAwait(false);
+			if (admin != null)
 			{
 				admin.Enabled = true;
 				cryptographySuite.SetUserPassword(admin, Api.Models.User.DefaultAdminPassword, false);
 			}
 
 			await databaseContext.Save(cancellationToken).ConfigureAwait(false);
+		}
+
+		/// <summary>
+		/// Get or create the admin <see cref="User"/>.
+		/// </summary>
+		/// <param name="databaseContext">The <see cref="IDatabaseContext"/> to use.</param>
+		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
+		/// <returns>A <see cref="Task{TResult}"/> resulting in the admin <see cref="User"/> or <see langword="null"/>. If <see langword="null"/>, <see cref="IDatabaseContext.Save(CancellationToken)"/> must be called on <paramref name="databaseContext"/>.</returns>
+		async Task<User> GetAdminUser(IDatabaseContext databaseContext, CancellationToken cancellationToken)
+		{
+			var admin = await databaseContext.Users.Where(x => x.CanonicalName == Api.Models.User.AdminName.ToUpperInvariant()).FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+			if (admin == default)
+				SeedAdminUser(databaseContext);
+
+			return admin;
 		}
 	}
 }

--- a/src/Tgstation.Server.Host/Database/IDatabaseSeeder.cs
+++ b/src/Tgstation.Server.Host/Database/IDatabaseSeeder.cs
@@ -17,6 +17,14 @@ namespace Tgstation.Server.Host.Database
 		Task SeedDatabase(IDatabaseContext databaseContext, CancellationToken cancellationToken);
 
 		/// <summary>
+		/// Correct invalid database data caused by previous versions.
+		/// </summary>
+		/// <param name="databaseContext">The <see cref="IDatabaseContext"/> to sanitize.</param>
+		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
+		/// <returns>A <see cref="Task"/> representing the running operation.</returns>
+		Task SanitizeDatabase(IDatabaseContext databaseContext, CancellationToken cancellationToken);
+
+		/// <summary>
 		/// Changes the admin password in <see cref="IDatabaseContext"/> back to it's default and enables the account
 		/// </summary>
 		/// <param name="databaseContext">The <see cref="IDatabaseContext"/> to reset the admin password for</param>

--- a/src/Tgstation.Server.Host/Jobs/IJobManager.cs
+++ b/src/Tgstation.Server.Host/Jobs/IJobManager.cs
@@ -47,7 +47,7 @@ namespace Tgstation.Server.Host.Jobs
 		/// <param name="user">The <see cref="User"/> who cancelled the <paramref name="job"/></param>
 		/// <param name="blocking">If the operation should wait until the job exits before completing</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
-		/// <returns>A <see cref="Task{TResult}"/> resulting in <see langword="true"/> if the <paramref name="job"/> was cancelled, <see langword="false"/> if it couldn't be found</returns>
-		Task<bool> CancelJob(Job job, User user, bool blocking, CancellationToken cancellationToken);
+		/// <returns>A <see cref="Task{TResult}"/> resulting in the updated <paramref name="job"/> if it was cancelled, <see langword="null"/> if it couldn't be found.</returns>
+		Task<Job> CancelJob(Job job, User user, bool blocking, CancellationToken cancellationToken);
 	}
 }

--- a/src/Tgstation.Server.Host/Jobs/JobManager.cs
+++ b/src/Tgstation.Server.Host/Jobs/JobManager.cs
@@ -218,7 +218,7 @@ namespace Tgstation.Server.Host.Jobs
 		}
 
 		/// <inheritdoc />
-		public async Task<bool> CancelJob(Job job, User user, bool blocking, CancellationToken cancellationToken)
+		public async Task<Job> CancelJob(Job job, User user, bool blocking, CancellationToken cancellationToken)
 		{
 			if (job == null)
 				throw new ArgumentNullException(nameof(job));
@@ -232,7 +232,7 @@ namespace Tgstation.Server.Host.Jobs
 			catch (InvalidOperationException)
 			{
 				// this is fine
-				return false;
+				return null;
 			}
 
 			handler.Cancel(); // this will ensure the db update is only done once
@@ -249,7 +249,7 @@ namespace Tgstation.Server.Host.Jobs
 			}).ConfigureAwait(false);
 			if (blocking)
 				await handler.Wait(cancellationToken).ConfigureAwait(false);
-			return true;
+			return job;
 		}
 
 		/// <inheritdoc />

--- a/src/Tgstation.Server.Host/Models/User.cs
+++ b/src/Tgstation.Server.Host/Models/User.cs
@@ -44,6 +44,13 @@ namespace Tgstation.Server.Host.Models
 		public List<TestMerge> TestMerges { get; set; }
 
 		/// <summary>
+		/// Change a <see cref="Api.Models.Internal.User.Name"/> into a <see cref="CanonicalName"/>.
+		/// </summary>
+		/// <param name="name">The <see cref="Api.Models.Internal.User.Name"/>.</param>
+		/// <returns>The <see cref="CanonicalName"/>.</returns>
+		public static string CanonicalizeName(string name) => name?.ToUpperInvariant() ?? throw new ArgumentNullException(nameof(name));
+
+		/// <summary>
 		/// See <see cref="ToApi(bool)"/>
 		/// </summary>
 		/// <param name="recursive">If we should recurse on <see cref="CreatedBy"/></param>

--- a/tests/Tgstation.Server.Api.Tests/Rights/TestRights.cs
+++ b/tests/Tgstation.Server.Api.Tests/Rights/TestRights.cs
@@ -36,5 +36,14 @@ namespace Tgstation.Server.Api.Rights.Tests
 				}
 			}
 		}
+
+		[TestMethod]
+		public void TestAllRightsWorks()
+		{
+			var allByondRights = ByondRights.CancelInstall | ByondRights.ChangeVersion | ByondRights.ListInstalled | ByondRights.ReadActive;
+			var automaticByondRights = RightsHelper.AllRights<ByondRights>();
+
+			Assert.AreEqual(allByondRights, automaticByondRights);
+		}
 	}
 }

--- a/tests/Tgstation.Server.Tests/UsersTest.cs
+++ b/tests/Tgstation.Server.Tests/UsersTest.cs
@@ -20,10 +20,20 @@ namespace Tgstation.Server.Tests
 
 		public async Task Run(CancellationToken cancellationToken)
 		{
+			await TestRetrieveCurrentUser(cancellationToken).ConfigureAwait(false);
 			await TestSpamCreation(cancellationToken).ConfigureAwait(false);
 		}
+		
+		async Task TestRetrieveCurrentUser(CancellationToken cancellationToken)
+		{
+			var user = await this.client.Read(cancellationToken).ConfigureAwait(false);
+			Assert.IsNotNull(user);
+			Assert.AreEqual("Admin", user.Name);
+			Assert.IsNull(user.SystemIdentifier);
+			Assert.AreEqual(true, user.Enabled);
+		}
 
-		public async Task TestSpamCreation(CancellationToken cancellationToken)
+		async Task TestSpamCreation(CancellationToken cancellationToken)
 		{
 			ICollection<Task<User>> tasks = new List<Task<User>>();
 


### PR DESCRIPTION
:cl:
Pressing Ctrl+C without the host watchdog will now log an appropriate message.
Fixed being unable to select an existing database in the Setup Wizard.
The admin user permissions will no longer have unassigned flags set.
/:cl: