### PR TITLE
Fix the service not installing when double clicked

### DIFF
--- a/src/Tgstation.Server.Host.Service/Program.cs
+++ b/src/Tgstation.Server.Host.Service/Program.cs
@@ -110,9 +110,6 @@ namespace Tgstation.Server.Host.Service
 
 			using (var loggerFactory = new LoggerFactory())
 			{
-				if (Configure)
-					await WatchdogFactory.CreateWatchdog(loggerFactory).RunAsync(true, Array.Empty<string>(), default).ConfigureAwait(false);
-
 				if (Install)
 				{
 					if (Uninstall)
@@ -134,6 +131,12 @@ namespace Tgstation.Server.Host.Service
 						var state = new ListDictionary();
 						installer.Install(state);
 					}
+
+					if (Configure)
+					{
+						Console.WriteLine("For this first run we'll launch the console runner so you may use the setup wizard.");
+						Console.WriteLine("If it starts successfully, feel free to close it and then start the service from the Windows control panel.");
+					}
 				}
 				else if (Uninstall)
 					using (var installer = new ServiceInstaller())
@@ -145,6 +148,9 @@ namespace Tgstation.Server.Host.Service
 				else if (!Configure)
 					using (var service = new ServerService(WatchdogFactory, loggerFactory, Trace ? LogLevel.Trace : Debug ? LogLevel.Debug : LogLevel.Information))
 						ServiceBase.Run(service);
+
+				if (Configure)
+					await WatchdogFactory.CreateWatchdog(loggerFactory).RunAsync(true, Array.Empty<string>(), default).ConfigureAwait(false);
 			}
 		}
 	}

--- a/src/Tgstation.Server.Host/Controllers/UserController.cs
+++ b/src/Tgstation.Server.Host/Controllers/UserController.cs
@@ -147,7 +147,7 @@ namespace Tgstation.Server.Host.Controllers
 				}
 				catch (NotImplementedException)
 				{
-					return StatusCode((int)HttpStatusCode.NotImplemented);
+					return StatusCode((int)HttpStatusCode.NotImplemented, new ErrorMessage(ErrorCode.RequiresPosixSystemIdentity));
 				}
 			else
 			{

--- a/tools/ReleaseNotes/Program.cs
+++ b/tools/ReleaseNotes/Program.cs
@@ -77,6 +77,7 @@ namespace ReleaseNotes
 				var authorizedUsers = new Dictionary<long, Task<bool>>();
 
 				bool hasSqliteFuckage = false;
+				bool postControlPanelMessage = false;
 
 				async Task GetReleaseNotesFromPR(Issue pullRequest)
 				{
@@ -243,6 +244,9 @@ namespace ReleaseNotes
 						var webControlVersion = Version.Parse(versionsPropertyGroup.Element(xmlNamespace + "TgsControlPanelVersion").Value);
 						var hostWatchdogVersion = Version.Parse(versionsPropertyGroup.Element(xmlNamespace + "TgsHostWatchdogVersion").Value);
 
+						if (webControlVersion.Major == 0)
+							postControlPanelMessage = true;
+
 						prefix = $"#### Component Versions\nCore: {coreVersion}\nHTTP API: {apiVersion}\nDreamMaker API: {dmApiVersion}\n[Web Control Panel](https://github.com/tgstation/tgstation-server-control-panel): {webControlVersion}\nHost Watchdog: {hostWatchdogVersion}";
 
 						//hasSqliteFuckage = hasSqliteFuckage && version != new Version(4, 1, 0);
@@ -259,6 +263,13 @@ namespace ReleaseNotes
 				}
 
 				var newNotes = new StringBuilder(prefix);
+				if (postControlPanelMessage)
+				{
+					newNotes.Append(Environment.NewLine);
+					newNotes.Append(Environment.NewLine);
+					newNotes.Append("### The recommended client is currently the legacy [Tgstation.Server.ControlPanel](https://github.com/tgstation/Tgstation.Server.ControlPanel/releases/latest). This will be phased out as the web client is completed.");
+				}
+
 				newNotes.Append(Environment.NewLine);
 				newNotes.Append(Environment.NewLine);
 				if (version.Build == 0)
@@ -270,7 +281,7 @@ namespace ReleaseNotes
 				else
 				{
 					newNotes.Append("## [Patch ");
-					newNotes.Append(version.Revision);
+					newNotes.Append(version.Build);
 				}
 				newNotes.Append("](");
 				var milestone = await milestoneTask.ConfigureAwait(false);


### PR DESCRIPTION
Fixes #873 

:cl:
Fixed double clicking the service executable (or running with `-i -c`) would not install the service.
Fixed getting an incorrect response when attempting to create system identity users on POSIX.
/:cl: