### PR TITLE
v4.3.3

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- This is the authorative version list -->
     <!-- Integration tests will ensure they match across the board -->
-    <TgsCoreVersion>4.3.2</TgsCoreVersion>
+    <TgsCoreVersion>4.3.3</TgsCoreVersion>
     <TgsApiVersion>6.6.0</TgsApiVersion>
     <TgsClientVersion>7.2.0</TgsClientVersion>
     <TgsDmapiVersion>5.2.2</TgsDmapiVersion>

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordProvider.cs
@@ -177,7 +177,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		}
 
 		/// <inheritdoc />
-		public override async Task Disconnect(CancellationToken cancellationToken)
+		protected override async Task DisconnectImpl(CancellationToken cancellationToken)
 		{
 			Logger.LogTrace("Disconnecting...");
 			if (!Connected)

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/IProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/IProvider.cs
@@ -37,7 +37,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		Task<bool> Connect(CancellationToken cancellationToken);
 
 		/// <summary>
-		/// Gracefully disconnects the provider. Implies a call to <see cref="IDisposable.Dispose"/>
+		/// Gracefully disconnects the provider. Permanently stops the reconnection timer.
 		/// </summary>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="Task"/> representing the running operation</returns>

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/IrcProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/IrcProvider.cs
@@ -346,7 +346,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		}, cancellationToken, TaskCreationOptions.LongRunning, TaskScheduler.Current);
 
 		/// <inheritdoc />
-		public override async Task Disconnect(CancellationToken cancellationToken)
+		protected override async Task DisconnectImpl(CancellationToken cancellationToken)
 		{
 			if (!Connected)
 				return;

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/Provider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/Provider.cs
@@ -87,8 +87,19 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		/// <inheritdoc />
 		public abstract Task<bool> Connect(CancellationToken cancellationToken);
 
+		/// <summary>
+		/// Gracefully disconnects the provider.
+		/// </summary>
+		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
+		/// <returns>A <see cref="Task"/> representing the running operation.</returns>
+		protected abstract Task DisconnectImpl(CancellationToken cancellationToken);
+
 		/// <inheritdoc />
-		public abstract Task Disconnect(CancellationToken cancellationToken);
+		public async Task Disconnect(CancellationToken cancellationToken)
+		{
+			await StopReconnectionTimer().ConfigureAwait(false);
+			await DisconnectImpl(cancellationToken).ConfigureAwait(false);
+		}
 
 		/// <inheritdoc />
 		public abstract Task<IReadOnlyCollection<ChannelRepresentation>> MapChannels(IEnumerable<Api.Models.ChatChannel> channels, CancellationToken cancellationToken);

--- a/src/Tgstation.Server.Host/Controllers/ChatController.cs
+++ b/src/Tgstation.Server.Host/Controllers/ChatController.cs
@@ -197,7 +197,7 @@ namespace Tgstation.Server.Host.Controllers
 		{
 			var query = DatabaseContext.ChatBots
 				.AsQueryable()
-				.Where(x => x.Id == id)
+				.Where(x => x.Id == id && x.InstanceId == Instance.Id)
 				.Include(x => x.Channels);
 
 			var results = await query.FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
:cl:
You can no longer read chat bots from an instance other than the one in your request headers.
Fixed a hang that could occur if a chat bot attempted to reconnect at the same time an instance was being offlined.
/:cl: