### PR TITLE
v4.2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The following dependencies are required to run tgstation-server on Linux alongsi
 
 - libc6-i386
 - libstdc++6:i386
+- libssl1.0.0
 - gcc-multilib (Only on 64-bit systems)
 
 Note that tgstation-server has only ever been tested on Linux via it's [docker environment](build/Dockerfile#L22). If you are having trouble with something in a native installation, or figure out a required workaround, please contact project maintainers so this documentation may be better updated.

--- a/build/Version.props
+++ b/build/Version.props
@@ -3,8 +3,8 @@
     <!-- This is the authorative version list -->
     <!-- Integration tests will ensure they match across the board -->
     <TgsCoreVersion>4.2.5</TgsCoreVersion>
-    <TgsApiVersion>6.4.0</TgsApiVersion>
-    <TgsClientVersion>6.3.0</TgsClientVersion>
+    <TgsApiVersion>6.4.1</TgsApiVersion>
+    <TgsClientVersion>7.0.0</TgsClientVersion>
     <TgsDmapiVersion>5.2.1</TgsDmapiVersion>
     <TgsControlPanelVersion>0.4.0</TgsControlPanelVersion>
     <TgsHostWatchdogVersion>1.1.0</TgsHostWatchdogVersion>

--- a/src/Tgstation.Server.Api/ApiHeaders.cs
+++ b/src/Tgstation.Server.Api/ApiHeaders.cs
@@ -69,12 +69,12 @@ namespace Tgstation.Server.Api
 		/// <summary>
 		/// The client's user agent as a <see cref="ProductHeaderValue"/> if valid
 		/// </summary>
-		public ProductHeaderValue UserAgent => ProductInfoHeaderValue.TryParse(RawUserAgent, out var userAgent) ? userAgent.Product : null;
+		public ProductHeaderValue? UserAgent => ProductInfoHeaderValue.TryParse(RawUserAgent, out var userAgent) ? userAgent.Product : null;
 
 		/// <summary>
 		/// The client's raw user agent
 		/// </summary>
-		public string RawUserAgent { get; }
+		public string? RawUserAgent { get; }
 
 		/// <summary>
 		/// The client's API version
@@ -84,17 +84,17 @@ namespace Tgstation.Server.Api
 		/// <summary>
 		/// The client's JWT
 		/// </summary>
-		public string Token { get; }
+		public string? Token { get; }
 
 		/// <summary>
 		/// The client's username
 		/// </summary>
-		public string Username { get; }
+		public string? Username { get; }
 
 		/// <summary>
 		/// The client's password
 		/// </summary>
-		public string Password { get; }
+		public string? Password { get; }
 
 		/// <summary>
 		/// If the header uses password or JWT authentication
@@ -236,7 +236,7 @@ namespace Tgstation.Server.Api
 		/// <param name="token">The value of <see cref="Token"/></param>
 		/// <param name="username">The value of <see cref="Username"/></param>
 		/// <param name="password">The value of <see cref="Password"/></param>
-		ApiHeaders(ProductHeaderValue userAgent, string token, string username, string password)
+		ApiHeaders(ProductHeaderValue userAgent, string? token, string? username, string? password)
 		{
 			RawUserAgent = userAgent?.ToString();
 			Token = token;
@@ -274,7 +274,7 @@ namespace Tgstation.Server.Api
 
 			headers.UserAgent.Add(new ProductInfoHeaderValue(UserAgent));
 			headers.Add(ApiVersionHeader, new ProductHeaderValue(AssemblyName.Name, ApiVersion.ToString()).ToString());
-			instanceId = instanceId ?? InstanceId;
+			instanceId ??= InstanceId;
 			if (instanceId.HasValue)
 				headers.Add(InstanceIdHeader, instanceId.ToString());
 		}

--- a/src/Tgstation.Server.Api/Models/Administration.cs
+++ b/src/Tgstation.Server.Api/Models/Administration.cs
@@ -15,16 +15,16 @@ namespace Tgstation.Server.Api.Models
 		/// <summary>
 		/// The GitHub repository the server is built to recieve updates from
 		/// </summary>
-		public Uri TrackedRepositoryUrl { get; set; }
+		public Uri? TrackedRepositoryUrl { get; set; }
 
 		/// <summary>
 		/// The latest available version of the Tgstation.Server.Host assembly from the upstream repository. If <see cref="Version.Major"/> is higher than <see cref="NewVersion"/>'s the update cannot be applied due to API changes
 		/// </summary>
-		public Version LatestVersion { get; set; }
+		public Version? LatestVersion { get; set; }
 
 		/// <summary>
 		/// Changes the version of Tgstation.Server.Host to the given version from the upstream repository
 		/// </summary>
-		public Version NewVersion { get; set; }
+		public Version? NewVersion { get; set; }
 	}
 }

--- a/src/Tgstation.Server.Api/Models/Byond.cs
+++ b/src/Tgstation.Server.Api/Models/Byond.cs
@@ -10,11 +10,11 @@ namespace Tgstation.Server.Api.Models
 		/// <summary>
 		/// The <see cref="System.Version"/> of the <see cref="Byond"/> installation used for new compiles. Will be <see langword="null"/> if the user does not have permission to view it or there is no BYOND version installed. Only considers the <see cref="Version.Major"/> and <see cref="Version.Minor"/> numbers.
 		/// </summary>
-		public Version Version { get; set; }
+		public Version? Version { get; set; }
 
 		/// <summary>
 		/// The <see cref="Job"/> being used to install a new <see cref="Version"/>
 		/// </summary>
-		public Job InstallJob { get; set; }
+		public Job? InstallJob { get; set; }
 	}
 }

--- a/src/Tgstation.Server.Api/Models/ChatBot.cs
+++ b/src/Tgstation.Server.Api/Models/ChatBot.cs
@@ -10,7 +10,7 @@ namespace Tgstation.Server.Api.Models
 		/// <summary>
 		/// Channels the Discord bot should listen/announce in
 		/// </summary>
-		public ICollection<ChatChannel> Channels { get; set; }
+		public ICollection<ChatChannel>? Channels { get; set; }
 
 		/// <summary>
 		/// Validates <see cref="Channels"/> are correct for the <see cref="Internal.ChatBot.Provider"/>
@@ -20,15 +20,12 @@ namespace Tgstation.Server.Api.Models
 		{
 			if (!Provider.HasValue)
 				return true;
-			switch (Provider.Value)
+			return Provider.Value switch
 			{
-				case ChatProvider.Discord:
-					return Channels?.Select(x => x.DiscordChannelId.HasValue && x.IrcChannel == null).All(x => x) ?? true;
-				case ChatProvider.Irc:
-					return Channels?.Select(x => !x.DiscordChannelId.HasValue && x.IrcChannel != null).All(x => x) ?? true;
-				default:
-					throw new InvalidOperationException("Invalid provider type!");
-			}
+				ChatProvider.Discord => Channels?.Select(x => x.DiscordChannelId.HasValue && x.IrcChannel == null).All(x => x) ?? true,
+				ChatProvider.Irc => Channels?.Select(x => !x.DiscordChannelId.HasValue && x.IrcChannel != null).All(x => x) ?? true,
+				_ => throw new InvalidOperationException("Invalid provider type!"),
+			};
 		}
 	}
 }

--- a/src/Tgstation.Server.Api/Models/ChatChannel.cs
+++ b/src/Tgstation.Server.Api/Models/ChatChannel.cs
@@ -12,7 +12,7 @@ namespace Tgstation.Server.Api.Models
 		/// If multiple copies of the same channel with different keys are added to the server, the one that will be used is undefined.
 		/// </summary>
 		[StringLength(Limits.MaximumIndexableStringLength)]
-		public string IrcChannel { get; set; }
+		public string? IrcChannel { get; set; }
 
 		/// <summary>
 		/// The Discord channel ID
@@ -41,6 +41,6 @@ namespace Tgstation.Server.Api.Models
 		/// A custom tag users can define to group channels together
 		/// </summary>
 		[StringLength(Limits.MaximumStringLength)]
-		public string Tag { get; set; }
+		public string? Tag { get; set; }
 	}
 }

--- a/src/Tgstation.Server.Api/Models/CompileJob.cs
+++ b/src/Tgstation.Server.Api/Models/CompileJob.cs
@@ -8,16 +8,16 @@ namespace Tgstation.Server.Api.Models
 		/// <summary>
 		/// The <see cref="Job"/> relating to this job
 		/// </summary>
-		public Job Job { get; set; }
+		public Job? Job { get; set; }
 
 		/// <summary>
 		/// Git revision the compiler ran on. Not modifiable
 		/// </summary>
-		public RevisionInformation RevisionInformation { get; set; }
+		public RevisionInformation? RevisionInformation { get; set; }
 
 		/// <summary>
 		/// The <see cref="Byond.Version"/> the <see cref="CompileJob"/> was made with
 		/// </summary>
-		public Version ByondVersion { get; set; }
+		public Version? ByondVersion { get; set; }
 	}
 }

--- a/src/Tgstation.Server.Api/Models/ConfigurationFile.cs
+++ b/src/Tgstation.Server.Api/Models/ConfigurationFile.cs
@@ -11,7 +11,7 @@ namespace Tgstation.Server.Api.Models
 		/// The path to the <see cref="ConfigurationFile"/> file
 		/// </summary>
 		[StringLength(Limits.MaximumStringLength)]
-		public string Path { get; set; }
+		public string? Path { get; set; }
 
 		/// <summary>
 		/// If access to the <see cref="ConfigurationFile"/> file was denied for the operation
@@ -26,13 +26,13 @@ namespace Tgstation.Server.Api.Models
 		/// <summary>
 		/// The MD5 hash of the file when last read by the user. If this doesn't match during update actions, the write will be denied with <see cref="System.Net.HttpStatusCode.Conflict"/>
 		/// </summary>
-		public string LastReadHash { get; set; }
+		public string? LastReadHash { get; set; }
 
 		/// <summary>
 		/// The content of the <see cref="ConfigurationFile"/>. Will be <see langword="null"/> if <see cref="AccessDenied"/> is <see langword="true"/> or during listing and write operations
 		/// </summary>
-#pragma warning disable CA1819 // Properties should not return arrays
-		public byte[] Content { get; set; }
-#pragma warning restore CA1819 // Properties should not return arrays
+#pragma warning disable CA1819, SA1011 // Properties should not return arrays, Closing square bracket should be followed by a space
+		public byte[]? Content { get; set; }
+#pragma warning restore CA1819, SA1011 // Properties should not return arrays, Closing square bracket should be followed by a space
 	}
 }

--- a/src/Tgstation.Server.Api/Models/DiscordConnectionStringBuilder.cs
+++ b/src/Tgstation.Server.Api/Models/DiscordConnectionStringBuilder.cs
@@ -15,7 +15,7 @@ namespace Tgstation.Server.Api.Models
 		/// The Discord bot token
 		/// </summary>
 		/// <remarks>See https://discordapp.com/developers/docs/topics/oauth2#bots</remarks>
-		public string BotToken { get; set; }
+		public string? BotToken { get; set; }
 
 		/// <summary>
 		/// Construct a <see cref="DiscordConnectionStringBuilder"/>
@@ -32,6 +32,6 @@ namespace Tgstation.Server.Api.Models
 		}
 
 		/// <inheritdoc />
-		public override string ToString() => BotToken;
+		public override string ToString() => BotToken ?? "(null)";
 	}
 }

--- a/src/Tgstation.Server.Api/Models/DreamDaemon.cs
+++ b/src/Tgstation.Server.Api/Models/DreamDaemon.cs
@@ -11,12 +11,12 @@ namespace Tgstation.Server.Api.Models
 		/// <summary>
 		/// The live revision
 		/// </summary>
-		public CompileJob ActiveCompileJob { get; set; }
+		public CompileJob? ActiveCompileJob { get; set; }
 
 		/// <summary>
 		/// The next revision to go live
 		/// </summary>
-		public CompileJob StagedCompileJob { get; set; }
+		public CompileJob? StagedCompileJob { get; set; }
 
 		/// <summary>
 		/// The current status of <see cref="DreamDaemon"/>

--- a/src/Tgstation.Server.Api/Models/DreamMaker.cs
+++ b/src/Tgstation.Server.Api/Models/DreamMaker.cs
@@ -11,7 +11,7 @@ namespace Tgstation.Server.Api.Models
 		/// The .dme file <see cref="DreamMaker"/> tries to compile with without the extension
 		/// </summary>
 		[StringLength(Limits.MaximumStringLength)]
-		public string ProjectName { get; set; }
+		public string? ProjectName { get; set; }
 
 		/// <summary>
 		/// The port used during compilation to validate the DMAPI

--- a/src/Tgstation.Server.Api/Models/ErrorCodeExtensions.cs
+++ b/src/Tgstation.Server.Api/Models/ErrorCodeExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 
 namespace Tgstation.Server.Api.Models
@@ -13,9 +14,9 @@ namespace Tgstation.Server.Api.Models
 		/// </summary>
 		/// <param name="errorCode">The <see cref="ErrorCode"/> to describe.</param>
 		/// <returns>A description of the <paramref name="errorCode"/> on success, <see langword="null"/> on failure.</returns>
-		public static string Describe(this ErrorCode errorCode)
+		public static string? Describe(this ErrorCode errorCode)
 		{
-			var attributes = (DescriptionAttribute[])typeof(ErrorCode)
+			var attributes = (IEnumerable<DescriptionAttribute>?)typeof(ErrorCode)
 			   .GetField(errorCode.ToString())
 			   ?.GetCustomAttributes(typeof(DescriptionAttribute), false);
 

--- a/src/Tgstation.Server.Api/Models/ErrorMessage.cs
+++ b/src/Tgstation.Server.Api/Models/ErrorMessage.cs
@@ -12,24 +12,29 @@ namespace Tgstation.Server.Api.Models
 		/// The version of the API the server is using
 		/// </summary>
 		[Required]
-		public Version ServerApiVersion { get; set; }
+		public Version? ServerApiVersion { get; set; }
 
 		/// <summary>
 		/// A human readable description of the error
 		/// </summary>
 		[Required]
-		public string Message { get; set; }
+		public string? Message { get; set; }
 
 		/// <summary>
 		/// Additional data associated with the error message.
 		/// </summary>
-		public string AdditionalData { get; set; }
+		public string? AdditionalData { get; set; }
 
 		/// <summary>
 		/// The <see cref="ErrorCode"/> of the <see cref="ErrorMessage"/>.
 		/// </summary>
 		[EnumDataType(typeof(ErrorCode))]
 		public ErrorCode ErrorCode { get; set; }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ErrorMessage"/> <see langword="class"/>.
+		/// </summary>
+		public ErrorMessage() { }
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="ErrorMessage"/> <see langword="class"/>.

--- a/src/Tgstation.Server.Api/Models/Instance.cs
+++ b/src/Tgstation.Server.Api/Models/Instance.cs
@@ -18,13 +18,13 @@ namespace Tgstation.Server.Api.Models
 		/// </summary>
 		[Required]
 		[StringLength(Limits.MaximumStringLength)]
-		public string Name { get; set; }
+		public string? Name { get; set; }
 
 		/// <summary>
 		/// The path to where the <see cref="Instance"/> is located. Can only be changed while the <see cref="Instance"/> is offline. Must not exist when the instance is created
 		/// </summary>
 		[Required]
-		public string Path { get; set; }
+		public string? Path { get; set; }
 
 		/// <summary>
 		/// If the <see cref="Instance"/> is online
@@ -56,7 +56,7 @@ namespace Tgstation.Server.Api.Models
 		/// </summary>
 		/// <remarks>Due to how <see cref="Job"/>s are children of <see cref="Instance"/>s but moving one requires the <see cref="Instance"/> to be offline, interactions with this <see cref="Job"/> are performed in a non-standard fashion. The <see cref="Job"/> is read by querying the <see cref="Instance"/> again (either via list or ID lookup) and cancelled by making any sort of update to the <see cref="Instance"/>. Once the <see cref="Instance"/> comes back <see cref="Online"/> it can be queried like a normal job</remarks>
 		[NotMapped]
-		public Job MoveJob { get; set; }
+		public Job? MoveJob { get; set; }
 
 		/// <summary>
 		/// Create a clone of the essential <see cref="Instance"/> metadata

--- a/src/Tgstation.Server.Api/Models/Internal/ChatBot.cs
+++ b/src/Tgstation.Server.Api/Models/Internal/ChatBot.cs
@@ -18,7 +18,7 @@ namespace Tgstation.Server.Api.Models.Internal
 		/// </summary>
 		[Required]
 		[StringLength(Limits.MaximumIndexableStringLength)]
-		public string Name { get; set; }
+		public string? Name { get; set; }
 
 		/// <summary>
 		/// If the connection is enabled
@@ -50,25 +50,22 @@ namespace Tgstation.Server.Api.Models.Internal
 		/// </summary>
 		[Required]
 		[StringLength(Limits.MaximumStringLength)]
-		public string ConnectionString { get; set; }
+		public string? ConnectionString { get; set; }
 
 		/// <summary>
 		/// Get the <see cref="ChatConnectionStringBuilder"/> which maps to the <see cref="ConnectionString"/>.
 		/// </summary>
 		/// <returns>A <see cref="ChatConnectionStringBuilder"/> for the <see cref="ChatBot"/>.</returns>
-		public ChatConnectionStringBuilder CreateConnectionStringBuilder()
+		public ChatConnectionStringBuilder? CreateConnectionStringBuilder()
 		{
 			if (ConnectionString == null)
 				return null;
-			switch (Provider)
+			return Provider switch
 			{
-				case ChatProvider.Discord:
-					return new DiscordConnectionStringBuilder(ConnectionString);
-				case ChatProvider.Irc:
-					return new IrcConnectionStringBuilder(ConnectionString);
-				default:
-					throw new InvalidOperationException("Invalid Provider!");
-			}
+				ChatProvider.Discord => new DiscordConnectionStringBuilder(ConnectionString),
+				ChatProvider.Irc => new IrcConnectionStringBuilder(ConnectionString),
+				_ => throw new InvalidOperationException("Invalid Provider!"),
+			};
 		}
 
 		/// <summary>
@@ -77,7 +74,7 @@ namespace Tgstation.Server.Api.Models.Internal
 		/// <param name="stringBuilder">The optional <see cref="ChatConnectionStringBuilder"/>.</param>
 		public void SetConnectionStringBuilder(ChatConnectionStringBuilder stringBuilder)
 		{
-			ConnectionString = stringBuilder?.ToString();
+			ConnectionString = stringBuilder?.ToString() ?? throw new ArgumentNullException(nameof(stringBuilder));
 		}
 	}
 }

--- a/src/Tgstation.Server.Api/Models/Internal/CompileJob.cs
+++ b/src/Tgstation.Server.Api/Models/Internal/CompileJob.cs
@@ -13,13 +13,13 @@ namespace Tgstation.Server.Api.Models.Internal
 		/// The .dme file used for compilation
 		/// </summary>
 		[Required]
-		public string DmeName { get; set; }
+		public string? DmeName { get; set; }
 
 		/// <summary>
 		/// Textual output of DM
 		/// </summary>
 		[Required]
-		public string Output { get; set; }
+		public string? Output { get; set; }
 
 		/// <summary>
 		/// The Game folder the results were compiled into
@@ -37,6 +37,6 @@ namespace Tgstation.Server.Api.Models.Internal
 		/// The DMAPI <see cref="Version"/>.
 		/// </summary>
 		[NotMapped]
-		public virtual Version DMApiVersion { get; set; }
+		public virtual Version? DMApiVersion { get; set; }
 	}
 }

--- a/src/Tgstation.Server.Api/Models/Internal/Job.cs
+++ b/src/Tgstation.Server.Api/Models/Internal/Job.cs
@@ -13,7 +13,7 @@ namespace Tgstation.Server.Api.Models.Internal
 		/// English description of the <see cref="Job"/>
 		/// </summary>
 		[Required]
-		public string Description { get; set; }
+		public string? Description { get; set; }
 
 		/// <summary>
 		/// The <see cref="Models.ErrorCode"/> associated with the <see cref="Job"/> if any.
@@ -23,7 +23,7 @@ namespace Tgstation.Server.Api.Models.Internal
 		/// <summary>
 		/// Details of any exceptions caught during the <see cref="Job"/>
 		/// </summary>
-		public string ExceptionDetails { get; set; }
+		public string? ExceptionDetails { get; set; }
 
 		/// <summary>
 		/// When the <see cref="Job"/> was started

--- a/src/Tgstation.Server.Api/Models/Internal/RepositorySettings.cs
+++ b/src/Tgstation.Server.Api/Models/Internal/RepositorySettings.cs
@@ -12,7 +12,7 @@ namespace Tgstation.Server.Api.Models.Internal
 		/// </summary>
 		[Required]
 		[StringLength(Limits.MaximumStringLength)]
-		public string CommitterName { get; set; }
+		public string? CommitterName { get; set; }
 
 		/// <summary>
 		/// The e-mail of the committer
@@ -20,19 +20,19 @@ namespace Tgstation.Server.Api.Models.Internal
 		[Required]
 		[StringLength(Limits.MaximumStringLength)]
 		[EmailAddress]
-		public string CommitterEmail { get; set; }
+		public string? CommitterEmail { get; set; }
 
 		/// <summary>
 		/// The username to access the git repository with
 		/// </summary>
 		[StringLength(Limits.MaximumStringLength)]
-		public string AccessUser { get; set; }
+		public string? AccessUser { get; set; }
 
 		/// <summary>
 		/// The token/password to access the git repository with
 		/// </summary>
 		[StringLength(Limits.MaximumStringLength)]
-		public string AccessToken { get; set; }
+		public string? AccessToken { get; set; }
 
 		/// <summary>
 		/// If commits created from testmerges are pushed to the remote

--- a/src/Tgstation.Server.Api/Models/Internal/RevisionInformation.cs
+++ b/src/Tgstation.Server.Api/Models/Internal/RevisionInformation.cs
@@ -12,13 +12,13 @@ namespace Tgstation.Server.Api.Models.Internal
 		/// </summary>
 		[Required]
 		[StringLength(40)]
-		public string CommitSha { get; set; }
+		public string? CommitSha { get; set; }
 
 		/// <summary>
 		/// The sha of the most recent remote commit
 		/// </summary>
 		[Required]
 		[StringLength(40)]
-		public string OriginCommitSha { get; set; }
+		public string? OriginCommitSha { get; set; }
 	}
 }

--- a/src/Tgstation.Server.Api/Models/Internal/ServerInformation.cs
+++ b/src/Tgstation.Server.Api/Models/Internal/ServerInformation.cs
@@ -25,6 +25,6 @@ namespace Tgstation.Server.Api.Models.Internal
 		/// <summary>
 		/// Limits the locations instances may be created or attached from.
 		/// </summary>
-		public ICollection<string> ValidInstancePaths { get; set; }
+		public ICollection<string>? ValidInstancePaths { get; set; }
 	}
 }

--- a/src/Tgstation.Server.Api/Models/Internal/TestMergeBase.cs
+++ b/src/Tgstation.Server.Api/Models/Internal/TestMergeBase.cs
@@ -12,27 +12,27 @@ namespace Tgstation.Server.Api.Models.Internal
 		/// The title of the pull request
 		/// </summary>
 		[Required]
-		public string TitleAtMerge { get; set; }
+		public string? TitleAtMerge { get; set; }
 
 		/// <summary>
 		/// The body of the pull request
 		/// </summary>
 		[Required]
-		public string BodyAtMerge { get; set; }
+		public string? BodyAtMerge { get; set; }
 
 		/// <summary>
 		/// The URL of the pull request
 		/// </summary>
 		[Required]
 #pragma warning disable CA1056 // Uri properties should not be strings
-		public string Url { get; set; }
+		public string? Url { get; set; }
 #pragma warning restore CA1056 // Uri properties should not be strings
 
 		/// <summary>
 		/// The author of the pull request
 		/// </summary>
 		[Required]
-		public string Author { get; set; }
+		public string? Author { get; set; }
 
 		/// <summary>
 		/// Construct a <see cref="TestMergeBase"/>

--- a/src/Tgstation.Server.Api/Models/Internal/User.cs
+++ b/src/Tgstation.Server.Api/Models/Internal/User.cs
@@ -31,14 +31,14 @@ namespace Tgstation.Server.Api.Models.Internal
 		/// The SID/UID of the <see cref="User"/> on Windows/POSIX respectively
 		/// </summary>
 		// No need for StringLength as the server MUST validate it.
-		public string SystemIdentifier { get; set; }
+		public string? SystemIdentifier { get; set; }
 
 		/// <summary>
 		/// The name of the <see cref="User"/>
 		/// </summary>
 		[Required]
 		[StringLength(Limits.MaximumStringLength)]
-		public string Name { get; set; }
+		public string? Name { get; set; }
 
 		/// <summary>
 		/// The <see cref="Rights.AdministrationRights"/> for the <see cref="User"/>

--- a/src/Tgstation.Server.Api/Models/IrcConnectionStringBuilder.cs
+++ b/src/Tgstation.Server.Api/Models/IrcConnectionStringBuilder.cs
@@ -16,7 +16,7 @@ namespace Tgstation.Server.Api.Models
 		/// <summary>
 		/// The IP address or URL of the IRC server
 		/// </summary>
-		public string Address { get; set; }
+		public string? Address { get; set; }
 
 		/// <summary>
 		/// The port the server runs on
@@ -26,7 +26,7 @@ namespace Tgstation.Server.Api.Models
 		/// <summary>
 		/// The nickname for the bot to use
 		/// </summary>
-		public string Nickname { get; set; }
+		public string? Nickname { get; set; }
 
 		/// <summary>
 		/// If the connection should be made using SSL
@@ -41,7 +41,7 @@ namespace Tgstation.Server.Api.Models
 		/// <summary>
 		/// The optional password to use
 		/// </summary>
-		public string Password { get; set; }
+		public string? Password { get; set; }
 
 		/// <summary>
 		/// Construct an <see cref="IrcConnectionStringBuilder"/>

--- a/src/Tgstation.Server.Api/Models/Job.cs
+++ b/src/Tgstation.Server.Api/Models/Job.cs
@@ -8,12 +8,12 @@
 		/// <summary>
 		/// The <see cref="User"/> that started the job
 		/// </summary>
-		public User StartedBy { get; set; }
+		public User? StartedBy { get; set; }
 
 		/// <summary>
 		/// The <see cref="User"/> that cancelled the job
 		/// </summary>
-		public User CancelledBy { get; set; }
+		public User? CancelledBy { get; set; }
 
 		/// <summary>
 		/// Optional progress between 0 and 100 inclusive

--- a/src/Tgstation.Server.Api/Models/Repository.cs
+++ b/src/Tgstation.Server.Api/Models/Repository.cs
@@ -10,32 +10,32 @@ namespace Tgstation.Server.Api.Models
 		/// <summary>
 		/// The origin URL. If <see langword="null"/>, the <see cref="Repository"/> does not exist
 		/// </summary>
-		public string Origin { get; set; }
+		public string? Origin { get; set; }
 
 		/// <summary>
 		/// The commit HEAD should point to. Not populated in responses, use <see cref="RevisionInformation"/> instead for retrieval
 		/// </summary>
-		public string CheckoutSha { get; set; }
+		public string? CheckoutSha { get; set; }
 
 		/// <summary>
 		/// The current <see cref="Models.RevisionInformation"/> for the <see cref="Repository"/>
 		/// </summary>
-		public RevisionInformation RevisionInformation { get; set; }
+		public RevisionInformation? RevisionInformation { get; set; }
 
 		/// <summary>
 		/// If the repository was cloned from GitHub.com this will be set with the owner of the repository
 		/// </summary>
-		public string GitHubOwner { get; set; }
+		public string? GitHubOwner { get; set; }
 
 		/// <summary>
 		/// If the repository was cloned from GitHub.com this will be set with the name of the repository
 		/// </summary>
-		public string GitHubName { get; set; }
+		public string? GitHubName { get; set; }
 
 		/// <summary>
 		/// The <see cref="Job"/> started by the <see cref="Repository"/> if any
 		/// </summary>
-		public Job ActiveJob { get; set; }
+		public Job? ActiveJob { get; set; }
 
 		/// <summary>
 		/// Do the equivalent of a git pull. Will attempt to merge unless <see cref="Reference"/> is also specified in which case a hard reset will be performed after checking out
@@ -45,11 +45,11 @@ namespace Tgstation.Server.Api.Models
 		/// <summary>
 		/// The branch or tag HEAD points to
 		/// </summary>
-		public string Reference { get; set; }
+		public string? Reference { get; set; }
 
 		/// <summary>
 		/// <see cref="TestMergeParameters"/> for new <see cref="TestMerge"/>s. Note that merges that conflict will not be performed
 		/// </summary>
-		public List<TestMergeParameters> NewTestMerges { get; set; }
+		public ICollection<TestMergeParameters>? NewTestMerges { get; set; }
 	}
 }

--- a/src/Tgstation.Server.Api/Models/RevisionInformation.cs
+++ b/src/Tgstation.Server.Api/Models/RevisionInformation.cs
@@ -8,16 +8,16 @@ namespace Tgstation.Server.Api.Models
 		/// <summary>
 		/// The <see cref="TestMerge"/> that was created with this <see cref="RevisionInformation"/>
 		/// </summary>
-		public TestMerge PrimaryTestMerge { get; set; }
+		public TestMerge? PrimaryTestMerge { get; set; }
 
 		/// <summary>
 		/// The <see cref="TestMerge"/>s active in the <see cref="RevisionInformation"/>
 		/// </summary>
-		public ICollection<TestMerge> ActiveTestMerges { get; set; }
+		public ICollection<TestMerge>? ActiveTestMerges { get; set; }
 
 		/// <summary>
 		/// The <see cref="CompileJob"/>s made from the <see cref="RevisionInformation"/>
 		/// </summary>
-		public ICollection<CompileJob> CompileJobs { get; set; }
+		public ICollection<CompileJob>? CompileJobs { get; set; }
 	}
 }

--- a/src/Tgstation.Server.Api/Models/ServerInformation.cs
+++ b/src/Tgstation.Server.Api/Models/ServerInformation.cs
@@ -10,16 +10,16 @@ namespace Tgstation.Server.Api.Models
 		/// <summary>
 		/// The version of the host
 		/// </summary>
-		public Version Version { get; set; }
+		public Version? Version { get; set; }
 
 		/// <summary>
 		/// The <see cref="Api"/> version of the host
 		/// </summary>
-		public Version ApiVersion { get; set; }
+		public Version? ApiVersion { get; set; }
 
 		/// <summary>
 		/// The DMAPI version of the host.
 		/// </summary>
-		public Version DMApiVersion { get; set; }
+		public Version? DMApiVersion { get; set; }
 	}
 }

--- a/src/Tgstation.Server.Api/Models/TestMerge.cs
+++ b/src/Tgstation.Server.Api/Models/TestMerge.cs
@@ -6,6 +6,6 @@
 		/// <summary>
 		/// The <see cref="User"/> who created the <see cref="TestMerge"/>
 		/// </summary>
-		public User MergedBy { get; set; }
+		public User? MergedBy { get; set; }
 	}
 }

--- a/src/Tgstation.Server.Api/Models/TestMergeParameters.cs
+++ b/src/Tgstation.Server.Api/Models/TestMergeParameters.cs
@@ -17,12 +17,12 @@ namespace Tgstation.Server.Api.Models
 		/// </summary>
 		[Required]
 		[StringLength(40)]
-		public string PullRequestRevision { get; set; }
+		public string? PullRequestRevision { get; set; }
 
 		/// <summary>
 		/// Optional comment about the test
 		/// </summary>
 		[StringLength(Limits.MaximumStringLength)]
-		public string Comment { get; set; }
+		public string? Comment { get; set; }
 	}
 }

--- a/src/Tgstation.Server.Api/Models/Token.cs
+++ b/src/Tgstation.Server.Api/Models/Token.cs
@@ -10,7 +10,7 @@ namespace Tgstation.Server.Api.Models
 		/// <summary>
 		/// The value of the JWT
 		/// </summary>
-		public string Bearer { get; set; }
+		public string? Bearer { get; set; }
 
 		/// <summary>
 		/// When the <see cref="Token"/> expires

--- a/src/Tgstation.Server.Api/Models/User.cs
+++ b/src/Tgstation.Server.Api/Models/User.cs
@@ -6,16 +6,16 @@
 		/// <summary>
 		/// The name of the default admin user
 		/// </summary>
-		public const string AdminName = "Admin";
+		public static readonly string AdminName = "Admin";
 
 		/// <summary>
 		/// The default admin password
 		/// </summary>
-		public const string DefaultAdminPassword = "ISolemlySwearToDeleteTheDataDirectory";
+		public static readonly string DefaultAdminPassword = "ISolemlySwearToDeleteTheDataDirectory";
 
 		/// <summary>
 		/// The <see cref="User"/> who created this <see cref="User"/>
 		/// </summary>
-		public User CreatedBy { get; set; }
+		public User? CreatedBy { get; set; }
 	}
 }

--- a/src/Tgstation.Server.Api/Models/UserUpdate.cs
+++ b/src/Tgstation.Server.Api/Models/UserUpdate.cs
@@ -11,6 +11,6 @@ namespace Tgstation.Server.Api.Models
 		/// Cleartext password of the <see cref="User"/>
 		/// </summary>
 		[Required]
-		public string Password { get; set; }
+		public string? Password { get; set; }
 	}
 }

--- a/src/Tgstation.Server.Api/Tgstation.Server.Api.csproj
+++ b/src/Tgstation.Server.Api/Tgstation.Server.Api.csproj
@@ -2,15 +2,16 @@
   <Import Project="../../build/Version.props" />
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <DebugType>Full</DebugType>
+    <Version>$(TgsApiVersion)</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Cyberboss</Authors>
-    <Company>/tg/station</Company>
+    <Company>/tg/station 13</Company>
     <Description>API definitions for tgstation-server</Description>
+    <PackageProjectUrl>https://tgstation.github.io/tgstation-server</PackageProjectUrl>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIcon>tgs.png</PackageIcon>
-    <PackageProjectUrl>https://tgstation.github.io/tgstation-server</PackageProjectUrl>
     <RepositoryType>Git</RepositoryType>
     <RepositoryUrl>https://github.com/tgstation/tgstation-server</RepositoryUrl>
     <Copyright>2018</Copyright>
@@ -18,21 +19,16 @@
     <PackageReleaseNotes>See https://github.com/tgstation/tgstation-server/releases/tag/api-v$(TgsApiVersion)</PackageReleaseNotes>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>$(TgsApiVersion)</Version>
     <CodeAnalysisRuleSet>../../build/analyzers.ruleset</CodeAnalysisRuleSet>
     <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <DocumentationFile>bin\$(Configuration)\netstandard2.1\Tgstation.Server.Api.xml</DocumentationFile>
+    <NoWarn>CA1028</NoWarn>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
-    <DocumentationFile>bin\Release\netstandard2.1\Tgstation.Server.Api.xml</DocumentationFile>
-    <NoWarn>1701;1702;CA1028</NoWarn>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <NoWarn>1701;1702;CA1028</NoWarn>
-    <DocumentationFile>bin\Debug\netstandard2.1\Tgstation.Server.Api.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tgstation.Server.Client/ApiClient.cs
+++ b/src/Tgstation.Server.Client/ApiClient.cs
@@ -57,7 +57,7 @@ namespace Tgstation.Server.Client
 
 		static void HandleBadResponse(HttpResponseMessage response, string json)
 		{
-			ErrorMessage errorMessage = null;
+			ErrorMessage? errorMessage = null;
 			try
 			{
 				// check if json serializes to an error message
@@ -124,7 +124,7 @@ namespace Tgstation.Server.Client
 		/// <param name="instanceId">The optional <see cref="Instance.Id"/> for the request</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the response on success</returns>
-		async Task<TResult> RunRequest<TResult>(string route, object body, HttpMethod method, long? instanceId, CancellationToken cancellationToken)
+		async Task<TResult> RunRequest<TResult>(string route, object? body, HttpMethod method, long? instanceId, CancellationToken cancellationToken)
 		{
 			if (route == null)
 				throw new ArgumentNullException(nameof(route));
@@ -162,7 +162,7 @@ namespace Tgstation.Server.Client
 
 				try
 				{
-					return JsonConvert.DeserializeObject<TResult>(json, serializerSettings);
+					return JsonConvert.DeserializeObject<TResult>(json, serializerSettings) !;
 				}
 				catch (JsonException)
 				{

--- a/src/Tgstation.Server.Client/ApiClientFactory.cs
+++ b/src/Tgstation.Server.Client/ApiClientFactory.cs
@@ -7,6 +7,6 @@ namespace Tgstation.Server.Client
 	sealed class ApiClientFactory : IApiClientFactory
 	{
 		/// <inheritdoc />
-		public IApiClient CreateApiClient(Uri url, ApiHeaders apiHeaders) => new ApiClient(new HttpClient(), url, apiHeaders);
+		public IApiClient CreateApiClient(Uri url, ApiHeaders apiHeaders, ApiHeaders? tokenRefreshHeaders) => new ApiClient(new HttpClient(), url, apiHeaders, tokenRefreshHeaders);
 	}
 }

--- a/src/Tgstation.Server.Client/ApiConflictException.cs
+++ b/src/Tgstation.Server.Client/ApiConflictException.cs
@@ -14,7 +14,7 @@ namespace Tgstation.Server.Client
 		/// </summary>
 		/// <param name="errorMessage">The <see cref="ErrorMessage"/> for the <see cref="ApiException"/></param>
 		/// <param name="responseMessage">The <see cref="HttpResponseMessage"/> for the <see cref="ClientException"/></param>
-		public ApiConflictException(ErrorMessage errorMessage, HttpResponseMessage responseMessage) : base(errorMessage, responseMessage)
+		public ApiConflictException(ErrorMessage? errorMessage, HttpResponseMessage responseMessage) : base(errorMessage, responseMessage)
 		{ }
 
 		/// <summary>

--- a/src/Tgstation.Server.Client/ApiException.cs
+++ b/src/Tgstation.Server.Client/ApiException.cs
@@ -12,12 +12,12 @@ namespace Tgstation.Server.Client
 		/// <summary>
 		/// The <see cref="Version"/> of the server's API.
 		/// </summary>
-		public Version ServerApiVersion { get; }
+		public Version? ServerApiVersion { get; }
 
 		/// <summary>
 		/// Additional error data from the server.
 		/// </summary>
-		public string AdditionalServerData { get; }
+		public string? AdditionalServerData { get; }
 
 		/// <summary>
 		/// The API <see cref="ErrorCode"/> if applicable.
@@ -29,7 +29,7 @@ namespace Tgstation.Server.Client
 		/// </summary>
 		/// <param name="errorMessage">The <see cref="ErrorMessage"/> returned from the API.</param>
 		/// <param name="responseMessage">The <see cref="HttpResponseMessage"/>.</param>
-		protected ApiException(ErrorMessage errorMessage, HttpResponseMessage responseMessage) : base(
+		protected ApiException(ErrorMessage? errorMessage, HttpResponseMessage responseMessage) : base(
 			responseMessage,
 			errorMessage?.Message ?? $"HTTP {responseMessage.StatusCode}. Unknown API error, ErrorMessage payload not present!")
 		{

--- a/src/Tgstation.Server.Client/ClientException.cs
+++ b/src/Tgstation.Server.Client/ClientException.cs
@@ -12,7 +12,7 @@ namespace Tgstation.Server.Client
 		/// <summary>
 		/// The <see cref="HttpStatusCode"/> of the <see cref="ClientException"/>
 		/// </summary>
-		public HttpResponseMessage ResponseMessage { get; }
+		public HttpResponseMessage? ResponseMessage { get; }
 
 		/// <summary>
 		/// Initialize a new instance of the <see cref="ClientException"/> <see langword="class"/>.

--- a/src/Tgstation.Server.Client/Components/ConfigurationClient.cs
+++ b/src/Tgstation.Server.Client/Components/ConfigurationClient.cs
@@ -59,7 +59,10 @@ namespace Tgstation.Server.Client.Components
 		{
 			if (file == null)
 				throw new ArgumentNullException(nameof(file));
-			return apiClient.Read<ConfigurationFile>(Routes.ConfigurationFile + SanitizeGetPath(file.Path), instance.Id, cancellationToken);
+			return apiClient.Read<ConfigurationFile>(
+				Routes.ConfigurationFile + SanitizeGetPath(file.Path ?? throw new ArgumentException("file.Path should not be null!", nameof(file))),
+				instance.Id,
+				cancellationToken);
 		}
 
 		/// <inheritdoc />

--- a/src/Tgstation.Server.Client/Components/InstanceUserClient.cs
+++ b/src/Tgstation.Server.Client/Components/InstanceUserClient.cs
@@ -35,7 +35,12 @@ namespace Tgstation.Server.Client.Components
 		public Task<InstanceUser> Create(InstanceUser instanceUser, CancellationToken cancellationToken) => apiClient.Create<InstanceUser, InstanceUser>(Routes.InstanceUser, instanceUser ?? throw new ArgumentNullException(nameof(instanceUser)), instance.Id, cancellationToken);
 
 		/// <inheritdoc />
-		public Task Delete(InstanceUser instanceUser, CancellationToken cancellationToken) => apiClient.Delete(Routes.SetID(Routes.InstanceUser, instanceUser.UserId.Value), instance.Id, cancellationToken);
+		public Task Delete(InstanceUser instanceUser, CancellationToken cancellationToken) => apiClient.Delete(
+			Routes.SetID(
+				Routes.InstanceUser,
+				instanceUser.UserId ?? throw new ArgumentException("Missing instanceUser.UserId!", nameof(instanceUser))),
+			instance.Id,
+			cancellationToken);
 
 		/// <inheritdoc />
 		public Task<InstanceUser> Read(CancellationToken cancellationToken) => apiClient.Read<InstanceUser>(Routes.InstanceUser, instance.Id, cancellationToken);

--- a/src/Tgstation.Server.Client/ConflictException.cs
+++ b/src/Tgstation.Server.Client/ConflictException.cs
@@ -14,7 +14,7 @@ namespace Tgstation.Server.Client
 		/// </summary>
 		/// <param name="errorMessage">The <see cref="ErrorMessage"/> for the <see cref="ApiException"/>.</param>
 		/// <param name="responseMessage">The <see cref="HttpResponseMessage"/> for the <see cref="ClientException"/>.</param>
-		public ConflictException(ErrorMessage errorMessage, HttpResponseMessage responseMessage) : base(errorMessage, responseMessage)
+		public ConflictException(ErrorMessage? errorMessage, HttpResponseMessage responseMessage) : base(errorMessage, responseMessage)
 		{ }
 
 		/// <summary>

--- a/src/Tgstation.Server.Client/IApiClientFactory.cs
+++ b/src/Tgstation.Server.Client/IApiClientFactory.cs
@@ -13,7 +13,8 @@ namespace Tgstation.Server.Client
 		/// </summary>
 		/// <param name="url">The base <see cref="Uri"/></param>
 		/// <param name="apiHeaders">The <see cref="ApiHeaders"/> for the <see cref="IApiClient"/></param>
+		/// <param name="tokenRefreshHeaders">The <see cref="ApiHeaders"/> to use to generate a new <see cref="Api.Models.Token"/>.</param>
 		/// <returns>A new <see cref="IApiClient"/></returns>
-		IApiClient CreateApiClient(Uri url, ApiHeaders apiHeaders);
+		IApiClient CreateApiClient(Uri url, ApiHeaders apiHeaders, ApiHeaders? tokenRefreshHeaders);
 	}
 }

--- a/src/Tgstation.Server.Client/IServerClientFactory.cs
+++ b/src/Tgstation.Server.Client/IServerClientFactory.cs
@@ -19,6 +19,7 @@ namespace Tgstation.Server.Client
 		/// <param name="password">The password for the <see cref="IServerClient"/></param>
 		/// <param name="requestLoggers">Optional initial <see cref="IRequestLogger"/>s to add to the <see cref="IServerClient"/>.</param>
 		/// <param name="timeout">Optional <see cref="TimeSpan"/> representing timeout for the connection</param>
+		/// <param name="attemptLoginRefresh">Attempt to refresh the received <see cref="Token"/> when it expires or becomes invalid. <paramref name="username"/> and <paramref name="password"/> will be stored in memory if this is <see langword="true"/>.</param>
 		/// <param name="cancellationToken">Optional <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in a new <see cref="IServerClient"/></returns>
 		Task<IServerClient> CreateFromLogin(
@@ -27,6 +28,7 @@ namespace Tgstation.Server.Client
 			string password,
 			IEnumerable<IRequestLogger>? requestLoggers = null,
 			TimeSpan? timeout = null,
+			bool attemptLoginRefresh = true,
 			CancellationToken cancellationToken = default);
 
 		/// <summary>

--- a/src/Tgstation.Server.Client/IServerClientFactory.cs
+++ b/src/Tgstation.Server.Client/IServerClientFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Tgstation.Server.Api.Models;
@@ -16,18 +17,26 @@ namespace Tgstation.Server.Client
 		/// <param name="host">The URL to access TGS</param>
 		/// <param name="username">The username to for the <see cref="IServerClient"/></param>
 		/// <param name="password">The password for the <see cref="IServerClient"/></param>
-		/// <param name="timeout">The <see cref="TimeSpan"/> representing timeout for the connection</param>
-		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
+		/// <param name="requestLoggers">Optional initial <see cref="IRequestLogger"/>s to add to the <see cref="IServerClient"/>.</param>
+		/// <param name="timeout">Optional <see cref="TimeSpan"/> representing timeout for the connection</param>
+		/// <param name="cancellationToken">Optional <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in a new <see cref="IServerClient"/></returns>
-		Task<IServerClient> CreateServerClient(Uri host, string username, string password, TimeSpan timeout = default, CancellationToken cancellationToken = default);
+		Task<IServerClient> CreateFromLogin(
+			Uri host,
+			string username,
+			string password,
+			IEnumerable<IRequestLogger>? requestLoggers = null,
+			TimeSpan? timeout = null,
+			CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Create a <see cref="IServerClient"/>
 		/// </summary>
 		/// <param name="host">The URL to access TGS</param>
 		/// <param name="token">The <see cref="Token"/> to access the API with</param>
-		/// <param name="timeout">The <see cref="TimeSpan"/> representing timeout for the connection</param>
 		/// <returns>A new <see cref="IServerClient"/></returns>
-		IServerClient CreateServerClient(Uri host, Token token, TimeSpan timeout = default);
+		IServerClient CreateFromToken(
+			Uri host,
+			Token token);
 	}
 }

--- a/src/Tgstation.Server.Client/MethodNotSupportedException.cs
+++ b/src/Tgstation.Server.Client/MethodNotSupportedException.cs
@@ -14,7 +14,7 @@ namespace Tgstation.Server.Client
 		/// </summary>
 		/// <param name="errorMessage">The <see cref="ErrorMessage"/> for the <see cref="ApiException"/>.</param>
 		/// <param name="responseMessage">The <see cref="HttpResponseMessage"/> for the <see cref="ClientException"/>.</param>
-		public MethodNotSupportedException(ErrorMessage errorMessage, HttpResponseMessage responseMessage) : base(errorMessage, responseMessage)
+		public MethodNotSupportedException(ErrorMessage? errorMessage, HttpResponseMessage responseMessage) : base(errorMessage, responseMessage)
 		{ }
 
 		/// <summary>

--- a/src/Tgstation.Server.Client/RateLimitException.cs
+++ b/src/Tgstation.Server.Client/RateLimitException.cs
@@ -21,7 +21,7 @@ namespace Tgstation.Server.Client
 		/// </summary>
 		/// <param name="errorMessage">The <see cref="ErrorMessage"/> for the <see cref="ApiException"/>.</param>
 		/// <param name="responseMessage">The <see cref="HttpResponseMessage"/> for the <see cref="ClientException"/>.</param>
-		public RateLimitException(ErrorMessage errorMessage, HttpResponseMessage responseMessage) : base(errorMessage, responseMessage)
+		public RateLimitException(ErrorMessage? errorMessage, HttpResponseMessage responseMessage) : base(errorMessage, responseMessage)
 		{
 			if (!responseMessage.Headers.TryGetValues(HeaderNames.RetryAfter, out var values))
 				return;

--- a/src/Tgstation.Server.Client/ServerClient.cs
+++ b/src/Tgstation.Server.Client/ServerClient.cs
@@ -19,7 +19,7 @@ namespace Tgstation.Server.Client
 			set
 			{
 				token = value ?? throw new InvalidOperationException("Cannot set a null Token!");
-				apiClient.Headers = new ApiHeaders(apiClient.Headers.UserAgent, token.Bearer);
+				apiClient.Headers = new ApiHeaders(apiClient.Headers.UserAgent!, token.Bearer!);
 			}
 		}
 

--- a/src/Tgstation.Server.Client/ServerErrorException.cs
+++ b/src/Tgstation.Server.Client/ServerErrorException.cs
@@ -19,7 +19,7 @@ namespace Tgstation.Server.Client
 		/// </summary>
 		/// <param name="errorMessage">The <see cref="ErrorMessage"/> for the <see cref="ApiException"/></param>
 		/// <param name="responseMessage">The <see cref="HttpResponseMessage"/> for the <see cref="ClientException"/></param>
-		public ServerErrorException(ErrorMessage errorMessage, HttpResponseMessage responseMessage) : base(errorMessage, responseMessage)
+		public ServerErrorException(ErrorMessage? errorMessage, HttpResponseMessage responseMessage) : base(errorMessage, responseMessage)
 		{
 		}
 

--- a/src/Tgstation.Server.Client/Tgstation.Server.Client.csproj
+++ b/src/Tgstation.Server.Client/Tgstation.Server.Client.csproj
@@ -2,41 +2,34 @@
   <Import Project="../../build/Version.props" />
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <DebugType>Full</DebugType>
     <Version>$(TgsClientVersion)</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Cyberboss</Authors>
     <Company>/tg/station 13</Company>
-    <Product />
     <Description>Client library for tgstation-server</Description>
     <PackageProjectUrl>https://tgstation.github.io/tgstation-server</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/tgstation/tgstation-server</RepositoryUrl>
-    <RepositoryType>Git</RepositoryType>
-    <NeutralLanguage>en-CA</NeutralLanguage>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIcon>tgs.png</PackageIcon>
+    <RepositoryType>Git</RepositoryType>
+    <RepositoryUrl>https://github.com/tgstation/tgstation-server</RepositoryUrl>
+    <Copyright>2018</Copyright>
     <PackageTags>json web api tgstation-server tgstation ss13 byond client</PackageTags>
-    <PackageReleaseNotes>Updated to API version $(TgsApiVersion)</PackageReleaseNotes>
+    <PackageReleaseNotes>.Net Standard 2.1, allow login requests to be logged.</PackageReleaseNotes>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Copyright>2018</Copyright>
     <CodeAnalysisRuleSet>../../build/analyzers.ruleset</CodeAnalysisRuleSet>
     <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <DocumentationFile>bin\$(Configuration)\netstandard2.1\Tgstation.Server.Client.xml</DocumentationFile>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
-    <DocumentationFile>bin\Release\netstandard2.1\Tgstation.Server.Client.xml</DocumentationFile>
-    <NoWarn>1701;1702</NoWarn>
   </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <NoWarn>1701;1702</NoWarn>
-    <DocumentationFile>bin\Debug\netstandard2.1\Tgstation.Server.Client.xml</DocumentationFile>
-  </PropertyGroup>
-
+  
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/src/Tgstation.Server.Client/UnauthorizedException.cs
+++ b/src/Tgstation.Server.Client/UnauthorizedException.cs
@@ -14,7 +14,7 @@ namespace Tgstation.Server.Client
 		/// </summary>
 		/// <param name="errorMessage">The <see cref="ErrorMessage"/> returned by the API.</param>
 		/// <param name="responseMessage">The <see cref="HttpResponseMessage"/>.</param>
-		public UnauthorizedException(ErrorMessage errorMessage, HttpResponseMessage responseMessage) : base(errorMessage, responseMessage)
+		public UnauthorizedException(ErrorMessage? errorMessage, HttpResponseMessage responseMessage) : base(errorMessage, responseMessage)
 		{ }
 
 		/// <summary>

--- a/src/Tgstation.Server.Client/VersionMismatchException.cs
+++ b/src/Tgstation.Server.Client/VersionMismatchException.cs
@@ -14,7 +14,7 @@ namespace Tgstation.Server.Client
 		/// </summary>
 		/// <param name="errorMessage">The <see cref="ErrorMessage"/> for the <see cref="ApiException"/>.</param>
 		/// <param name="responseMessage">The <see cref="HttpResponseMessage"/> for the <see cref="ClientException"/>.</param>
-		public VersionMismatchException(ErrorMessage errorMessage, HttpResponseMessage responseMessage) : base(errorMessage, responseMessage)
+		public VersionMismatchException(ErrorMessage? errorMessage, HttpResponseMessage responseMessage) : base(errorMessage, responseMessage)
 		{
 		}
 

--- a/src/Tgstation.Server.Host/Components/Repository/Repository.cs
+++ b/src/Tgstation.Server.Host/Components/Repository/Repository.cs
@@ -265,12 +265,12 @@ namespace Tgstation.Server.Host.Components.Repository
 			if (progressReporter == null)
 				throw new ArgumentNullException(nameof(progressReporter));
 
-			logger.LogDebug("Begin AddTestMerge: #{0} at {1} ({4}) by <{2} ({3})>",
+			logger.LogDebug("Begin AddTestMerge: #{0} at {1} ({2}) by <{3} ({4})>",
 				testMergeParameters.Number,
 				testMergeParameters.PullRequestRevision?.Substring(0, 7),
+				testMergeParameters.Comment,
 				committerName,
-				committerEmail,
-				testMergeParameters.Comment);
+				committerEmail);
 
 			if (!IsGitHubRepository)
 				throw new InvalidOperationException("Test merging is only available on GitHub hosted origin repositories!");

--- a/src/Tgstation.Server.Host/Setup/SetupWizard.cs
+++ b/src/Tgstation.Server.Host/Setup/SetupWizard.cs
@@ -556,10 +556,7 @@ namespace Tgstation.Server.Host.Setup
 			if (String.IsNullOrWhiteSpace(newGeneralConfiguration.GitHubAccessToken))
 				newGeneralConfiguration.GitHubAccessToken = null;
 
-			newGeneralConfiguration.UseExperimentalWatchdog = await PromptYesNo("Use the experimental watchdog (NOT RECOMMENDED)? (y/n): ", cancellationToken).ConfigureAwait(false);
-
-			newGeneralConfiguration.UseBasicWatchdogOnWindows = true;
-
+			// newGeneralConfiguration.UseExperimentalWatchdog = await PromptYesNo("Use the experimental watchdog (NOT RECOMMENDED)? (y/n): ", cancellationToken).ConfigureAwait(false);
 			return newGeneralConfiguration;
 		}
 

--- a/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
+++ b/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
@@ -9,18 +9,13 @@
     <CodeAnalysisRuleSet>../../build/analyzers.ruleset</CodeAnalysisRuleSet>
     <IsPackable>false</IsPackable>
     <IncludeOpenAPIAnalyzers>true</IncludeOpenAPIAnalyzers>
+    <DocumentationFile>bin\$(Configuration)\netcoreapp3.1\Tgstation.Server.Host.xml</DocumentationFile>
+    <NoWarn>API1000</NoWarn>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
-    <DocumentationFile>bin\Release\netcoreapp2.1\Tgstation.Server.Host.xml</DocumentationFile>
-    <NoWarn>API1000</NoWarn>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <NoWarn>API1000</NoWarn>
-    <DocumentationFile>bin\Debug\netcoreapp2.1\Tgstation.Server.Host.xml</DocumentationFile>
   </PropertyGroup>
   
   <PropertyGroup>

--- a/tests/Tgstation.Server.Client.Tests/TestApiClient.cs
+++ b/tests/Tgstation.Server.Client.Tests/TestApiClient.cs
@@ -39,7 +39,7 @@ namespace Tgstation.Server.Client.Tests
 			var httpClient = new Mock<IHttpClient>();
 			httpClient.Setup(x => x.SendAsync(It.IsNotNull<HttpRequestMessage>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(response));
 
-			var client = new ApiClient(httpClient.Object, new Uri("http://fake.com"), new ApiHeaders(new ProductHeaderValue("fake"), "fake"));
+			var client = new ApiClient(httpClient.Object, new Uri("http://fake.com"), new ApiHeaders(new ProductHeaderValue("fake"), "fake"), null);
 
 			var result = await client.Read<Byond>(Routes.Byond, default).ConfigureAwait(false);
 			Assert.AreEqual(sample.Version, result.Version);
@@ -64,7 +64,7 @@ namespace Tgstation.Server.Client.Tests
 			var httpClient = new Mock<IHttpClient>();
 			httpClient.Setup(x => x.SendAsync(It.IsNotNull<HttpRequestMessage>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(response));
 
-			var client = new ApiClient(httpClient.Object, new Uri("http://fake.com"), new ApiHeaders(new ProductHeaderValue("fake"), "fake"));
+			var client = new ApiClient(httpClient.Object, new Uri("http://fake.com"), new ApiHeaders(new ProductHeaderValue("fake"), "fake"), null);
 
 			await Assert.ThrowsExceptionAsync<UnrecognizedResponseException>(() => client.Read<Byond>(Routes.Byond, default)).ConfigureAwait(false);
 		}

--- a/tests/Tgstation.Server.Host.Tests/Setup/TestSetupWizard.cs
+++ b/tests/Tgstation.Server.Host.Tests/Setup/TestSetupWizard.cs
@@ -86,7 +86,7 @@ namespace Tgstation.Server.Host.Setup.Tests
 			var mockFailCommand = new Mock<DbCommand>();
 			mockFailCommand.Setup(x => x.ExecuteNonQueryAsync(It.IsAny<CancellationToken>())).Throws(new Exception()).Verifiable();
 
-			void SetDbCommandCreator(Mock<DbConnection> mock, Func<DbCommand> creator) => mock.Protected().Setup<DbCommand>("CreateDbCommand").Returns(creator).Verifiable();
+			static void SetDbCommandCreator(Mock<DbConnection> mock, Func<DbCommand> creator) => mock.Protected().Setup<DbCommand>("CreateDbCommand").Returns(creator).Verifiable();
 
 			var mockGoodDbConnection = new Mock<DbConnection>();
 			mockGoodDbConnection.Setup(x => x.OpenAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask).Verifiable();
@@ -144,7 +144,6 @@ namespace Tgstation.Server.Host.Setup.Tests
 				"-27",
 				"5000",
 				"fake token",
-				"y",
 				//logging config
 				"no",
 				//cp config
@@ -167,7 +166,6 @@ namespace Tgstation.Server.Host.Setup.Tests
 				String.Empty,
 				String.Empty,
 				"n",
-				"y",
 				//logging config
 				"y",
 				"not actually verified because lol mocks /../!@#$%^&*()/..///.",
@@ -190,7 +188,6 @@ namespace Tgstation.Server.Host.Setup.Tests
 				String.Empty,
 				String.Empty,
 				String.Empty,
-				"y",
 				"y",
 				"will faile",
 				String.Empty,

--- a/tests/Tgstation.Server.Tests/IntegrationTest.cs
+++ b/tests/Tgstation.Server.Tests/IntegrationTest.cs
@@ -43,7 +43,7 @@ namespace Tgstation.Server.Tests
 				{
 					try
 					{
-						adminClient = await clientFactory.CreateServerClient(server.Url, User.AdminName, User.DefaultAdminPassword).ConfigureAwait(false);
+						adminClient = await clientFactory.CreateFromLogin(server.Url, User.AdminName, User.DefaultAdminPassword).ConfigureAwait(false);
 						break;
 					}
 					catch (HttpRequestException)
@@ -144,7 +144,7 @@ namespace Tgstation.Server.Tests
 					{
 						try
 						{
-							return await clientFactory.CreateServerClient(server.Url, User.AdminName, User.DefaultAdminPassword).ConfigureAwait(false);
+							return await clientFactory.CreateFromLogin(server.Url, User.AdminName, User.DefaultAdminPassword).ConfigureAwait(false);
 						}
 						catch (HttpRequestException)
 						{
@@ -193,7 +193,7 @@ namespace Tgstation.Server.Tests
 						Bearer = adminClient.Token.Bearer + '0'
 					};
 
-					var badClient = clientFactory.CreateServerClient(server.Url, newToken);
+					var badClient = clientFactory.CreateFromToken(server.Url, newToken);
 					await Assert.ThrowsExceptionAsync<UnauthorizedException>(() => badClient.Version(cancellationToken)).ConfigureAwait(false);
 
 					var adminTest = new AdministrationTest(adminClient.Administration).Run(cancellationToken);

--- a/tests/Tgstation.Server.Tests/IntegrationTest.cs
+++ b/tests/Tgstation.Server.Tests/IntegrationTest.cs
@@ -144,7 +144,7 @@ namespace Tgstation.Server.Tests
 					{
 						try
 						{
-							return await clientFactory.CreateFromLogin(server.Url, User.AdminName, User.DefaultAdminPassword).ConfigureAwait(false);
+							return await clientFactory.CreateFromLogin(server.Url, User.AdminName, User.DefaultAdminPassword, attemptLoginRefresh: false).ConfigureAwait(false);
 						}
 						catch (HttpRequestException)
 						{


### PR DESCRIPTION
:cl:
Fixed an issue where the database would not save more than one test merge added if they were added in bulk.
Fixed the setup wizard incorrectly disabling the Windows watchdog. If you have a Windows installation, please set `UseBasicWatchdogOnWindows` to `false` in your configuration.
The experimental watchdog has been disabled until it is functional.
/:cl:

:cl: HTTP API
No-op patch to facilitate implementation changes.
/:cl:

:cl: Nuget API/Client
Updated to .NET Standard 2.1. with nullable reference support.
Added automatic login refresh functionality to `IServerClient`
/:cl:

Closes #1015 