### PR TITLE
Customize Kestrel configuration

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -4,7 +4,7 @@
     <!-- Integration tests will ensure they match across the board -->
     <TgsCoreVersion>4.2.7</TgsCoreVersion>
     <TgsApiVersion>6.4.1</TgsApiVersion>
-    <TgsClientVersion>7.0.1</TgsClientVersion>
+    <TgsClientVersion>7.0.2</TgsClientVersion>
     <TgsDmapiVersion>5.2.1</TgsDmapiVersion>
     <TgsControlPanelVersion>0.4.0</TgsControlPanelVersion>
     <TgsHostWatchdogVersion>1.1.0</TgsHostWatchdogVersion>

--- a/build/Version.props
+++ b/build/Version.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- This is the authorative version list -->
     <!-- Integration tests will ensure they match across the board -->
-    <TgsCoreVersion>4.2.7</TgsCoreVersion>
+    <TgsCoreVersion>4.3.0</TgsCoreVersion>
     <TgsApiVersion>6.4.1</TgsApiVersion>
     <TgsClientVersion>7.0.2</TgsClientVersion>
     <TgsDmapiVersion>5.2.1</TgsDmapiVersion>

--- a/src/Tgstation.Server.Host/Configuration/GeneralConfiguration.cs
+++ b/src/Tgstation.Server.Host/Configuration/GeneralConfiguration.cs
@@ -15,6 +15,11 @@ namespace Tgstation.Server.Host.Configuration
 		public const string Section = "General";
 
 		/// <summary>
+		/// The default value of <see cref="ApiPort"/>.
+		/// </summary>
+		public const ushort DefaultApiPort = 5000;
+
+		/// <summary>
 		/// The default value for <see cref="ServerInformation.MinimumPasswordLength"/>.
 		/// </summary>
 		const uint DefaultMinimumPasswordLength = 15;
@@ -38,6 +43,11 @@ namespace Tgstation.Server.Host.Configuration
 		/// The default value for <see cref="RestartTimeout"/>
 		/// </summary>
 		const int DefaultRestartTimeout = 10000;
+
+		/// <summary>
+		/// The port the TGS API listens on.
+		/// </summary>
+		public ushort ApiPort { get; set; }
 
 		/// <summary>
 		/// A GitHub personal access token to use for bypassing rate limits on requests. Requires no scopes

--- a/src/Tgstation.Server.Host/ServerFactory.cs
+++ b/src/Tgstation.Server.Host/ServerFactory.cs
@@ -1,10 +1,12 @@
 ﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Tgstation.Server.Host.Core;
 using Tgstation.Server.Host.Extensions;
 using Tgstation.Server.Host.IO;
 using Tgstation.Server.Host.Setup;
@@ -58,8 +60,17 @@ namespace Tgstation.Server.Host
 			}
 
 			var hostBuilder = CreateDefaultBuilder()
