### PR TITLE
Various fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ DreamDaemon can be finicky and will crash with several high load games or bad DM
 TGS supports creating infinite chat bots for notifying staff or players of things like code deployments and uptime in. Currently the following providers are supported
 
 - Internet Relay Chat (IRC)
-- Discord (Bot requires perms to chat and edit own messages)
+- Discord
 
 More can be added by providing a new implementation of the [IProvider](src/Tgstation.Server.Host/Components/Chat/Providers/IProvider.cs) interface
 

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ DreamDaemon can be finicky and will crash with several high load games or bad DM
 TGS supports creating infinite chat bots for notifying staff or players of things like code deployments and uptime in. Currently the following providers are supported
 
 - Internet Relay Chat (IRC)
-- Discord
+- Discord (Bot requires perms to chat and edit own messages)
 
 More can be added by providing a new implementation of the [IProvider](src/Tgstation.Server.Host/Components/Chat/Providers/IProvider.cs) interface
 

--- a/src/Tgstation.Server.Api/ApiHeaders.cs
+++ b/src/Tgstation.Server.Api/ApiHeaders.cs
@@ -62,7 +62,7 @@ namespace Tgstation.Server.Api
 		public static readonly Version Version = AssemblyName.Version.Semver();
 
 		/// <summary>
-		/// The <see cref="Models.Instance.Id"/> being accessed
+		/// The instance <see cref="Models.EntityId.Id"/> being accessed
 		/// </summary>
 		public long? InstanceId { get; set; }
 
@@ -255,7 +255,7 @@ namespace Tgstation.Server.Api
 		/// Set <see cref="HttpRequestHeaders"/> using the <see cref="ApiHeaders"/>. This initially clears <paramref name="headers"/>
 		/// </summary>
 		/// <param name="headers">The <see cref="HttpRequestHeaders"/> to set</param>
-		/// <param name="instanceId">The <see cref="Models.Instance.Id"/> for the request</param>
+		/// <param name="instanceId">The instance <see cref="Models.EntityId.Id"/> for the request</param>
 		public void SetRequestHeaders(HttpRequestHeaders headers, long? instanceId = null)
 		{
 			if (headers == null)

--- a/src/Tgstation.Server.Api/Models/EntityId.cs
+++ b/src/Tgstation.Server.Api/Models/EntityId.cs
@@ -1,7 +1,7 @@
 ﻿namespace Tgstation.Server.Api.Models
 {
 	/// <summary>
-	/// Common base of <see cref="CompileJob"/>s and <see cref="Job"/>s.
+	/// Common base of <see cref="Instance"/>s, <see cref="CompileJob"/>s, and <see cref="Job"/>s.
 	/// </summary>
 	public class EntityId
 	{

--- a/src/Tgstation.Server.Api/Models/Instance.cs
+++ b/src/Tgstation.Server.Api/Models/Instance.cs
@@ -6,13 +6,8 @@ namespace Tgstation.Server.Api.Models
 	/// <summary>
 	/// Metadata about a server instance
 	/// </summary>
-	public class Instance
+	public class Instance : EntityId
 	{
-		/// <summary>
-		/// The id of the <see cref="Instance"/>. Not modifiable
-		/// </summary>
-		public long Id { get; set; }
-
 		/// <summary>
 		/// The name of the <see cref="Instance"/>
 		/// </summary>

--- a/src/Tgstation.Server.Client/ApiClient.cs
+++ b/src/Tgstation.Server.Client/ApiClient.cs
@@ -138,7 +138,7 @@ namespace Tgstation.Server.Client
 		/// <param name="route">The route to run</param>
 		/// <param name="body">The body of the request</param>
 		/// <param name="method">The method of the request</param>
-		/// <param name="instanceId">The optional <see cref="Instance.Id"/> for the request</param>
+		/// <param name="instanceId">The optional instance <see cref="EntityId.Id"/> for the request</param>
 		/// <param name="tokenRefresh">If this is a token refresh operation.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the response on success</returns>

--- a/src/Tgstation.Server.Client/IApiClient.cs
+++ b/src/Tgstation.Server.Client/IApiClient.cs
@@ -105,7 +105,7 @@ namespace Tgstation.Server.Client
 		/// <typeparam name="TResult">The type of the response body</typeparam>
 		/// <param name="route">The server route to make the request to</param>
 		/// <param name="body">The request body</param>
-		/// <param name="instanceId">The <see cref="Api.Models.Instance.Id"/> to make the request to</param>
+		/// <param name="instanceId">The instance <see cref="Api.Models.EntityId.Id"/> to make the request to</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the response body as a <typeparamref name="TResult"/></returns>
 		Task<TResult> Create<TBody, TResult>(string route, TBody body, long instanceId, CancellationToken cancellationToken);
@@ -115,7 +115,7 @@ namespace Tgstation.Server.Client
 		/// </summary>
 		/// <typeparam name="TResult">The type of the response body</typeparam>
 		/// <param name="route">The server route to make the request to</param>
-		/// <param name="instanceId">The <see cref="Api.Models.Instance.Id"/> to make the request to</param>
+		/// <param name="instanceId">The instance <see cref="Api.Models.EntityId.Id"/> to make the request to</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the response body as a <typeparamref name="TResult"/></returns>
 		Task<TResult> Create<TResult>(string route, long instanceId, CancellationToken cancellationToken);
@@ -125,7 +125,7 @@ namespace Tgstation.Server.Client
 		/// </summary>
 		/// <typeparam name="TResult">The type of the response body</typeparam>
 		/// <param name="route">The server route to make the request to</param>
-		/// <param name="instanceId">The <see cref="Api.Models.Instance.Id"/> to make the request to</param>
+		/// <param name="instanceId">The instance <see cref="Api.Models.EntityId.Id"/> to make the request to</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the response body as a <typeparamref name="TResult"/></returns>
 		Task<TResult> Patch<TResult>(string route, long instanceId, CancellationToken cancellationToken);
@@ -135,7 +135,7 @@ namespace Tgstation.Server.Client
 		/// </summary>
 		/// <typeparam name="TResult">The type of the response body</typeparam>
 		/// <param name="route">The server route to make the request to</param>
-		/// <param name="instanceId">The <see cref="Api.Models.Instance.Id"/> to make the request to</param>
+		/// <param name="instanceId">The instance <see cref="Api.Models.EntityId.Id"/> to make the request to</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the response body as a <typeparamref name="TResult"/></returns>
 		Task<TResult> Read<TResult>(string route, long instanceId, CancellationToken cancellationToken);
@@ -147,7 +147,7 @@ namespace Tgstation.Server.Client
 		/// <typeparam name="TResult">The type of the response body</typeparam>
 		/// <param name="route">The server route to make the request to</param>
 		/// <param name="body">The request body</param>
-		/// <param name="instanceId">The <see cref="Api.Models.Instance.Id"/> to make the request to</param>
+		/// <param name="instanceId">The instance <see cref="Api.Models.EntityId.Id"/> to make the request to</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the response body as a <typeparamref name="TResult"/></returns>
 		Task<TResult> Update<TBody, TResult>(string route, TBody body, long instanceId, CancellationToken cancellationToken);
@@ -156,7 +156,7 @@ namespace Tgstation.Server.Client
 		/// Run an HTTP DELETE request
 		/// </summary>
 		/// <param name="route">The server route to make the request to</param>
-		/// <param name="instanceId">The <see cref="Api.Models.Instance.Id"/> to make the request to</param>
+		/// <param name="instanceId">The instance <see cref="Api.Models.EntityId.Id"/> to make the request to</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="Task"/> representing the running operation</returns>
 		Task Delete(string route, long instanceId, CancellationToken cancellationToken);
@@ -167,7 +167,7 @@ namespace Tgstation.Server.Client
 		/// <typeparam name="TBody">The type to of the request body</typeparam>
 		/// <param name="route">The server route to make the request to</param>
 		/// <param name="body">The request body</param>
-		/// <param name="instanceId">The <see cref="Api.Models.Instance.Id"/> to make the request to</param>
+		/// <param name="instanceId">The instance <see cref="Api.Models.EntityId.Id"/> to make the request to</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="Task"/> representing the running operation</returns>
 		Task Delete<TBody>(string route, TBody body, long instanceId, CancellationToken cancellationToken);
@@ -177,7 +177,7 @@ namespace Tgstation.Server.Client
 		/// </summary>
 		/// <typeparam name="TResult">The type of the response body</typeparam>
 		/// <param name="route">The server route to make the request to</param>
-		/// <param name="instanceId">The <see cref="Api.Models.Instance.Id"/> to make the request to</param>
+		/// <param name="instanceId">The instance <see cref="Api.Models.EntityId.Id"/> to make the request to</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the response body as a <typeparamref name="TResult"/></returns>
 		Task<TResult> Delete<TResult>(string route, long instanceId, CancellationToken cancellationToken);

--- a/src/Tgstation.Server.Client/IInstanceManagerClient.cs
+++ b/src/Tgstation.Server.Client/IInstanceManagerClient.cs
@@ -21,7 +21,7 @@ namespace Tgstation.Server.Client
 		/// <summary>
 		/// Create or attach an <paramref name="instance"/>
 		/// </summary>
-		/// <param name="instance">The <see cref="Instance"/> to create. <see cref="Instance.Id"/> will be ignored</param>
+		/// <param name="instance">The <see cref="Instance"/> to create. <see cref="EntityId.Id"/> will be ignored</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the created or attached <see cref="Instance"/></returns>
 		Task<Instance> CreateOrAttach(Instance instance, CancellationToken cancellationToken);

--- a/src/Tgstation.Server.Host/Components/Chat/Message.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Message.cs
@@ -11,7 +11,7 @@
 		public string Content { get; set; }
 
 		/// <summary>
-		/// The <see cref="Components.Chat.ChatUser"/> who sent the <see cref="Message"/>
+		/// The <see cref="ChatUser"/> who sent the <see cref="Message"/>
 		/// </summary>
 		public ChatUser User { get; set; }
 	}

--- a/src/Tgstation.Server.Host/Components/IInstance.cs
+++ b/src/Tgstation.Server.Host/Components/IInstance.cs
@@ -13,7 +13,7 @@ namespace Tgstation.Server.Host.Components
 	/// <summary>
 	/// For interacting with the instance services
 	/// </summary>
-	public interface IInstance : ILatestCompileJobProvider, IHostedService, IDisposable
+	public interface IInstance : ILatestCompileJobProvider, IHostedService, IRenameNotifyee, IDisposable
 	{
 		/// <summary>
 		/// The <see cref="IRepositoryManager"/> for the <see cref="IInstance"/>
@@ -44,12 +44,6 @@ namespace Tgstation.Server.Host.Components
 		/// The <see cref="IConfiguration"/> for the <see cref="IInstance"/>
 		/// </summary>
 		IConfiguration Configuration { get; }
-
-		/// <summary>
-		/// Rename the <see cref="IInstance"/>
-		/// </summary>
-		/// <param name="newName">The new name for the <see cref="IInstance"/></param>
-		void Rename(string newName);
 
 		/// <summary>
 		/// Change the <see cref="Api.Models.Instance.AutoUpdateInterval"/> for the <see cref="IInstance"/>

--- a/src/Tgstation.Server.Host/Components/IRenameNotifyee.cs
+++ b/src/Tgstation.Server.Host/Components/IRenameNotifyee.cs
@@ -1,0 +1,19 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace Tgstation.Server.Host.Components
+{
+	/// <summary>
+	/// Handler for an instance being renamed.
+	/// </summary>
+	public interface IRenameNotifyee
+	{
+		/// <summary>
+		/// Called when the owning <see cref="Instance"/> is renamed.
+		/// </summary>
+		/// <param name="newInstanceName">The new <see cref="Api.Models.Instance.Name"/>.</param>
+		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
+		/// <returns>A <see cref="Task"/> representing the running operation.</returns>
+		Task InstanceRenamed(string newInstanceName, CancellationToken cancellationToken);
+	}
+}

--- a/src/Tgstation.Server.Host/Components/Instance.cs
+++ b/src/Tgstation.Server.Host/Components/Instance.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Serilog.Context;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -134,12 +135,15 @@ namespace Tgstation.Server.Host.Components
 		/// <inheritdoc />
 		public void Dispose()
 		{
-			timerCts?.Dispose();
-			Configuration.Dispose();
-			Chat.Dispose();
-			Watchdog.Dispose();
-			dmbFactory.Dispose();
-			RepositoryManager.Dispose();
+			using (LogContext.PushProperty("Instance", metadata.Id))
+			{
+				timerCts?.Dispose();
+				Configuration.Dispose();
+				Chat.Dispose();
+				Watchdog.Dispose();
+				dmbFactory.Dispose();
+				RepositoryManager.Dispose();
+			}
 		}
 
 		/// <summary>
@@ -393,17 +397,20 @@ namespace Tgstation.Server.Host.Components
 		#pragma warning restore CA1502
 
 		/// <inheritdoc />
-		public void Rename(string newName)
+		public Task InstanceRenamed(string newName, CancellationToken cancellationToken)
 		{
 			if (String.IsNullOrWhiteSpace(newName))
 				throw new ArgumentNullException(nameof(newName));
 			metadata.Name = newName;
+			return Watchdog.InstanceRenamed(newName, cancellationToken);
 		}
 
 		/// <inheritdoc />
 		public async Task StartAsync(CancellationToken cancellationToken)
 		{
-			await Task.WhenAll(
+			using (LogContext.PushProperty("Instance", metadata.Id))
+			{
+				await Task.WhenAll(
 				SetAutoUpdateInterval(metadata.AutoUpdateInterval.Value),
 				Configuration.StartAsync(cancellationToken),
 				ByondManager.StartAsync(cancellationToken),
@@ -411,23 +418,27 @@ namespace Tgstation.Server.Host.Components
 				dmbFactory.StartAsync(cancellationToken))
 				.ConfigureAwait(false);
 
-			// dependent on so many things, its just safer this way
-			await Watchdog.StartAsync(cancellationToken).ConfigureAwait(false);
+				// dependent on so many things, its just safer this way
+				await Watchdog.StartAsync(cancellationToken).ConfigureAwait(false);
 
-			await dmbFactory.CleanUnusedCompileJobs(cancellationToken).ConfigureAwait(false);
+				await dmbFactory.CleanUnusedCompileJobs(cancellationToken).ConfigureAwait(false);
+			}
 		}
 
 		/// <inheritdoc />
 		public async Task StopAsync(CancellationToken cancellationToken)
 		{
-			await SetAutoUpdateInterval(0).ConfigureAwait(false);
-			await Watchdog.StopAsync(cancellationToken).ConfigureAwait(false);
-			await Task.WhenAll(
-				Configuration.StopAsync(cancellationToken),
-				ByondManager.StopAsync(cancellationToken),
-				Chat.StopAsync(cancellationToken),
-				dmbFactory.StopAsync(cancellationToken))
-				.ConfigureAwait(false);
+			using (LogContext.PushProperty("Instance", metadata.Id))
+			{
+				await SetAutoUpdateInterval(0).ConfigureAwait(false);
+				await Watchdog.StopAsync(cancellationToken).ConfigureAwait(false);
+				await Task.WhenAll(
+					Configuration.StopAsync(cancellationToken),
+					ByondManager.StopAsync(cancellationToken),
+					Chat.StopAsync(cancellationToken),
+					dmbFactory.StopAsync(cancellationToken))
+					.ConfigureAwait(false);
+			}
 		}
 
 		/// <inheritdoc />

--- a/src/Tgstation.Server.Host/Components/Instance.cs
+++ b/src/Tgstation.Server.Host/Components/Instance.cs
@@ -151,7 +151,7 @@ namespace Tgstation.Server.Host.Components
 		#pragma warning disable CA1502 // TODO: Decomplexify
 		async Task TimerLoop(uint minutes, CancellationToken cancellationToken)
 		{
-			logger.LogTrace("Entering auto-update loop");
+			logger.LogDebug("Entering auto-update loop");
 			while (true)
 				try
 				{

--- a/src/Tgstation.Server.Host/Components/InstanceManager.cs
+++ b/src/Tgstation.Server.Host/Components/InstanceManager.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Tgstation.Server.Api.Models;
 using Tgstation.Server.Host.Components.Interop;
 using Tgstation.Server.Host.Components.Interop.Bridge;
 using Tgstation.Server.Host.Configuration;
@@ -72,7 +73,7 @@ namespace Tgstation.Server.Host.Components
 		readonly ILogger<InstanceManager> logger;
 
 		/// <summary>
-		/// Map of <see cref="Api.Models.Instance.Id"/>s to respective <see cref="IInstance"/>s. Also used as a <see langword="lock"/> <see cref="object"/>.
+		/// Map of instance <see cref="EntityId.Id"/>s to respective <see cref="IInstance"/>s. Also used as a <see langword="lock"/> <see cref="object"/>.
 		/// </summary>
 		readonly IDictionary<long, IInstance> instances;
 

--- a/src/Tgstation.Server.Host/Components/Interop/Bridge/IBridgeHandler.cs
+++ b/src/Tgstation.Server.Host/Components/Interop/Bridge/IBridgeHandler.cs
@@ -1,7 +1,4 @@
-﻿using System.Threading;
-using System.Threading.Tasks;
-
-namespace Tgstation.Server.Host.Components.Interop.Bridge
+﻿namespace Tgstation.Server.Host.Components.Interop.Bridge
 {
 	/// <inheritdoc />
 	interface IBridgeHandler : IBridgeDispatcher
@@ -10,13 +7,5 @@ namespace Tgstation.Server.Host.Components.Interop.Bridge
 		/// The <see cref="DMApiParameters"/> for the <see cref="IBridgeHandler"/>.
 		/// </summary>
 		DMApiParameters DMApiParameters { get; }
-
-		/// <summary>
-		/// Called when the owning <see cref="Instance"/> is renamed.
-		/// </summary>
-		/// <param name="newInstanceName">The new <see cref="Api.Models.Instance.Name"/>.</param>
-		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
-		/// <returns>A <see cref="Task"/> representing the running operation.</returns>
-		Task InstanceRenamed(string newInstanceName, CancellationToken cancellationToken);
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Session/DeadSessionController.cs
+++ b/src/Tgstation.Server.Host/Components/Session/DeadSessionController.cs
@@ -120,5 +120,8 @@ namespace Tgstation.Server.Host.Components.Session
 
 		/// <inheritdoc />
 		public void Resume() => throw new NotSupportedException();
+
+		/// <inheritdoc />
+		public Task InstanceRenamed(string newInstanceName, CancellationToken cancellationToken) => Task.CompletedTask;
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Session/ISessionController.cs
+++ b/src/Tgstation.Server.Host/Components/Session/ISessionController.cs
@@ -10,7 +10,7 @@ namespace Tgstation.Server.Host.Components.Session
 	/// <summary>
 	/// Handles communication with a DreamDaemon <see cref="IProcess"/>
 	/// </summary>
-	interface ISessionController : IProcessBase
+	interface ISessionController : IRenameNotifyee, IProcessBase
 	{
 		/// <summary>
 		/// A <see cref="Task"/> that completes when DreamDaemon starts pumping the windows message queue after loading a .dmb or when it crashes

--- a/src/Tgstation.Server.Host/Components/Session/SessionControllerFactory.cs
+++ b/src/Tgstation.Server.Host/Components/Session/SessionControllerFactory.cs
@@ -123,7 +123,7 @@ namespace Tgstation.Server.Host.Components.Session
 
 			try
 			{
-				socket.Bind(new IPEndPoint(IPAddress.Loopback, port));
+				socket.Bind(new IPEndPoint(IPAddress.Any, port));
 			}
 			catch (Exception ex)
 			{
@@ -326,6 +326,7 @@ namespace Tgstation.Server.Host.Components.Session
 
 						var sessionController = new SessionController(
 							reattachInformation,
+							instance,
 							process,
 							byondLock,
 							byondTopicSender,
@@ -391,6 +392,7 @@ namespace Tgstation.Server.Host.Components.Session
 
 						var controller = new SessionController(
 							reattachInformation,
+							instance,
 							process,
 							byondLock,
 							byondTopicSender,

--- a/src/Tgstation.Server.Host/Components/Watchdog/BasicWatchdog.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/BasicWatchdog.cs
@@ -346,5 +346,9 @@ namespace Tgstation.Server.Host.Components.Watchdog
 			await LaunchNoLock(true, false, null, cancellationToken).ConfigureAwait(false);
 			await chatTask.ConfigureAwait(false);
 		}
+
+		/// <inheritdoc />
+		public sealed override Task InstanceRenamed(string newInstanceName, CancellationToken cancellationToken)
+			=> Server?.InstanceRenamed(newInstanceName, cancellationToken) ?? Task.CompletedTask;
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Watchdog/ExperimentalWatchdog.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/ExperimentalWatchdog.cs
@@ -583,5 +583,11 @@ namespace Tgstation.Server.Host.Components.Watchdog
 				Alpha = alphaServer?.Release(),
 				Bravo = bravoServer?.Release()
 			};
+
+		/// <inheritdoc />
+		public override Task InstanceRenamed(string newInstanceName, CancellationToken cancellationToken)
+			=> Task.WhenAll(
+				alphaServer?.InstanceRenamed(newInstanceName, cancellationToken) ?? Task.CompletedTask,
+				bravoServer?.InstanceRenamed(newInstanceName, cancellationToken) ?? Task.CompletedTask);
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Watchdog/IWatchdog.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/IWatchdog.cs
@@ -11,7 +11,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 	/// <summary>
 	/// Runs and monitors the twin server controllers
 	/// </summary>
-	public interface IWatchdog : IHostedService, IDisposable, IEventConsumer
+	public interface IWatchdog : IHostedService, IDisposable, IEventConsumer, IRenameNotifyee
 	{
 		/// <summary>
 		/// If the watchdog is running

--- a/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
@@ -289,10 +289,10 @@ namespace Tgstation.Server.Host.Components.Watchdog
 				switch (++heartbeatsMissed)
 				{
 					case 1:
-						Logger.LogDebug("DEFCON 4: Watchdog missed first heartbeat!");
+						Logger.LogDebug("DEFCON 4: DreamDaemon missed first heartbeat!");
 						break;
 					case 2:
-						var message2 = "DEFCON 3: Watchdog has missed 2 heartbeats!";
+						var message2 = "DEFCON 3: DreamDaemon has missed 2 heartbeats!";
 						Logger.LogInformation(message2);
 						await Chat.SendWatchdogMessage(message2, true, cancellationToken).ConfigureAwait(false);
 						break;
@@ -300,7 +300,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 						var actionToTake = shouldShutdown
 							? "shutdown"
 							: "be restarted";
-						var message3 = $"DEFCON 2: Watchdog has missed 3 heartbeats! If DreamDaemon does not respond to the next one, the watchdog will {actionToTake}!";
+						var message3 = $"DEFCON 2: DreamDaemon has missed 3 heartbeats! If it does not respond to the next one, the watchdog will {actionToTake}!";
 						Logger.LogWarning(message3);
 						await Chat.SendWatchdogMessage(message3, false, cancellationToken).ConfigureAwait(false);
 						break;

--- a/src/Tgstation.Server.Host/Controllers/BridgeController.cs
+++ b/src/Tgstation.Server.Host/Controllers/BridgeController.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
+using Serilog.Context;
 using System;
 using System.Net;
 using System.Threading;
@@ -19,6 +21,11 @@ namespace Tgstation.Server.Host.Controllers
 	public class BridgeController : Controller
 	{
 		/// <summary>
+		/// Static counter for the number of requests processed.
+		/// </summary>
+		static long requestsProcessed;
+
+		/// <summary>
 		/// The <see cref="IBridgeDispatcher"/> for the <see cref="BridgeController"/>
 		/// </summary>
 		readonly IBridgeDispatcher bridgeDispatcher;
@@ -32,11 +39,17 @@ namespace Tgstation.Server.Host.Controllers
 		/// Initializes a new instance of the <see cref="BridgeController"/> <see langword="class"/>.
 		/// </summary>
 		/// <param name="bridgeDispatcher">The value of <see cref="bridgeDispatcher"/>.</param>
+		/// <param name="applicationLifetime">The <see cref="IHostApplicationLifetime"/> of the server.</param>
 		/// <param name="logger">The value of <see cref="logger"/>.</param>
-		public BridgeController(IBridgeDispatcher bridgeDispatcher, ILogger<BridgeController> logger)
+		public BridgeController(IBridgeDispatcher bridgeDispatcher, IHostApplicationLifetime applicationLifetime, ILogger<BridgeController> logger)
 		{
 			this.bridgeDispatcher = bridgeDispatcher ?? throw new ArgumentNullException(nameof(bridgeDispatcher));
+			if (applicationLifetime == null)
+				throw new ArgumentNullException(nameof(applicationLifetime));
+
 			this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+			applicationLifetime.ApplicationStopped.Register(() => requestsProcessed = 0);
 		}
 
 		/// <summary>
@@ -52,26 +65,29 @@ namespace Tgstation.Server.Host.Controllers
 			if (!IPAddress.IsLoopback(Request.HttpContext.Connection.RemoteIpAddress))
 				return NotFound();
 
-			BridgeParameters request;
-			try
+			using (LogContext.PushProperty("Bridge", Interlocked.Increment(ref requestsProcessed)))
 			{
-				request = JsonConvert.DeserializeObject<BridgeParameters>(data, DMApiConstants.SerializerSettings);
+				BridgeParameters request;
+				try
+				{
+					request = JsonConvert.DeserializeObject<BridgeParameters>(data, DMApiConstants.SerializerSettings);
+				}
+				catch
+				{
+					logger.LogWarning("Error deserializing bridge request: {0}", data);
+					return BadRequest();
+				}
+
+				logger.LogTrace("Bridge Request: {0}", data);
+
+				var response = await bridgeDispatcher.ProcessBridgeRequest(request, cancellationToken).ConfigureAwait(false);
+				if (response == null)
+					Forbid();
+
+				var responseJson = JsonConvert.SerializeObject(response, DMApiConstants.SerializerSettings);
+				logger.LogTrace("Bridge Response: {0}", responseJson);
+				return Content(responseJson, ApiHeaders.ApplicationJson);
 			}
-			catch
-			{
-				logger.LogWarning("Error deserializing bridge request: {0}", data);
-				return BadRequest();
-			}
-
-			logger.LogTrace("Bridge Request: {0}", data);
-
-			var response = await bridgeDispatcher.ProcessBridgeRequest(request, cancellationToken).ConfigureAwait(false);
-			if (response == null)
-				Forbid();
-
-			var responseJson = JsonConvert.SerializeObject(response, DMApiConstants.SerializerSettings);
-			logger.LogTrace("Bridge Response: {0}", responseJson);
-			return Content(responseJson, ApiHeaders.ApplicationJson);
 		}
 	}
 }

--- a/src/Tgstation.Server.Host/Controllers/InstanceController.cs
+++ b/src/Tgstation.Server.Host/Controllers/InstanceController.cs
@@ -308,7 +308,7 @@ namespace Tgstation.Server.Host.Controllers
 		/// <summary>
 		/// Detach an <see cref="Api.Models.Instance"/> with the given <paramref name="id"/>.
 		/// </summary>
-		/// <param name="id">The <see cref="Api.Models.Instance.Id"/> to detach.</param>
+		/// <param name="id">The <see cref="EntityId.Id"/> of the instance to detach.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> of the request.</returns>
 		/// <response code="204">Instance detatched successfully.</response>
@@ -475,7 +475,7 @@ namespace Tgstation.Server.Host.Controllers
 			await DatabaseContext.Save(cancellationToken).ConfigureAwait(false);
 
 			if (renamed)
-				instanceManager.GetInstance(originalModel).Rename(originalModel.Name);
+				await instanceManager.GetInstance(originalModel).InstanceRenamed(originalModel.Name, cancellationToken).ConfigureAwait(false);
 
 			var oldAutoStart = originalModel.DreamDaemonSettings.AutoStart;
 			try
@@ -582,7 +582,7 @@ namespace Tgstation.Server.Host.Controllers
 		/// <summary>
 		/// Get a specific <see cref="Api.Models.Instance"/>.
 		/// </summary>
-		/// <param name="id">The <see cref="Api.Models.Instance.Id"/> to retrieve.</param>
+		/// <param name="id">The instance <see cref="EntityId.Id"/> to retrieve.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> of the request.</returns>
 		/// <response code="200">Retrieved <see cref="Api.Models.Instance"/> successfully.</response>

--- a/src/Tgstation.Server.Host/Core/Application.cs
+++ b/src/Tgstation.Server.Host/Core/Application.cs
@@ -136,7 +136,7 @@ namespace Tgstation.Server.Host.Core
 						"{Timestamp:o} {RequestId,13} [{Level:u3}] {SourceContext:l}: {Message} ({EventId:x8}){NewLine}{Exception}",
 						null);
 
-					logPath = IOManager.ConcatPath(logPath, "tgs-{Date}.log");
+					logPath = IOManager.ConcatPath(logPath, "tgs-.log");
 					var rollingFileConfig = sinkConfig.File(
 						formatter,
 						logPath,

--- a/src/Tgstation.Server.Host/Core/Application.cs
+++ b/src/Tgstation.Server.Host/Core/Application.cs
@@ -167,6 +167,7 @@ namespace Tgstation.Server.Host.Core
 				};
 			});
 
+			// WARNING: STATIC CODE
 			// fucking prevents converting 'sub' to M$ bs
 			// can't be done in the above lambda, that's too late
 			JwtSecurityTokenHandler.DefaultInboundClaimTypeMap.Clear();

--- a/src/Tgstation.Server.Host/Core/Application.cs
+++ b/src/Tgstation.Server.Host/Core/Application.cs
@@ -133,7 +133,9 @@ namespace Tgstation.Server.Host.Core
 					var logEventLevel = ConvertSeriLogLevel(postSetupServices.FileLoggingConfiguration.LogLevel);
 
 					var formatter = new MessageTemplateTextFormatter(
-						"{Timestamp:o} {RequestId,13} [{Level:u3}] {SourceContext:l}: {Message} ({EventId:x8}){NewLine}{Exception}",
+						"{Timestamp:o} "
+						+ ServiceCollectionExtensions.SerilogContextTemplate
+						+ ": [{Level:u3}] {SourceContext:l}: {Message} ({EventId:x8}){NewLine}{Exception}",
 						null);
 
 					logPath = IOManager.ConcatPath(logPath, "tgs-.log");

--- a/src/Tgstation.Server.Host/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Tgstation.Server.Host/Extensions/ServiceCollectionExtensions.cs
@@ -16,6 +16,11 @@ namespace Tgstation.Server.Host.Extensions
 	static class ServiceCollectionExtensions
 	{
 		/// <summary>
+		/// Common template used for adding our custom log context to serilog.
+		/// </summary>
+		public const string SerilogContextTemplate = "(Instance:{Instance}|Job:{Job}|Request:{Request}|User:{User}|Monitor:{Monitor}|Bridge:{Bridge}|Chat:{ChatMessage})";
+
+		/// <summary>
 		/// Add a standard <typeparamref name="TConfig"/> binding
 		/// </summary>
 		/// <typeparam name="TConfig">The <see langword="class"/> to bind. Must have a <see langword="public"/> const/static <see cref="string"/> field named "Section"</typeparam>
@@ -67,11 +72,14 @@ namespace Tgstation.Server.Host.Extensions
 				configurationAction?.Invoke(configuration);
 
 				configuration
+					.Enrich.FromLogContext()
 					.WriteTo
 					.Async(sinkConfiguration =>
 					{
 						sinkConfiguration.Console(
-							outputTemplate: "[{Timestamp:HH:mm:ss}] {Level:w3}: {SourceContext:l}{NewLine}    {Message:lj}{NewLine}{Exception}");
+							outputTemplate: "[{Timestamp:HH:mm:ss}] {Level:w3}: {SourceContext:l} "
+								+ SerilogContextTemplate
+								+ "{NewLine}    {Message:lj}{NewLine}{Exception}");
 						sinkConfigurationAction?.Invoke(sinkConfiguration);
 					});
 

--- a/src/Tgstation.Server.Host/Models/ChatBot.cs
+++ b/src/Tgstation.Server.Host/Models/ChatBot.cs
@@ -13,7 +13,7 @@ namespace Tgstation.Server.Host.Models
 		public const ushort DefaultChannelLimit = 100;
 
 		/// <summary>
-		/// The <see cref="Api.Models.Instance.Id"/>
+		/// The instance <see cref="Api.Models.EntityId.Id"/>
 		/// </summary>
 		public long InstanceId { get; set; }
 

--- a/src/Tgstation.Server.Host/Models/DreamDaemonSettings.cs
+++ b/src/Tgstation.Server.Host/Models/DreamDaemonSettings.cs
@@ -11,7 +11,7 @@ namespace Tgstation.Server.Host.Models
 		public long Id { get; set; }
 
 		/// <summary>
-		/// The <see cref="Api.Models.Instance.Id"/>
+		/// The <see cref="Api.Models.EntityId.Id"/>
 		/// </summary>
 		public long InstanceId { get; set; }
 

--- a/src/Tgstation.Server.Host/Models/DreamMakerSettings.cs
+++ b/src/Tgstation.Server.Host/Models/DreamMakerSettings.cs
@@ -11,7 +11,7 @@ namespace Tgstation.Server.Host.Models
 		public long Id { get; set; }
 
 		/// <summary>
-		/// The <see cref="Api.Models.Instance.Id"/>
+		/// The instance <see cref="Api.Models.EntityId.Id"/>
 		/// </summary>
 		public long InstanceId { get; set; }
 

--- a/src/Tgstation.Server.Host/Models/DualReattachInformation.cs
+++ b/src/Tgstation.Server.Host/Models/DualReattachInformation.cs
@@ -11,7 +11,7 @@
 		public long Id { get; set; }
 
 		/// <summary>
-		/// The <see cref="Api.Models.Instance.Id"/> of the <see cref="Instance"/> the <see cref="DualReattachInformation"/> belongs to
+		/// The <see cref="Api.Models.EntityId.Id"/> of the <see cref="Instance"/> the <see cref="DualReattachInformation"/> belongs to
 		/// </summary>
 		public long InstanceId { get; set; }
 

--- a/src/Tgstation.Server.Host/Models/InstanceUser.cs
+++ b/src/Tgstation.Server.Host/Models/InstanceUser.cs
@@ -11,7 +11,7 @@ namespace Tgstation.Server.Host.Models
 		public long Id { get; set; }
 
 		/// <summary>
-		/// The <see cref="Api.Models.Instance.Id"/> of <see cref="Instance"/>
+		/// The <see cref="Api.Models.EntityId.Id"/> of <see cref="Instance"/>
 		/// </summary>
 		public long InstanceId { get; set; }
 

--- a/src/Tgstation.Server.Host/Models/RepositorySettings.cs
+++ b/src/Tgstation.Server.Host/Models/RepositorySettings.cs
@@ -12,7 +12,7 @@ namespace Tgstation.Server.Host.Models
 		public long Id { get; set; }
 
 		/// <summary>
-		/// The <see cref="Api.Models.Instance.Id"/>
+		/// The instance <see cref="EntityId.Id"/>
 		/// </summary>
 		public long InstanceId { get; set; }
 

--- a/src/Tgstation.Server.Host/Models/RevisionInformation.cs
+++ b/src/Tgstation.Server.Host/Models/RevisionInformation.cs
@@ -13,7 +13,7 @@ namespace Tgstation.Server.Host.Models
 		public long Id { get; set; }
 
 		/// <summary>
-		/// The <see cref="Api.Models.Instance.Id"/>
+		/// The instance <see cref="Api.Models.EntityId.Id"/>
 		/// </summary>
 		public long InstanceId { get; set; }
 

--- a/src/Tgstation.Server.Host/Security/IAuthenticationContextFactory.cs
+++ b/src/Tgstation.Server.Host/Security/IAuthenticationContextFactory.cs
@@ -18,7 +18,7 @@ namespace Tgstation.Server.Host.Security
 		/// Create an <see cref="IAuthenticationContext"/> to populate <see cref="CurrentAuthenticationContext"/>
 		/// </summary>
 		/// <param name="userId">The <see cref="Api.Models.Internal.User.Id"/> of the <see cref="IAuthenticationContext.User"/></param>
-		/// <param name="instanceId">The <see cref="Api.Models.Instance.Id"/> of the operation</param>
+		/// <param name="instanceId">The <see cref="Api.Models.EntityId.Id"/> of the operation</param>
 		/// <param name="validAfter">The <see cref="DateTimeOffset"/> the resulting <see cref="IAuthenticationContext.User"/>'s password must be valid after</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="Task"/> representing the running operation</returns>

--- a/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
+++ b/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
@@ -68,7 +68,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.3" />
-    <PackageReference Include="Octokit" Version="0.47.0" />
+    <PackageReference Include="Octokit" Version="0.48.0" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="3.1.1" />
     <!-- If this is updated, be sure to update the reference in the README.md -->
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />


### PR DESCRIPTION
:cl:
Fixed log files containing the string `{Date}`.
Fixed detection of services running on requested DreamDaemon port.
Fixed the DMAPI not being notified of instance renaming.
Fixed being unable to repeatedly change the auto update interval.
Heavily enriched log message context.
/:cl: