### PR TITLE
v4.1.1

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- This is the authorative version list -->
     <!-- Integration tests will ensure they match across the board -->
-    <TgsCoreVersion>4.1.0</TgsCoreVersion>
+    <TgsCoreVersion>4.1.1</TgsCoreVersion>
     <TgsApiVersion>6.1.0</TgsApiVersion>
     <TgsClientVersion>6.0.0</TgsClientVersion>
     <TgsDmapiVersion>5.0.0</TgsDmapiVersion>

--- a/src/Tgstation.Server.Host/Controllers/ChatController.cs
+++ b/src/Tgstation.Server.Host/Controllers/ChatController.cs
@@ -87,8 +87,8 @@ namespace Tgstation.Server.Host.Controllers
 			if (countOfExistingBotsInInstance >= Instance.ChatBotLimit.Value)
 				return Conflict(new ErrorMessage(ErrorCode.ChatBotMax));
 
-			model.Enabled = model.Enabled ?? false;
-			model.ReconnectionInterval = model.ReconnectionInterval ?? 1;
+			model.Enabled ??= false;
+			model.ReconnectionInterval ??= 1;
 
 			// try to update das db first
 			var dbModel = new Models.ChatBot
@@ -330,7 +330,7 @@ namespace Tgstation.Server.Host.Controllers
 				return BadRequest(new ErrorMessage(ErrorCode.ChatBotMaxChannels));
 
 			if (forCreation)
-				model.ChannelLimit = model.ChannelLimit ?? (ushort)defaultMaxChannels;
+				model.ChannelLimit ??= (ushort)defaultMaxChannels;
 
 			return null;
 		}

--- a/src/Tgstation.Server.Host/Controllers/ChatController.cs
+++ b/src/Tgstation.Server.Host/Controllers/ChatController.cs
@@ -264,6 +264,7 @@ namespace Tgstation.Server.Host.Controllers
 				|| CheckModified(x => x.Name, ChatBotRights.WriteName)
 				|| CheckModified(x => x.Provider, ChatBotRights.WriteProvider)
 				|| CheckModified(x => x.ReconnectionInterval, ChatBotRights.WriteReconnectionInterval)
+				|| CheckModified(x => x.ChannelLimit, ChatBotRights.WriteChannelLimit)
 				|| (model.Channels != null && !userRights.HasFlag(ChatBotRights.WriteChannels)))
 				return Forbid();
 

--- a/src/Tgstation.Server.Host/Controllers/InstanceController.cs
+++ b/src/Tgstation.Server.Host/Controllers/InstanceController.cs
@@ -349,7 +349,7 @@ namespace Tgstation.Server.Host.Controllers
 		/// <response code="200">Instance updated successfully.</response>
 		/// <response code="202">Instance updated successfully and relocation job created.</response>
 		[HttpPost]
-		[TgsAuthorize(InstanceManagerRights.Relocate | InstanceManagerRights.Rename | InstanceManagerRights.SetAutoUpdate | InstanceManagerRights.SetConfiguration | InstanceManagerRights.SetOnline)]
+		[TgsAuthorize(InstanceManagerRights.Relocate | InstanceManagerRights.Rename | InstanceManagerRights.SetAutoUpdate | InstanceManagerRights.SetConfiguration | InstanceManagerRights.SetOnline | InstanceManagerRights.SetChatBotLimit)]
 		[ProducesResponseType(typeof(Api.Models.Instance), 200)]
 		[ProducesResponseType(typeof(Api.Models.Instance), 202)]
 		[ProducesResponseType(410)]

--- a/tests/Tgstation.Server.Tests/Instance/ChatTest.cs
+++ b/tests/Tgstation.Server.Tests/Instance/ChatTest.cs
@@ -198,6 +198,7 @@ namespace Tgstation.Server.Tests.Instance
 			await ApiAssert.ThrowsException<ConflictException>(() => instanceClient.Update(instance, cancellationToken), ErrorCode.ChatBotMax);
 
 			discordBot.ChannelLimit = 20;
+			discordBot.Channels = null;
 			await chatClient.Update(discordBot, cancellationToken);
 		}
 	}

--- a/tests/Tgstation.Server.Tests/Instance/ChatTest.cs
+++ b/tests/Tgstation.Server.Tests/Instance/ChatTest.cs
@@ -196,6 +196,9 @@ namespace Tgstation.Server.Tests.Instance
 			var instance = metadata.CloneMetadata();
 			instance.ChatBotLimit = 0;
 			await ApiAssert.ThrowsException<ConflictException>(() => instanceClient.Update(instance, cancellationToken), ErrorCode.ChatBotMax);
+
+			discordBot.ChannelLimit = 20;
+			await chatClient.Update(discordBot, cancellationToken);
 		}
 	}
 }

--- a/tests/Tgstation.Server.Tests/InstanceManagerTest.cs
+++ b/tests/Tgstation.Server.Tests/InstanceManagerTest.cs
@@ -167,11 +167,14 @@ namespace Tgstation.Server.Tests
 				InstanceManagerRights = InstanceManagerRights.SetChatBotLimit
 			};
 			await usersClient.Update(update, cancellationToken);
-			firstTest.ChatBotLimit = 77;
-			var newThing = await instanceManagerClient.Update(firstTest, cancellationToken);
-			Assert.AreEqual(77, newThing.ChatBotLimit);
+			var update2 = new Api.Models.Instance
+			{
+				Id = firstTest.Id,
+				ChatBotLimit = 77
+			};
+			var newThing = await instanceManagerClient.Update(update2, cancellationToken);
 
-			update.InstanceManagerRights |= InstanceManagerRights.Delete;
+			update.InstanceManagerRights |= InstanceManagerRights.Delete | InstanceManagerRights.Create;
 			await usersClient.Update(update, cancellationToken);
 
 			//but only if the attach file exists

--- a/tests/Tgstation.Server.Tests/IntegrationTest.cs
+++ b/tests/Tgstation.Server.Tests/IntegrationTest.cs
@@ -123,7 +123,7 @@ namespace Tgstation.Server.Tests
 						}
 					} while (true);
 
-					var testUpdateVersion = new Version(4, 0, 0, 6);
+					var testUpdateVersion = new Version(4, 1, 0);
 					using (adminClient)
 						//attempt to update to stable
 						await adminClient.Administration.Update(new Administration
@@ -142,7 +142,7 @@ namespace Tgstation.Server.Tests
 					Assert.IsTrue(File.Exists(updatedAssemblyPath), "Updated assembly missing!");
 
 					var updatedAssemblyVersion = FileVersionInfo.GetVersionInfo(updatedAssemblyPath);
-					Assert.AreEqual(testUpdateVersion, Version.Parse(updatedAssemblyVersion.FileVersion));
+					Assert.AreEqual(testUpdateVersion, Version.Parse(updatedAssemblyVersion.FileVersion).Semver());
 				}
 				finally
 				{
@@ -220,7 +220,7 @@ namespace Tgstation.Server.Tests
 
 					var adminTest = new AdministrationTest(adminClient.Administration).Run(cancellationToken);
 					var usersTest = new UsersTest(adminClient.Users).Run(cancellationToken);
-					await new InstanceManagerTest(adminClient.Instances, server.Directory).Run(cancellationToken).ConfigureAwait(false);
+					await new InstanceManagerTest(adminClient.Instances, adminClient.Users, server.Directory).Run(cancellationToken).ConfigureAwait(false);
 
 					await adminTest.ConfigureAwait(false);
 					await usersTest.ConfigureAwait(false);

--- a/tests/Tgstation.Server.Tests/IntegrationTest.cs
+++ b/tests/Tgstation.Server.Tests/IntegrationTest.cs
@@ -78,8 +78,6 @@ namespace Tgstation.Server.Tests
 			Assert.IsTrue(discordProvider.Connected, "Discord provider not connected!");
 		}
 
-		// Disabled until 4.1.0 due to changes in version handling
-		[Ignore]
 		[TestMethod]
 		public async Task TestServerUpdate()
 		{


### PR DESCRIPTION
:cl:
Fixed being unable to change chat bot channel limits once created.
Fixed the SetChatBotLimit permission not being able to be used on its own.
/:cl: