### PR TITLE
Day zero fixes

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -3,8 +3,8 @@
     <!-- This is the authorative version list -->
     <!-- Integration tests will ensure they match across the board -->
     <TgsCoreVersion>4.3.0</TgsCoreVersion>
-    <TgsApiVersion>6.5.0</TgsApiVersion>
-    <TgsClientVersion>7.1.0</TgsClientVersion>
+    <TgsApiVersion>6.5.1</TgsApiVersion>
+    <TgsClientVersion>7.1.1</TgsClientVersion>
     <TgsDmapiVersion>5.2.2</TgsDmapiVersion>
     <TgsControlPanelVersion>0.4.0</TgsControlPanelVersion>
     <TgsHostWatchdogVersion>1.1.0</TgsHostWatchdogVersion>

--- a/build/Version.props
+++ b/build/Version.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- This is the authorative version list -->
     <!-- Integration tests will ensure they match across the board -->
-    <TgsCoreVersion>4.3.0</TgsCoreVersion>
+    <TgsCoreVersion>4.3.1</TgsCoreVersion>
     <TgsApiVersion>6.5.1</TgsApiVersion>
     <TgsClientVersion>7.1.1</TgsClientVersion>
     <TgsDmapiVersion>5.2.2</TgsDmapiVersion>

--- a/src/Tgstation.Server.Api/Models/Internal/DreamDaemonLaunchParameters.cs
+++ b/src/Tgstation.Server.Api/Models/Internal/DreamDaemonLaunchParameters.cs
@@ -52,11 +52,10 @@ namespace Tgstation.Server.Api.Models.Internal
 		/// </summary>
 		/// <param name="otherParameters">The <see cref="DreamDaemonLaunchParameters"/> to compare against</param>
 		/// <returns><see langword="true"/> if they match, <see langword="false"/> otherwise</returns>
-		public bool Match(DreamDaemonLaunchParameters otherParameters) =>
+		public bool CanApplyWithoutReboot(DreamDaemonLaunchParameters otherParameters) =>
 			AllowWebClient == (otherParameters?.AllowWebClient ?? throw new ArgumentNullException(nameof(otherParameters)))
 				&& SecurityLevel == otherParameters.SecurityLevel
 				&& PrimaryPort == otherParameters.PrimaryPort
-				&& SecondaryPort == otherParameters.SecondaryPort
-				&& HeartbeatSeconds == otherParameters.HeartbeatSeconds; // We intentionally don't check StartupTimeout as it doesn't matter
+				&& SecondaryPort == otherParameters.SecondaryPort; // We intentionally don't check StartupTimeout or heartbeat seconds as it doesn't matter in terms of the watchdog
 	}
 }

--- a/src/Tgstation.Server.Api/Models/Internal/DreamDaemonLaunchParameters.cs
+++ b/src/Tgstation.Server.Api/Models/Internal/DreamDaemonLaunchParameters.cs
@@ -48,7 +48,7 @@ namespace Tgstation.Server.Api.Models.Internal
 		public uint? HeartbeatSeconds { get; set; }
 
 		/// <summary>
-		/// Check if we match a given set of <paramref name="otherParameters"/>
+		/// Check if we match a given set of <paramref name="otherParameters"/>. <see cref="StartupTimeout"/> is excluded.
 		/// </summary>
 		/// <param name="otherParameters">The <see cref="DreamDaemonLaunchParameters"/> to compare against</param>
 		/// <returns><see langword="true"/> if they match, <see langword="false"/> otherwise</returns>
@@ -57,7 +57,6 @@ namespace Tgstation.Server.Api.Models.Internal
 				&& SecurityLevel == otherParameters.SecurityLevel
 				&& PrimaryPort == otherParameters.PrimaryPort
 				&& SecondaryPort == otherParameters.SecondaryPort
-				&& StartupTimeout == otherParameters.StartupTimeout
-				&& HeartbeatSeconds == otherParameters.HeartbeatSeconds;
+				&& HeartbeatSeconds == otherParameters.HeartbeatSeconds; // We intentionally don't check StartupTimeout as it doesn't matter
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Deployment/DmbFactory.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/DmbFactory.cs
@@ -141,8 +141,11 @@ namespace Tgstation.Server.Host.Components.Deployment
 			{
 				nextDmbProvider?.Dispose();
 				nextDmbProvider = newProvider;
-				newerDmbTcs.SetResult(nextDmbProvider);
+
+				// Oh god dammit
+				var temp = newerDmbTcs;
 				newerDmbTcs = new TaskCompletionSource<object>();
+				temp.SetResult(nextDmbProvider);
 			}
 		}
 

--- a/src/Tgstation.Server.Host/Components/Instance.cs
+++ b/src/Tgstation.Server.Host/Components/Instance.cs
@@ -150,6 +150,7 @@ namespace Tgstation.Server.Host.Components
 		#pragma warning disable CA1502 // TODO: Decomplexify
 		async Task TimerLoop(uint minutes, CancellationToken cancellationToken)
 		{
+			logger.LogTrace("Entering auto-update loop");
 			while (true)
 				try
 				{

--- a/src/Tgstation.Server.Host/Components/Instance.cs
+++ b/src/Tgstation.Server.Host/Components/Instance.cs
@@ -301,11 +301,12 @@ namespace Tgstation.Server.Host.Components
 										var currentHead = repo.Head;
 
 										currentRevInfo = await databaseContext.RevisionInformations
-										.AsQueryable()
-										.Where(x => x.CommitSha == currentHead && x.Instance.Id == metadata.Id)
-										.FirstOrDefaultAsync(jobCancellationToken).ConfigureAwait(false);
+											.AsQueryable()
+											.Where(x => x.CommitSha == currentHead && x.Instance.Id == metadata.Id)
+											.FirstOrDefaultAsync(jobCancellationToken)
+											.ConfigureAwait(false);
 
-										if (currentHead != startSha && currentRevInfo != default)
+										if (currentHead != startSha && currentRevInfo == default)
 											await UpdateRevInfo(currentHead, true).ConfigureAwait(false);
 
 										shouldSyncTracked = true;

--- a/src/Tgstation.Server.Host/Components/Instance.cs
+++ b/src/Tgstation.Server.Host/Components/Instance.cs
@@ -234,7 +234,7 @@ namespace Tgstation.Server.Host.Components
 											.AsQueryable()
 											.Where(x => x.CommitSha == startSha && x.Instance.Id == metadata.Id)
 											.Include(x => x.ActiveTestMerges).ThenInclude(x => x.TestMerge)
-											.FirstOrDefaultAsync(cancellationToken);
+											.FirstOrDefaultAsync(jobCancellationToken);
 
 									async Task UpdateRevInfo(string currentHead, bool onOrigin)
 									{
@@ -326,7 +326,7 @@ namespace Tgstation.Server.Host.Components
 									if (hasDbChanges)
 										try
 										{
-											await databaseContext.Save(cancellationToken).ConfigureAwait(false);
+											await databaseContext.Save(jobCancellationToken).ConfigureAwait(false);
 										}
 										catch
 										{
@@ -369,7 +369,7 @@ namespace Tgstation.Server.Host.Components
 							DreamMaker.DeploymentProcess,
 							cancellationToken).ConfigureAwait(false);
 
-						await jobManager.WaitForJobCompletion(compileProcessJob, user, cancellationToken, default).ConfigureAwait(false);
+						await jobManager.WaitForJobCompletion(compileProcessJob, user, default, cancellationToken).ConfigureAwait(false);
 					}
 					catch (OperationCanceledException)
 					{

--- a/src/Tgstation.Server.Host/Components/Session/SessionController.cs
+++ b/src/Tgstation.Server.Host/Components/Session/SessionController.cs
@@ -281,6 +281,8 @@ namespace Tgstation.Server.Host.Components.Session
 			{
 				if (disposed)
 					return;
+				disposed = true;
+				logger.LogTrace("Disposing...");
 				if (disposing)
 				{
 					if (!released)
@@ -294,7 +296,6 @@ namespace Tgstation.Server.Host.Components.Session
 					Dmb?.Dispose(); // will be null when released
 					chatTrackingContext.Dispose();
 					reattachTopicCts.Dispose();
-					disposed = true;
 				}
 				else
 				{

--- a/src/Tgstation.Server.Host/Components/Session/SessionController.cs
+++ b/src/Tgstation.Server.Host/Components/Session/SessionController.cs
@@ -293,7 +293,7 @@ namespace Tgstation.Server.Host.Components.Session
 
 					process.Dispose();
 					bridgeRegistration.Dispose();
-					Dmb?.Dispose(); // will be null when released
+					reattachInformation.Dmb?.Dispose(); // will be null when released
 					chatTrackingContext.Dispose();
 					reattachTopicCts.Dispose();
 				}

--- a/src/Tgstation.Server.Host/Components/Session/SessionController.cs
+++ b/src/Tgstation.Server.Host/Components/Session/SessionController.cs
@@ -241,8 +241,9 @@ namespace Tgstation.Server.Host.Components.Session
 			_ = process.Lifetime.ContinueWith(
 				x =>
 				{
-					if (!disposed)
-						reattachTopicCts.Cancel();
+					lock (synchronizationLock)
+						if (!disposed)
+							reattachTopicCts.Cancel();
 					chatTrackingContext.Active = false;
 				},
 				TaskScheduler.Current);

--- a/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
@@ -747,7 +747,10 @@ namespace Tgstation.Server.Host.Components.Watchdog
 					return;
 				ActiveLaunchParameters = launchParameters;
 				if (Running)
+				{
 					ActiveParametersUpdated.TrySetResult(null); // queue an update
+					ActiveParametersUpdated = new TaskCompletionSource<object>();
+				}
 			}
 		}
 

--- a/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
@@ -621,9 +621,9 @@ namespace Tgstation.Server.Host.Components.Watchdog
 
 							// wait for something to happen
 							await toWaitOn.ConfigureAwait(false);
-							cancellationToken.ThrowIfCancellationRequested();
 						}
 
+						cancellationToken.ThrowIfCancellationRequested();
 						Logger.LogTrace("Monitor activated");
 
 						using (await SemaphoreSlimContext.Lock(Semaphore, cancellationToken).ConfigureAwait(false))
@@ -711,17 +711,17 @@ namespace Tgstation.Server.Host.Components.Watchdog
 
 						await chatTask.ConfigureAwait(false);
 					}
-				}
-				catch (OperationCanceledException)
-				{
-					Logger.LogDebug("Monitor cancelled");
+			}
+			catch (OperationCanceledException)
+			{
+				Logger.LogDebug("Monitor cancelled");
 
-					if (releaseServers)
-					{
-						Logger.LogTrace("Detaching servers...");
-						releasedReattachInformation = CreateReattachInformation();
-					}
+				if (releaseServers)
+				{
+					Logger.LogTrace("Detaching servers...");
+					releasedReattachInformation = CreateReattachInformation();
 				}
+			}
 
 			DisposeAndNullControllers();
 

--- a/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
@@ -904,14 +904,9 @@ namespace Tgstation.Server.Host.Components.Watchdog
 		/// <inheritdoc />
 		public async Task StopAsync(CancellationToken cancellationToken)
 		{
-			if (releaseServers)
-			{
-				await StopMonitor().ConfigureAwait(false);
-				if (releasedReattachInformation != null)
-					await reattachInfoHandler.Save(releasedReattachInformation, cancellationToken).ConfigureAwait(false);
-			}
-
 			await TerminateNoLock(false, !releaseServers, cancellationToken).ConfigureAwait(false);
+			if (releasedReattachInformation != null)
+				await reattachInfoHandler.Save(releasedReattachInformation, cancellationToken).ConfigureAwait(false);
 		}
 
 		/// <inheritdoc />

--- a/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
@@ -743,14 +743,13 @@ namespace Tgstation.Server.Host.Components.Watchdog
 		{
 			using (await SemaphoreSlimContext.Lock(Semaphore, cancellationToken).ConfigureAwait(false))
 			{
-				if (launchParameters.Match(ActiveLaunchParameters))
-					return;
+				bool match = launchParameters.CanApplyWithoutReboot(ActiveLaunchParameters);
 				ActiveLaunchParameters = launchParameters;
-				if (Running)
-				{
-					ActiveParametersUpdated.TrySetResult(null); // queue an update
-					ActiveParametersUpdated = new TaskCompletionSource<object>();
-				}
+				if (match || !Running)
+					return;
+
+				ActiveParametersUpdated.TrySetResult(null); // queue an update
+				ActiveParametersUpdated = new TaskCompletionSource<object>();
 			}
 		}
 

--- a/src/Tgstation.Server.Host/Components/Watchdog/WindowsWatchdog.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/WindowsWatchdog.cs
@@ -117,8 +117,6 @@ namespace Tgstation.Server.Host.Components.Watchdog
 		/// <inheritdoc />
 		protected override MonitorAction HandleNormalReboot()
 		{
-			if (activeSwappable == null)
-				throw new InvalidOperationException("Expected activeSwappable to not be null!");
 			if (pendingSwappable != null)
 			{
 				Logger.LogTrace("Replacing activeSwappable with pendingSwappable...");

--- a/src/Tgstation.Server.Host/Core/Application.cs
+++ b/src/Tgstation.Server.Host/Core/Application.cs
@@ -357,8 +357,6 @@ namespace Tgstation.Server.Host.Core
 			// Final point where we wrap exceptions in a 500 (ErrorMessage) response
 			applicationBuilder.UseServerErrorHandling();
 
-			applicationBuilder.UseRequestCounting();
-
 			// 503 requests made while the application is starting
 			applicationBuilder.UseAsyncInitialization(async (cancellationToken) =>
 			{

--- a/src/Tgstation.Server.Host/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/Tgstation.Server.Host/Extensions/ApplicationBuilderExtensions.cs
@@ -107,32 +107,5 @@ namespace Tgstation.Server.Host.Extensions
 				}
 			});
 		}
-
-		/// <summary>
-		/// Add middleware for logging the request number.
-		/// </summary>
-		/// <param name="applicationBuilder">The <see cref="IApplicationBuilder"/> to configure.</param>
-		public static void UseRequestCounting(this IApplicationBuilder applicationBuilder)
-		{
-			if (applicationBuilder == null)
-				throw new ArgumentNullException(nameof(applicationBuilder));
-
-			ulong requestCounter = 0;
-
-			applicationBuilder.Use(async (context, next) =>
-			{
-				var logger = GetLogger(context);
-				var requestNumber = ++requestCounter;
-				logger.LogTrace("Starting request #{0}...", requestNumber);
-				try
-				{
-					await next().ConfigureAwait(false);
-				}
-				finally
-				{
-					logger.LogTrace("Finished request #{0}", requestNumber);
-				}
-			});
-		}
 	}
 }


### PR DESCRIPTION
:cl:
You can now change the watchdog heartbeat interval and startup timeout without triggering a soft restart.
Fixed a watchdog crash loop that could potentially occur during the commit phase of deployment.
Changing the auto-update interval will no longer cancel pull/deploy jobs that are in progress.
Fixed an auto update failure that could occur if auto updates began with the latest origin commit and test merges active.
Fixed a crash that could occur as a result of a race condition when the watchdog reattaches.
Fixed a watchdog crash lop that could potentially occur when updating DreamDaemon settings.
Fixed a Windows watchdog crash that would occur after the first deployment after a reattach.
Fixed the watchdog detach event not being sent to the DMAPI.
/:cl:

:cl: HTTP API
Patch version bump to facilitate implementation changes.
/:cl: