### PR TITLE
API Documentation Cleanup

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -3,8 +3,8 @@
     <!-- This is the authorative version list -->
     <!-- Integration tests will ensure they match across the board -->
     <TgsCoreVersion>4.3.2</TgsCoreVersion>
-    <TgsApiVersion>6.6.0</TgsApiVersion>
-    <TgsClientVersion>7.2.0</TgsClientVersion>
+    <TgsApiVersion>7.0.0</TgsApiVersion>
+    <TgsClientVersion>7.3.0</TgsClientVersion>
     <TgsDmapiVersion>5.2.2</TgsDmapiVersion>
     <TgsControlPanelVersion>0.4.0</TgsControlPanelVersion>
     <TgsHostWatchdogVersion>1.1.0</TgsHostWatchdogVersion>

--- a/src/Tgstation.Server.Api/Models/ErrorCode.cs
+++ b/src/Tgstation.Server.Api/Models/ErrorCode.cs
@@ -495,5 +495,29 @@ namespace Tgstation.Server.Api.Models
 		/// </summary>
 		[Description("Cannot restart the watchdog as it is not running!")]
 		WatchdogNotRunning,
+
+		/// <summary>
+		/// Attempted to access a resourse that is not (currently) present.
+		/// </summary>
+		[Description("The requested resource is not currently present, but may have been in the past.")]
+		ResourceNotPresent,
+
+		/// <summary>
+		/// Attempted to access a resource that was never present.
+		/// </summary>
+		[Description("The requested resource is not present and never has been.")]
+		ResourceNeverPresent,
+
+		/// <summary>
+		/// A required GitHub API call failed due to rate limiting.
+		/// </summary>
+		[Description("A required GitHub API call failed due to rate limiting.")]
+		GitHubApiRateLimit,
+
+		/// <summary>
+		/// Attempted to cancel a stopped job.
+		/// </summary>
+		[Description("Cannot cancel the job as it is no longer running.")]
+		JobStopped,
 	}
 }

--- a/src/Tgstation.Server.Host/Controllers/ApiController.cs
+++ b/src/Tgstation.Server.Host/Controllers/ApiController.cs
@@ -76,6 +76,24 @@ namespace Tgstation.Server.Host.Controllers
 			this.requireHeaders = requireHeaders;
 		}
 
+		/// <summary>
+		/// Generic 410 response.
+		/// </summary>
+		/// <returns>An <see cref="ObjectResult"/> with <see cref="HttpStatusCode.Gone"/>.</returns>
+		protected ObjectResult Gone() => StatusCode((int)HttpStatusCode.Gone, new ErrorMessage(ErrorCode.ResourceNotPresent));
+
+		/// <summary>
+		/// Generic 404 response.
+		/// </summary>
+		/// <returns>An <see cref="ObjectResult"/> with <see cref="HttpStatusCode.NotFound"/>.</returns>
+		protected new ObjectResult NotFound() => StatusCode((int)HttpStatusCode.NotFound, new ErrorMessage(ErrorCode.ResourceNeverPresent));
+
+		/// <summary>
+		/// Generic 501 response.
+		/// </summary>
+		/// <returns>An <see cref="ObjectResult"/> with <see cref="HttpStatusCode.NotImplemented"/>.</returns>
+		protected ObjectResult RequiresPosixSystemIdentity() => StatusCode((int)HttpStatusCode.NotImplemented, new ErrorMessage(ErrorCode.RequiresPosixSystemIdentity));
+
 		/// <inheritdoc />
 		#pragma warning disable CA1506 // TODO: Decomplexify
 		public override async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)

--- a/src/Tgstation.Server.Host/Controllers/ChatController.cs
+++ b/src/Tgstation.Server.Host/Controllers/ChatController.cs
@@ -150,7 +150,7 @@ namespace Tgstation.Server.Host.Controllers
 					.DeleteAsync(cancellationToken))
 				.ConfigureAwait(false);
 
-			return Ok();
+			return NoContent();
 		}
 
 		/// <summary>
@@ -188,11 +188,9 @@ namespace Tgstation.Server.Host.Controllers
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> for the operation.</returns>
 		/// <response code="200">Retrieved <see cref="Api.Models.ChatBot"/> successfully.</response>
-		/// <response code="410">Chat bot does not exist.</response>
 		[HttpGet("{id}")]
 		[TgsAuthorize(ChatBotRights.Read)]
 		[ProducesResponseType(typeof(Api.Models.ChatBot), 200)]
-		[ProducesResponseType(410)]
 		public async Task<IActionResult> GetId(long id, CancellationToken cancellationToken)
 		{
 			var query = DatabaseContext.ChatBots
@@ -202,7 +200,7 @@ namespace Tgstation.Server.Host.Controllers
 
 			var results = await query.FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
 			if (results == default)
-				return StatusCode((int)HttpStatusCode.Gone);
+				return Gone();
 
 			var connectionStrings = (AuthenticationContext.GetRight(RightsType.ChatBots) & (ulong)ChatBotRights.ReadConnectionString) != 0;
 
@@ -223,11 +221,9 @@ namespace Tgstation.Server.Host.Controllers
 		[TgsAuthorize(ChatBotRights.WriteChannels | ChatBotRights.WriteConnectionString | ChatBotRights.WriteEnabled | ChatBotRights.WriteName | ChatBotRights.WriteProvider)]
 		[ProducesResponseType(200)]
 		[ProducesResponseType(typeof(Api.Models.ChatBot), 200)]
-#pragma warning disable CA1502 // TODO: Decomplexify
-#pragma warning disable CA1506
+		#pragma warning disable CA1502, CA1506 // TODO: Decomplexify
 		public async Task<IActionResult> Update([FromBody] Api.Models.ChatBot model, CancellationToken cancellationToken)
-		#pragma warning restore CA1502
-		#pragma warning restore CA1506
+		#pragma warning restore CA1502, CA1506
 		{
 			if (model == null)
 				throw new ArgumentNullException(nameof(model));
@@ -245,7 +241,7 @@ namespace Tgstation.Server.Host.Controllers
 			var current = await query.FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
 
 			if (current == default)
-				return StatusCode((int)HttpStatusCode.Gone);
+				return Gone();
 
 			if ((model.Channels?.Count ?? current.Channels.Count) > (model.ChannelLimit ?? current.ChannelLimit.Value))
 			{

--- a/src/Tgstation.Server.Host/Controllers/ConfigurationController.cs
+++ b/src/Tgstation.Server.Host/Controllers/ConfigurationController.cs
@@ -74,8 +74,7 @@ namespace Tgstation.Server.Host.Controllers
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> for the operation.</returns>
 		/// <response code="200">File updated successfully.</response>
-		/// <response code="200">File created successfully.</response>
-		/// <response code="501">POSIX system impersonation requested but not implemented.</response>
+		/// <response code="201">File created successfully.</response>
 		[HttpPost]
 		[TgsAuthorize(ConfigurationRights.Write)]
 		[ProducesResponseType(typeof(ConfigurationFile), 200)]
@@ -108,7 +107,7 @@ namespace Tgstation.Server.Host.Controllers
 			}
 			catch (NotImplementedException)
 			{
-				return StatusCode((int)HttpStatusCode.NotImplemented);
+				return RequiresPosixSystemIdentity();
 			}
 		}
 
@@ -118,12 +117,9 @@ namespace Tgstation.Server.Host.Controllers
 		/// <param name="filePath">The path of the file to get</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> for the operation</returns>
-		/// <response code="410">File not found on disk.</response>
-		/// <response code="501">POSIX system impersonation requested but not implemented.</response>
 		[HttpGet(Routes.File + "/{*filePath}")]
 		[TgsAuthorize(ConfigurationRights.Read)]
 		[ProducesResponseType(typeof(ConfigurationFile), 200)]
-		[ProducesResponseType(410)]
 		public async Task<IActionResult> File(string filePath, CancellationToken cancellationToken)
 		{
 			if (ForbidDueToModeConflicts(filePath, out var systemIdentity))
@@ -133,7 +129,7 @@ namespace Tgstation.Server.Host.Controllers
 			{
 				var result = await instanceManager.GetInstance(Instance).Configuration.Read(filePath, systemIdentity, cancellationToken).ConfigureAwait(false);
 				if (result == null)
-					return StatusCode((int)HttpStatusCode.Gone);
+					return Gone();
 
 				return Json(result);
 			}
@@ -147,7 +143,7 @@ namespace Tgstation.Server.Host.Controllers
 			}
 			catch (NotImplementedException)
 			{
-				return StatusCode((int)HttpStatusCode.NotImplemented);
+				return RequiresPosixSystemIdentity();
 			}
 		}
 
@@ -157,12 +153,9 @@ namespace Tgstation.Server.Host.Controllers
 		/// <param name="directoryPath">The path of the directory to get</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> for the operation</returns>
-		/// <response code="410">Directory not found on disk.</response>
-		/// <response code="501">POSIX system impersonation requested but not implemented.</response>
 		[HttpGet(Routes.List + "/{*directoryPath}")]
 		[TgsAuthorize(ConfigurationRights.List)]
 		[ProducesResponseType(typeof(IReadOnlyList<ConfigurationFile>), 200)]
-		[ProducesResponseType(410)]
 		public async Task<IActionResult> Directory(string directoryPath, CancellationToken cancellationToken)
 		{
 			if (ForbidDueToModeConflicts(directoryPath, out var systemIdentity))
@@ -172,13 +165,13 @@ namespace Tgstation.Server.Host.Controllers
 			{
 				var result = await instanceManager.GetInstance(Instance).Configuration.ListDirectory(directoryPath, systemIdentity, cancellationToken).ConfigureAwait(false);
 				if (result == null)
-					return StatusCode((int)HttpStatusCode.Gone);
+					return Gone();
 
 				return Json(result);
 			}
 			catch (NotImplementedException)
 			{
-				return StatusCode((int)HttpStatusCode.NotImplemented);
+				return RequiresPosixSystemIdentity();
 			}
 			catch (UnauthorizedAccessException)
 			{
@@ -191,13 +184,9 @@ namespace Tgstation.Server.Host.Controllers
 		/// </summary>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> for the operation.</returns>
-		/// <response code="410">Directory not found on disk.</response>
-		/// <response code="501">POSIX system impersonation requested but not implemented.</response>
 		[HttpGet(Routes.List)]
 		[TgsAuthorize(ConfigurationRights.List)]
 		[ProducesResponseType(typeof(IReadOnlyList<ConfigurationFile>), 200)]
-		[ProducesResponseType(410)]
-		[ProducesResponseType(501)]
 		public Task<IActionResult> List(CancellationToken cancellationToken) => Directory(null, cancellationToken);
 
 		/// <summary>
@@ -208,12 +197,10 @@ namespace Tgstation.Server.Host.Controllers
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> for the operation.</returns>
 		/// <response code="200">Directory already exists.</response>
 		/// <response code="201">Directory created successfully.</response>
-		/// <response code="501">POSIX system impersonation requested but not implemented.</response>
 		[HttpPut]
 		[TgsAuthorize(ConfigurationRights.Write)]
 		[ProducesResponseType(typeof(ConfigurationFile), 200)]
 		[ProducesResponseType(typeof(ConfigurationFile), 201)]
-		[ProducesResponseType(501)]
 		public async Task<IActionResult> Create([FromBody] ConfigurationFile model, CancellationToken cancellationToken)
 		{
 			if (model == null)
@@ -237,7 +224,7 @@ namespace Tgstation.Server.Host.Controllers
 			}
 			catch (NotImplementedException)
 			{
-				return StatusCode((int)HttpStatusCode.NotImplemented);
+				return RequiresPosixSystemIdentity();
 			}
 			catch (UnauthorizedAccessException)
 			{
@@ -252,11 +239,9 @@ namespace Tgstation.Server.Host.Controllers
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> of the operation</returns>
 		/// <response code="204">Empty directory deleted successfully.</response>
-		/// <response code="501">POSIX system impersonation requested but not implemented.</response>
 		[HttpDelete]
 		[TgsAuthorize(ConfigurationRights.Delete)]
 		[ProducesResponseType(204)]
-		[ProducesResponseType(501)]
 		public async Task<IActionResult> Delete([FromBody] ConfigurationFile directory, CancellationToken cancellationToken)
 		{
 			if (directory == null)
@@ -277,7 +262,7 @@ namespace Tgstation.Server.Host.Controllers
 			}
 			catch (NotImplementedException)
 			{
-				return StatusCode((int)HttpStatusCode.NotImplemented);
+				return RequiresPosixSystemIdentity();
 			}
 			catch (UnauthorizedAccessException)
 			{

--- a/src/Tgstation.Server.Host/Controllers/DreamMakerController.cs
+++ b/src/Tgstation.Server.Host/Controllers/DreamMakerController.cs
@@ -4,7 +4,6 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Tgstation.Server.Api;
@@ -77,11 +76,9 @@ namespace Tgstation.Server.Host.Controllers
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> of the request.</returns>
 		/// <response code="200"><see cref="Api.Models.CompileJob"/> retrieved successfully.</response>
-		/// <response code="404">Specified compile job does not exist in this instance.</response>
 		[HttpGet("{id}")]
 		[TgsAuthorize(DreamMakerRights.CompileJobs)]
 		[ProducesResponseType(typeof(Api.Models.CompileJob), 200)]
-		[ProducesResponseType(404)]
 		public async Task<IActionResult> GetId(long id, CancellationToken cancellationToken)
 		{
 			var compileJob = await DatabaseContext
@@ -159,12 +156,10 @@ namespace Tgstation.Server.Host.Controllers
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> of the request.</returns>
 		/// <response code="200">Changes applied successfully. The updated <see cref="DreamMaker"/> settings will be returned.</response>
 		/// <response code="204">Changes applied successfully. The updated <see cref="DreamMaker"/> settings will be not be returned due to permissions.</response>
-		/// <response code="410">Instance no longer available.</response>
 		[HttpPost]
 		[TgsAuthorize(DreamMakerRights.SetDme | DreamMakerRights.SetApiValidationPort | DreamMakerRights.SetApiValidationPort)]
 		[ProducesResponseType(typeof(DreamMaker), 200)]
 		[ProducesResponseType(204)]
-		[ProducesResponseType(410)]
 		public async Task<IActionResult> Update([FromBody] DreamMaker model, CancellationToken cancellationToken)
 		{
 			if (model == null)
@@ -180,7 +175,7 @@ namespace Tgstation.Server.Host.Controllers
 				.FirstOrDefaultAsync(cancellationToken)
 				.ConfigureAwait(false);
 			if (hostModel == null)
-				return StatusCode((int)HttpStatusCode.Gone);
+				return Gone();
 
 			if (model.ProjectName != null)
 			{

--- a/src/Tgstation.Server.Host/Controllers/HomeController.cs
+++ b/src/Tgstation.Server.Host/Controllers/HomeController.cs
@@ -152,8 +152,6 @@ namespace Tgstation.Server.Host.Controllers
 		/// <response code="403">User authenticated but is disabled by an administrator.</response>
 		[HttpPost]
 		[ProducesResponseType(typeof(Api.Models.Token), 200)]
-		[ProducesResponseType(401)]
-		[ProducesResponseType(403)]
 		#pragma warning disable CA1506 // TODO: Decomplexify
 		public async Task<IActionResult> CreateToken(CancellationToken cancellationToken)
 		{

--- a/src/Tgstation.Server.Host/Controllers/InstanceController.cs
+++ b/src/Tgstation.Server.Host/Controllers/InstanceController.cs
@@ -312,11 +312,9 @@ namespace Tgstation.Server.Host.Controllers
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> of the request.</returns>
 		/// <response code="204">Instance detatched successfully.</response>
-		/// <response code="410">Instance not available.</response>
 		[HttpDelete("{id}")]
 		[TgsAuthorize(InstanceManagerRights.Delete)]
 		[ProducesResponseType(204)]
-		[ProducesResponseType(410)]
 		public async Task<IActionResult> Delete(long id, CancellationToken cancellationToken)
 		{
 			var originalModel = await DatabaseContext
@@ -328,7 +326,7 @@ namespace Tgstation.Server.Host.Controllers
 				.Include(x => x.WatchdogReattachInformation.Bravo)
 				.FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
 			if (originalModel == default)
-				return StatusCode((int)HttpStatusCode.Gone);
+				return Gone();
 			if (originalModel.Online.Value)
 				return Conflict(new ErrorMessage(ErrorCode.InstanceDetachOnline));
 
@@ -361,7 +359,6 @@ namespace Tgstation.Server.Host.Controllers
 		[TgsAuthorize(InstanceManagerRights.Relocate | InstanceManagerRights.Rename | InstanceManagerRights.SetAutoUpdate | InstanceManagerRights.SetConfiguration | InstanceManagerRights.SetOnline | InstanceManagerRights.SetChatBotLimit)]
 		[ProducesResponseType(typeof(Api.Models.Instance), 200)]
 		[ProducesResponseType(typeof(Api.Models.Instance), 202)]
-		[ProducesResponseType(410)]
 #pragma warning disable CA1502 // TODO: Decomplexify
 		public async Task<IActionResult> Update([FromBody] Api.Models.Instance model, CancellationToken cancellationToken)
 		{
@@ -393,7 +390,7 @@ namespace Tgstation.Server.Host.Controllers
 				.Include(x => x.DreamDaemonSettings) // need these for onlining
 				.FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
 			if (originalModel == default(Models.Instance))
-				return StatusCode((int)HttpStatusCode.Gone);
+				return Gone();
 
 			var userRights = (InstanceManagerRights)AuthenticationContext.GetRight(RightsType.InstanceManager);
 			bool CheckModified<T>(Expression<Func<Api.Models.Instance, T>> expression, InstanceManagerRights requiredRight)
@@ -586,11 +583,9 @@ namespace Tgstation.Server.Host.Controllers
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> of the request.</returns>
 		/// <response code="200">Retrieved <see cref="Api.Models.Instance"/> successfully.</response>
-		/// <response code="410">Instance not available.</response>
 		[HttpGet("{id}")]
 		[TgsAuthorize(InstanceManagerRights.List | InstanceManagerRights.Read)]
 		[ProducesResponseType(typeof(Api.Models.Instance), 200)]
-		[ProducesResponseType(410)]
 		public async Task<IActionResult> GetId(long id, CancellationToken cancellationToken)
 		{
 			var cantList = !AuthenticationContext.User.InstanceManagerRights.Value.HasFlag(InstanceManagerRights.List);
@@ -609,7 +604,7 @@ namespace Tgstation.Server.Host.Controllers
 			var instance = await QueryForUser().FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
 
 			if (instance == null)
-				return StatusCode((int)HttpStatusCode.Gone);
+				return Gone();
 
 			if (cantList && !instance.InstanceUsers.Any(instanceUser => instanceUser.UserId == AuthenticationContext.User.Id &&
 				(instanceUser.ByondRights != ByondRights.None ||

--- a/src/Tgstation.Server.Host/Controllers/InstanceUserController.cs
+++ b/src/Tgstation.Server.Host/Controllers/InstanceUserController.cs
@@ -89,11 +89,9 @@ namespace Tgstation.Server.Host.Controllers
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> of the request.</returns>
 		/// <response code="200"><see cref="Api.Models.InstanceUser"/> updated successfully.</response>
-		/// <response code="410">Instance user unavailable.</response>
 		[HttpPost]
 		[TgsAuthorize(InstanceUserRights.WriteUsers)]
 		[ProducesResponseType(typeof(Api.Models.InstanceUser), 200)]
-		[ProducesResponseType(410)]
 		#pragma warning disable CA1506 // TODO: Decomplexify
 		public async Task<IActionResult> Update([FromBody] Api.Models.InstanceUser model, CancellationToken cancellationToken)
 		{
@@ -110,7 +108,7 @@ namespace Tgstation.Server.Host.Controllers
 				.FirstOrDefaultAsync(cancellationToken)
 				.ConfigureAwait(false);
 			if (originalUser == null)
-				return StatusCode((int)HttpStatusCode.Gone);
+				return Gone();
 
 			originalUser.ByondRights = RightsHelper.Clamp(model.ByondRights ?? originalUser.ByondRights.Value);
 			originalUser.RepositoryRights = RightsHelper.Clamp(model.RepositoryRights ?? originalUser.RepositoryRights.Value);
@@ -165,11 +163,9 @@ namespace Tgstation.Server.Host.Controllers
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> of the request.</returns>
 		/// <response code="200">Retrieve <see cref="Api.Models.InstanceUser"/> successfully.</response>
-		/// <response code="410">Instance user unavailable.</response>
 		[HttpGet("{id}")]
 		[TgsAuthorize(InstanceUserRights.ReadUsers)]
 		[ProducesResponseType(typeof(Api.Models.InstanceUser), 200)]
-		[ProducesResponseType(410)]
 		public async Task<IActionResult> GetId(long id, CancellationToken cancellationToken)
 		{
 			// this functions as userId
@@ -182,7 +178,7 @@ namespace Tgstation.Server.Host.Controllers
 				.FirstOrDefaultAsync(cancellationToken)
 				.ConfigureAwait(false);
 			if (user == default)
-				return StatusCode((int)HttpStatusCode.Gone);
+				return Gone();
 			return Json(user.ToApi());
 		}
 

--- a/src/Tgstation.Server.Host/Controllers/JobController.cs
+++ b/src/Tgstation.Server.Host/Controllers/JobController.cs
@@ -4,10 +4,10 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Tgstation.Server.Api;
+using Tgstation.Server.Api.Models;
 using Tgstation.Server.Host.Database;
 using Tgstation.Server.Host.Jobs;
 using Tgstation.Server.Host.Models;
@@ -60,14 +60,14 @@ namespace Tgstation.Server.Host.Controllers
 		}
 
 		/// <summary>
-		/// List all <see cref="Api.Models.Job"/> <see cref="Api.Models.EntityId"/>s for the instance in reverse creation order.
+		/// List all <see cref="Api.Models.Job"/> <see cref="EntityId"/>s for the instance in reverse creation order.
 		/// </summary>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> of the request.</returns>
-		/// <response code="200">Retrieved <see cref="Api.Models.Job"/> <see cref="Api.Models.EntityId"/>s successfully.</response>
+		/// <response code="200">Retrieved <see cref="Api.Models.Job"/> <see cref="EntityId"/>s successfully.</response>
 		[HttpGet(Routes.List)]
 		[TgsAuthorize]
-		[ProducesResponseType(typeof(List<Api.Models.EntityId>), 200)]
+		[ProducesResponseType(typeof(List<EntityId>), 200)]
 		public async Task<IActionResult> List(CancellationToken cancellationToken)
 		{
 			// you KNOW this will need pagination eventually right?
@@ -76,7 +76,7 @@ namespace Tgstation.Server.Host.Controllers
 				.AsQueryable()
 				.Where(x => x.Instance.Id == Instance.Id)
 				.OrderByDescending(x => x.StartedAt)
-				.Select(x => new Api.Models.EntityId
+				.Select(x => new EntityId
 				{
 					Id = x.Id
 				})
@@ -88,17 +88,14 @@ namespace Tgstation.Server.Host.Controllers
 		/// <summary>
 		/// Cancel a running <see cref="Api.Models.Job"/>.
 		/// </summary>
-		/// <param name="id">The <see cref="Api.Models.EntityId.Id"/> of the <see cref="Api.Models.Job"/> to cancel.</param>
+		/// <param name="id">The <see cref="EntityId.Id"/> of the <see cref="Api.Models.Job"/> to cancel.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> of the request.</returns>
 		/// <response code="202"><see cref="Api.Models.Job"/> cancellation requested successfully.</response>
 		/// <response code="404"><see cref="Api.Models.Job"/> does not exist in this instance.</response>
-		/// <response code="410"><see cref="Api.Models.Job"/> already cancelled or completed.</response>
 		[HttpDelete("{id}")]
 		[TgsAuthorize]
 		[ProducesResponseType(typeof(Api.Models.Job), 202)]
-		[ProducesResponseType(404)]
-		[ProducesResponseType(410)]
 		public async Task<IActionResult> Delete(long id, CancellationToken cancellationToken)
 		{
 			// don't care if an instance post or not at this point
@@ -108,23 +105,23 @@ namespace Tgstation.Server.Host.Controllers
 				.Where(x => x.Id == id && x.Instance.Id == Instance.Id)
 				.FirstOrDefaultAsync(cancellationToken)
 				.ConfigureAwait(false);
-			if (job == default(Job))
+			if (job == default)
 				return NotFound();
 
 			if (job.StoppedAt != null)
-				return StatusCode((int)HttpStatusCode.Gone);
+				return Conflict(new ErrorMessage(ErrorCode.JobStopped));
 
 			if (job.CancelRight.HasValue && job.CancelRightsType.HasValue && (AuthenticationContext.GetRight(job.CancelRightsType.Value) & job.CancelRight.Value) == 0)
 				return Forbid();
 
 			var updatedJob = await jobManager.CancelJob(job, AuthenticationContext.User, false, cancellationToken).ConfigureAwait(false);
-			return updatedJob != null ? (IActionResult)Accepted(updatedJob.ToApi()) : StatusCode((int)HttpStatusCode.Gone);
+			return updatedJob != null ? Accepted(updatedJob.ToApi()) : Gone();
 		}
 
 		/// <summary>
 		/// Get a specific <see cref="Api.Models.Job"/>.
 		/// </summary>
-		/// <param name="id">The <see cref="Api.Models.EntityId.Id"/> of the <see cref="Api.Models.Job"/> to retrieve.</param>
+		/// <param name="id">The <see cref="EntityId.Id"/> of the <see cref="Api.Models.Job"/> to retrieve.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> of the request.</returns>
 		/// <response code="200">Retrieved <see cref="Api.Models.Job"/> successfully.</response>
@@ -132,7 +129,6 @@ namespace Tgstation.Server.Host.Controllers
 		[HttpGet("{id}")]
 		[TgsAuthorize]
 		[ProducesResponseType(typeof(Api.Models.Job), 200)]
-		[ProducesResponseType(404)]
 		public async Task<IActionResult> GetId(long id, CancellationToken cancellationToken)
 		{
 			var job = await DatabaseContext

--- a/src/Tgstation.Server.Host/Controllers/RepositoryController.cs
+++ b/src/Tgstation.Server.Host/Controllers/RepositoryController.cs
@@ -140,11 +140,9 @@ namespace Tgstation.Server.Host.Controllers
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> of the request.</returns>
 		/// <response code="201">The <see cref="Repository"/> was created successfully and the <see cref="Api.Models.Job"/> to clone it has begun.</response>
-		/// <response code="410">Instance no longer available.</response>
 		[HttpPut]
 		[TgsAuthorize(RepositoryRights.SetOrigin)]
 		[ProducesResponseType(typeof(Repository), 201)]
-		[ProducesResponseType(410)]
 		public async Task<IActionResult> Create([FromBody] Repository model, CancellationToken cancellationToken)
 		{
 			if (model == null)
@@ -164,7 +162,7 @@ namespace Tgstation.Server.Host.Controllers
 				.ConfigureAwait(false);
 
 			if (currentModel == default)
-				return StatusCode((int)HttpStatusCode.Gone);
+				return Gone();
 
 			// normalize github urls
 			const string BadGitHubUrl = "://www.github.com/";
@@ -234,11 +232,9 @@ namespace Tgstation.Server.Host.Controllers
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> of the operation</returns>
 		/// <response code="202">Job to delete the repository created successfully.</response>
-		/// <response code="410">Instance no longer available.</response>
 		[HttpDelete]
 		[TgsAuthorize(RepositoryRights.Delete)]
 		[ProducesResponseType(typeof(Repository), 202)]
-		[ProducesResponseType(410)]
 		public async Task<IActionResult> Delete(CancellationToken cancellationToken)
 		{
 			var currentModel = await DatabaseContext
@@ -249,7 +245,7 @@ namespace Tgstation.Server.Host.Controllers
 				.ConfigureAwait(false);
 
 			if (currentModel == default)
-				return StatusCode((int)HttpStatusCode.Gone);
+				return Gone();
 
 			currentModel.AccessToken = null;
 			currentModel.AccessUser = null;
@@ -277,12 +273,10 @@ namespace Tgstation.Server.Host.Controllers
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> of the operation.</returns>
 		/// <response code="200">Retrieved the <see cref="Repository"/> settings successfully.</response>
 		/// <response code="201">Retrieved the <see cref="Repository"/> settings successfully, though they did not previously exist.</response>
-		/// <response code="410">Instance no longer available.</response>
 		[HttpGet]
 		[TgsAuthorize(RepositoryRights.Read)]
 		[ProducesResponseType(typeof(Repository), 200)]
 		[ProducesResponseType(typeof(Repository), 201)]
-		[ProducesResponseType(410)]
 		public async Task<IActionResult> Read(CancellationToken cancellationToken)
 		{
 			var currentModel = await DatabaseContext
@@ -293,7 +287,7 @@ namespace Tgstation.Server.Host.Controllers
 				.ConfigureAwait(false);
 
 			if (currentModel == default)
-				return StatusCode((int)HttpStatusCode.Gone, new ErrorMessage(ErrorCode.RepoMissing));
+				return Gone();
 
 			var api = currentModel.ToApi();
 			var repoManager = instanceManager.GetInstance(Instance).RepositoryManager;
@@ -323,12 +317,10 @@ namespace Tgstation.Server.Host.Controllers
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> of the operation.</returns>
 		/// <response code="200">Updated the <see cref="Repository"/> settings successfully.</response>
 		/// <response code="202">Updated the <see cref="Repository"/> settings successfully and a <see cref="Api.Models.Job"/> was created to make the requested git changes.</response>
-		/// <response code="410">Instance no longer available.</response>
 		[HttpPost]
 		[TgsAuthorize(RepositoryRights.ChangeAutoUpdateSettings | RepositoryRights.ChangeCommitter | RepositoryRights.ChangeCredentials | RepositoryRights.ChangeTestMergeCommits | RepositoryRights.MergePullRequest | RepositoryRights.SetReference | RepositoryRights.SetSha | RepositoryRights.UpdateBranch)]
 		[ProducesResponseType(typeof(Repository), 200)]
 		[ProducesResponseType(typeof(Repository), 202)]
-		[ProducesResponseType(410)]
 		#pragma warning disable CA1502, CA1505 // TODO: Decomplexify
 		public async Task<IActionResult> Update([FromBody]Repository model, CancellationToken cancellationToken)
 		{
@@ -366,7 +358,7 @@ namespace Tgstation.Server.Host.Controllers
 				.ConfigureAwait(false);
 
 			if (currentModel == default)
-				return StatusCode((int)HttpStatusCode.Gone);
+				return Gone();
 
 			bool CheckModified<T>(Expression<Func<Api.Models.Internal.RepositorySettings, T>> expression, RepositoryRights requiredRight)
 			{

--- a/src/Tgstation.Server.Host/Controllers/UserController.cs
+++ b/src/Tgstation.Server.Host/Controllers/UserController.cs
@@ -99,12 +99,9 @@ namespace Tgstation.Server.Host.Controllers
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> of the operation.</returns>
 		/// <response code="201"><see cref="Api.Models.User"/> created successfully.</response>
-		/// <response code="410">The <see cref="Api.Models.Internal.User.SystemIdentifier"/> requested could not be loaded.</response>
-		/// <response code="501">A system user was requested but this is not implemented on POSIX.</response>
 		[HttpPut]
 		[TgsAuthorize(AdministrationRights.WriteUsers)]
 		[ProducesResponseType(typeof(Api.Models.User), 201)]
-		[ProducesResponseType(410)]
 		public async Task<IActionResult> Create([FromBody] UserUpdate model, CancellationToken cancellationToken)
 		{
 			if (model == null)
@@ -141,13 +138,13 @@ namespace Tgstation.Server.Host.Controllers
 				{
 					using var sysIdentity = await systemIdentityFactory.CreateSystemIdentity(dbUser, cancellationToken).ConfigureAwait(false);
 					if (sysIdentity == null)
-						return StatusCode((int)HttpStatusCode.Gone);
+						return Gone();
 					dbUser.Name = sysIdentity.Username;
 					dbUser.SystemIdentifier = sysIdentity.Uid;
 				}
 				catch (NotImplementedException)
 				{
-					return StatusCode((int)HttpStatusCode.NotImplemented, new ErrorMessage(ErrorCode.RequiresPosixSystemIdentity));
+					return RequiresPosixSystemIdentity();
 				}
 			else
 			{
@@ -176,7 +173,6 @@ namespace Tgstation.Server.Host.Controllers
 		[HttpPost]
 		[TgsAuthorize(AdministrationRights.WriteUsers | AdministrationRights.EditOwnPassword)]
 		[ProducesResponseType(typeof(Api.Models.User), 200)]
-		[ProducesResponseType(404)]
 		#pragma warning disable CA1502 // TODO: Decomplexify
 		#pragma warning disable CA1506
 		public async Task<IActionResult> Update([FromBody] UserUpdate model, CancellationToken cancellationToken)
@@ -294,7 +290,6 @@ namespace Tgstation.Server.Host.Controllers
 		[HttpGet("{id}")]
 		[TgsAuthorize]
 		[ProducesResponseType(typeof(Api.Models.User), 200)]
-		[ProducesResponseType(404)]
 		public async Task<IActionResult> GetId(long id, CancellationToken cancellationToken)
 		{
 			if (id == AuthenticationContext.User.Id)

--- a/src/Tgstation.Server.Host/Core/SwaggerConfiguration.cs
+++ b/src/Tgstation.Server.Host/Core/SwaggerConfiguration.cs
@@ -76,12 +76,18 @@ namespace Tgstation.Server.Host.Core
 
 			AddDefaultResponse(HttpStatusCode.Unauthorized, new OpenApiResponse
 			{
-				Description = "No/invalid token provided."
+				Description = "Invalid Authentication header."
 			});
 
 			AddDefaultResponse(HttpStatusCode.Forbidden, new OpenApiResponse
 			{
 				Description = "User lacks sufficient permissions for the operation."
+			});
+
+			AddDefaultResponse(HttpStatusCode.NotFound, new OpenApiResponse
+			{
+				Description = ErrorCode.ResourceNeverPresent.Describe(),
+				Content = errorMessageContent
 			});
 
 			AddDefaultResponse(HttpStatusCode.Conflict, new OpenApiResponse
@@ -90,9 +96,15 @@ namespace Tgstation.Server.Host.Core
 				Content = errorMessageContent
 			});
 
+			AddDefaultResponse(HttpStatusCode.Gone, new OpenApiResponse
+			{
+				Description = ErrorCode.ResourceNotPresent.Describe(),
+				Content = errorMessageContent
+			});
+
 			AddDefaultResponse(HttpStatusCode.InternalServerError, new OpenApiResponse
 			{
-				Description = "The server encountered an unhandled error. See error message for details.",
+				Description = ErrorCode.InternalServerError.Describe(),
 				Content = errorMessageContent
 			});
 
@@ -103,7 +115,7 @@ namespace Tgstation.Server.Host.Core
 
 			AddDefaultResponse(HttpStatusCode.NotImplemented, new OpenApiResponse
 			{
-				Description = "This operation requires POSIX system identites to be implemented. See https://github.com/tgstation/tgstation-server/issues/709",
+				Description = ErrorCode.RequiresPosixSystemIdentity.Describe(),
 				Content = errorMessageContent
 			});
 		}
@@ -289,7 +301,7 @@ namespace Tgstation.Server.Host.Core
 			foreach (var path in swaggerDoc.Paths)
 				foreach (var operation in path.Value.Operations.Select(x => x.Value))
 				{
-					if (operation.OperationId.Equals("BridgeController.Process", StringComparison.Ordinal))
+					if (operation.OperationId.Equals($"{nameof(BridgeController)}.{nameof(BridgeController.Process)}", StringComparison.Ordinal))
 					{
 						bridgeOperationPath = path.Key;
 						continue;


### PR DESCRIPTION
:cl: HTTP API
`ErrorMessage` payloads added to most 4XX responses that lacked them.
Conflicts with launching or restarting the watchdog now return 409 instead of 410.
`ErrorCode`s added for attempting to cancel a stopped job and GitHub API rate limits.
/:cl:

Closes #1037 