### PR TITLE
Jobs now take an IDatabaseContextFactory

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- This is the authorative version list -->
     <!-- Integration tests will ensure they match across the board -->
-    <TgsCoreVersion>4.2.3</TgsCoreVersion>
+    <TgsCoreVersion>4.2.4</TgsCoreVersion>
     <TgsApiVersion>6.4.0</TgsApiVersion>
     <TgsClientVersion>6.3.0</TgsClientVersion>
     <TgsDmapiVersion>5.2.0</TgsDmapiVersion>

--- a/src/Tgstation.Server.Host/Components/Deployment/IDreamMaker.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/IDreamMaker.cs
@@ -15,13 +15,13 @@ namespace Tgstation.Server.Host.Components.Deployment
 		/// Create and  a compile job and insert it into the database. Meant to be called by a <see cref="Jobs.IJobManager"/>.
 		/// </summary>
 		/// <param name="job">The running <see cref="Job"/>.</param>
-		/// <param name="databaseContext">The <see cref="IDatabaseContext"/> for the operation.</param>
+		/// <param name="databaseContextFactory">The <see cref="IDatabaseContextFactory"/> for the operation.</param>
 		/// <param name="progressReporter">The <see cref="Action{T1}"/> to report compilation progress.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task"/> representing the running operation.</returns>
 		Task DeploymentProcess(
 			Job job,
-			IDatabaseContext databaseContext,
+			IDatabaseContextFactory databaseContextFactory,
 			Action<int> progressReporter,
 			CancellationToken cancellationToken);
 	}

--- a/src/Tgstation.Server.Host/Components/InstanceFactory.cs
+++ b/src/Tgstation.Server.Host/Components/InstanceFactory.cs
@@ -211,8 +211,7 @@ namespace Tgstation.Server.Host.Components
 				repoIoManager,
 				eventConsumer,
 				loggerFactory.CreateLogger<Repository.Repository>(),
-				loggerFactory.CreateLogger<RepositoryManager>(),
-				metadata.RepositorySettings);
+				loggerFactory.CreateLogger<RepositoryManager>());
 			try
 			{
 				var byond = new ByondManager(byondIOManager, byondInstaller, eventConsumer, loggerFactory.CreateLogger<ByondManager>());

--- a/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
@@ -865,7 +865,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 				CancelRight = (ulong)DreamDaemonRights.Shutdown,
 				CancelRightsType = RightsType.DreamDaemon
 			};
-			await jobManager.RegisterOperation(job, async (j, databaseContext, progressFunction, ct) =>
+			await jobManager.RegisterOperation(job, async (j, databaseContextFactory, progressFunction, ct) =>
 			{
 				using (await SemaphoreSlimContext.Lock(Semaphore, ct).ConfigureAwait(false))
 					await LaunchImplNoLock(true, true, reattachInfo, ct).ConfigureAwait(false);

--- a/src/Tgstation.Server.Host/Controllers/ByondController.cs
+++ b/src/Tgstation.Server.Host/Controllers/ByondController.cs
@@ -120,7 +120,7 @@ namespace Tgstation.Server.Host.Controllers
 					CancelRight = (ulong)ByondRights.CancelInstall,
 					Instance = Instance
 				};
-				await jobManager.RegisterOperation(job, (paramJob, databaseContext, progressHandler, ct) => byondManager.ChangeVersion(installingVersion, ct), cancellationToken).ConfigureAwait(false);
+				await jobManager.RegisterOperation(job, (paramJob, databaseContextFactory, progressHandler, ct) => byondManager.ChangeVersion(installingVersion, ct), cancellationToken).ConfigureAwait(false);
 				result.InstallJob = job.ToApi();
 			}
 

--- a/src/Tgstation.Server.Host/Controllers/DreamDaemonController.cs
+++ b/src/Tgstation.Server.Host/Controllers/DreamDaemonController.cs
@@ -77,7 +77,7 @@ namespace Tgstation.Server.Host.Controllers
 				Instance = Instance,
 				StartedBy = AuthenticationContext.User
 			};
-			await jobManager.RegisterOperation(job, (paramJob, databaseContext, progressHandler, innerCt) => instance.Watchdog.Launch(innerCt), cancellationToken).ConfigureAwait(false);
+			await jobManager.RegisterOperation(job, (paramJob, databaseContextFactory, progressHandler, innerCt) => instance.Watchdog.Launch(innerCt), cancellationToken).ConfigureAwait(false);
 			return Accepted(job.ToApi());
 		}
 
@@ -274,7 +274,7 @@ namespace Tgstation.Server.Host.Controllers
 
 			var watchdog = instanceManager.GetInstance(Instance).Watchdog;
 
-			await jobManager.RegisterOperation(job, (paramJob, databaseContext, progressReporter, ct) => watchdog.Restart(false, ct), cancellationToken).ConfigureAwait(false);
+			await jobManager.RegisterOperation(job, (paramJob, databaseContextFactory, progressReporter, ct) => watchdog.Restart(false, ct), cancellationToken).ConfigureAwait(false);
 			return Accepted(job.ToApi());
 		}
 	}

--- a/src/Tgstation.Server.Host/Controllers/InstanceController.cs
+++ b/src/Tgstation.Server.Host/Controllers/InstanceController.cs
@@ -505,7 +505,7 @@ namespace Tgstation.Server.Host.Controllers
 					StartedBy = AuthenticationContext.User
 				};
 
-				await jobManager.RegisterOperation(job, (paramJob, databaseContext, progressHandler, ct) => instanceManager.MoveInstance(originalModel, rawPath, ct), cancellationToken).ConfigureAwait(false);
+				await jobManager.RegisterOperation(job, (paramJob, databaseContextFactory, progressHandler, ct) => instanceManager.MoveInstance(originalModel, rawPath, ct), cancellationToken).ConfigureAwait(false);
 				api.MoveJob = job.ToApi();
 			}
 

--- a/src/Tgstation.Server.Host/Core/SemaphoreSlimContext.cs
+++ b/src/Tgstation.Server.Host/Core/SemaphoreSlimContext.cs
@@ -19,8 +19,8 @@ namespace Tgstation.Server.Host.Core
 		{
 			if (semaphore == null)
 				throw new ArgumentNullException(nameof(semaphore));
-			await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
 			cancellationToken.ThrowIfCancellationRequested();
+			await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
 			return new SemaphoreSlimContext(semaphore);
 		}
 

--- a/src/Tgstation.Server.Host/Database/IDatabaseContextFactory.cs
+++ b/src/Tgstation.Server.Host/Database/IDatabaseContextFactory.cs
@@ -6,7 +6,7 @@ namespace Tgstation.Server.Host.Database
 	/// <summary>
 	/// Factory for scoping usage of <see cref="IDatabaseContext"/>s. Meant for use by <see cref="Components"/>
 	/// </summary>
-	interface IDatabaseContextFactory
+	public interface IDatabaseContextFactory
 	{
 		/// <summary>
 		/// Run an <paramref name="operation"/> in the scope of an <see cref="IDatabaseContext"/>

--- a/src/Tgstation.Server.Host/Jobs/IJobManager.cs
+++ b/src/Tgstation.Server.Host/Jobs/IJobManager.cs
@@ -23,10 +23,10 @@ namespace Tgstation.Server.Host.Jobs
 		/// Registers a given <see cref="Job"/> and begins running it
 		/// </summary>
 		/// <param name="job">The <see cref="Job"/></param>
-		/// <param name="operation">The operation to run taking the started <see cref="Job"/>, a <see cref="IDatabaseContext"/>, progress reporter <see cref="Action{T1}"/> and a <see cref="CancellationToken"/></param>
+		/// <param name="operation">The operation to run taking the started <see cref="Job"/>, a <see cref="IDatabaseContextFactory"/>, progress reporter <see cref="Action{T1}"/> and a <see cref="CancellationToken"/></param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="Task"/> representing a running operation</returns>
-		Task RegisterOperation(Job job, Func<Job, IDatabaseContext, Action<int>, CancellationToken, Task> operation, CancellationToken cancellationToken);
+		Task RegisterOperation(Job job, Func<Job, IDatabaseContextFactory, Action<int>, CancellationToken, Task> operation, CancellationToken cancellationToken);
 
 		/// <summary>
 		/// Wait for a given <paramref name="job"/> to complete


### PR DESCRIPTION
:cl:
The patch includes a refactor to the job system that may fix the issue with deployments stalling for long periods of time.
The watchdog should no longer enter crash loops when shutting down the server.
/:cl:

Closes #1004 
Hopefully fixes #993