-				.ConfigureWebHostDefaults(webHostBuilder =>
+				.ConfigureWebHost(webHostBuilder =>
 					webHostBuilder
+						.UseKestrel(kestrelOptions =>
+						{
+							var serverPortProvider = kestrelOptions.ApplicationServices.GetRequiredService<IServerPortProvider>();
+							kestrelOptions.ListenAnyIP(
+								serverPortProvider.HttpApiPort,
+								listenOptions => listenOptions.Protocols = HttpProtocols.Http1AndHttp2);
+						})
+						.UseIIS()
+						.UseIISIntegration()
 						.UseApplication(postSetupServices)
 						.SuppressStatusMessages(true)
 						.UseShutdownTimeout(TimeSpan.FromMinutes(1)));

--- a/src/Tgstation.Server.Host/Setup/SetupWizard.cs
+++ b/src/Tgstation.Server.Host/Setup/SetupWizard.cs
@@ -141,7 +141,11 @@ namespace Tgstation.Server.Host.Setup
 
 			do
 			{
-				await console.WriteAsync("API Port (leave blank for default): ", false, cancellationToken).ConfigureAwait(false);
+				await console.WriteAsync(
+					$"API Port (leave blank for default of {GeneralConfiguration.DefaultApiPort}): ",
+					false,
+					cancellationToken)
+					.ConfigureAwait(false);
 				var portString = await console.ReadLineAsync(false, cancellationToken).ConfigureAwait(false);
 				if (String.IsNullOrWhiteSpace(portString))
 					return null;
@@ -732,6 +736,7 @@ namespace Tgstation.Server.Host.Setup
 		{
 			await console.WriteAsync(String.Format(CultureInfo.InvariantCulture, "Configuration complete! Saving to {0}", userConfigFileName), true, cancellationToken).ConfigureAwait(false);
 
+			newGeneralConfiguration.ApiPort = hostingPort ?? GeneralConfiguration.DefaultApiPort;
 			var map = new Dictionary<string, object>()
 			{
 				{ DatabaseConfiguration.Section, databaseConfiguration },
@@ -739,18 +744,6 @@ namespace Tgstation.Server.Host.Setup
 				{ FileLoggingConfiguration.Section, fileLoggingConfiguration },
 				{ ControlPanelConfiguration.Section, controlPanelConfiguration }
 			};
-
-			if (hostingPort.HasValue)
-				map.Add("Kestrel", new
-				{
-					EndPoints = new
-					{
-						Http = new
-						{
-							Url = String.Format(CultureInfo.InvariantCulture, "http://0.0.0.0:{0}", hostingPort)
-						}
-					}
-				});
 
 			var json = JsonConvert.SerializeObject(map, Formatting.Indented);
 			var configBytes = Encoding.UTF8.GetBytes(json);

--- a/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
+++ b/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
@@ -83,7 +83,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="5.4.1" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
     <PackageReference Include="System.DirectoryServices.AccountManagement" Version="4.7.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.6.0" />
     <PackageReference Include="System.Management" Version="4.7.0" />
     <PackageReference Include="Wangkanai.Detection.Browser" Version="2.0.0" />
     <PackageReference Include="Z.EntityFramework.Plus.EFCore" Version="3.0.50" />

--- a/src/Tgstation.Server.Host/appsettings.json
+++ b/src/Tgstation.Server.Host/appsettings.json
@@ -1,5 +1,6 @@
 ﻿{
   "General": {
+    "ApiPort": 5000,
     "MinimumPasswordLength": 15,
     "GitHubAccessToken": null,
     "SetupWizardMode": "AutoDetect",
@@ -16,13 +17,6 @@
     "Disable": false,
     "LogLevel": "Debug",
     "MicrosoftLogLevel": "Warning"
-  },
-  "Kestrel": {
-    "EndPoints": {
-      "Http": {
-        "Url": "http://0.0.0.0:5000"
-      }
-    }
   },
   "Logging": {
     "IncludeScopes": false,

--- a/tests/Tgstation.Server.Tests/TestingServer.cs
+++ b/tests/Tgstation.Server.Tests/TestingServer.cs
@@ -72,7 +72,7 @@ namespace Tgstation.Server.Tests
 			var args = new List<string>()
 			{
 				String.Format(CultureInfo.InvariantCulture, "Database:DropDatabase={0}", true),
-				String.Format(CultureInfo.InvariantCulture, "Kestrel:EndPoints:Http:Url={0}", UrlString),
+				String.Format(CultureInfo.InvariantCulture, "General:ApiPort={0}", 5010),
 				String.Format(CultureInfo.InvariantCulture, "Database:DatabaseType={0}", DatabaseType),
 				String.Format(CultureInfo.InvariantCulture, "Database:ConnectionString={0}", connectionString),
 				String.Format(CultureInfo.InvariantCulture, "General:SetupWizardMode={0}", SetupWizardMode.Never),


### PR DESCRIPTION
Closes #1011 

:cl:
HTTP/2 has been enabled in addition to HTTP/1 for the web server.
The API port has a new configuration location. **Please migrate from the legacy `Kestrel` configuration section to the new `General:ApiPort` option**.
/:cl: