### PR TITLE
Add instance user restore permission

### DIFF
--- a/src/Tgstation.Server.Api/Models/ErrorCode.cs
+++ b/src/Tgstation.Server.Api/Models/ErrorCode.cs
@@ -531,5 +531,11 @@ namespace Tgstation.Server.Api.Models
 		/// </summary>
 		[Description("Could not create dump as gcore exited with a non-zero exit code!")]
 		GCoreFailure,
+
+		/// <summary>
+		/// Attempted to test merge with an invalid remote repository.
+		/// </summary>
+		[Description("Test merging cannot be performed with this remote!")]
+		RepoTestMergeInvalidRemote,
 	}
 }

--- a/src/Tgstation.Server.Api/Rights/InstanceManagerRights.cs
+++ b/src/Tgstation.Server.Api/Rights/InstanceManagerRights.cs
@@ -61,6 +61,11 @@ namespace Tgstation.Server.Api.Rights
 		/// <summary>
 		/// User can change <see cref="Models.Instance.ChatBotLimit"/>.
 		/// </summary>
-		SetChatBotLimit = 512
+		SetChatBotLimit = 512,
+
+		/// <summary>
+		/// User can give themselves full <see cref="Models.InstanceUser"/> rights on instances.
+		/// </summary>
+		GrantPermissions = 1024,
 	}
 }

--- a/src/Tgstation.Server.Client/ApiClient.cs
+++ b/src/Tgstation.Server.Client/ApiClient.cs
@@ -236,6 +236,9 @@ namespace Tgstation.Server.Client
 		public Task<TResult> Update<TBody, TResult>(string route, TBody body, CancellationToken cancellationToken) => RunRequest<TResult>(route, body, HttpMethod.Post, null, false, cancellationToken);
 
 		/// <inheritdoc />
+		public Task Patch(string route, CancellationToken cancellationToken) => RunRequest<object>(route, null, HttpMethod.Patch, null, false, cancellationToken);
+
+		/// <inheritdoc />
 		public Task Update<TBody>(string route, TBody body, CancellationToken cancellationToken) => RunRequest<object>(route, body, HttpMethod.Post, null, false, cancellationToken);
 
 		/// <inheritdoc />

--- a/src/Tgstation.Server.Client/IApiClient.cs
+++ b/src/Tgstation.Server.Client/IApiClient.cs
@@ -91,6 +91,14 @@ namespace Tgstation.Server.Client
 		Task Update<TBody>(string route, TBody body, CancellationToken cancellationToken);
 
 		/// <summary>
+		/// Run an HTTP PATCH request.
+		/// </summary>
+		/// <param name="route">The server route to make the request to.</param>
+		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
+		/// <returns>A <see cref="Task"/> representing the running operation.</returns>
+		Task Patch(string route, CancellationToken cancellationToken);
+
+		/// <summary>
 		/// Run an HTTP DELETE request
 		/// </summary>
 		/// <param name="route">The server route to make the request to</param>

--- a/src/Tgstation.Server.Client/IInstanceManagerClient.cs
+++ b/src/Tgstation.Server.Client/IInstanceManagerClient.cs
@@ -51,6 +51,14 @@ namespace Tgstation.Server.Client
 		Task Detach(Instance instance, CancellationToken cancellationToken);
 
 		/// <summary>
+		/// Gives the user full permissions on an <paramref name="instance"/>.
+		/// </summary>
+		/// <param name="instance">The <see cref="Instance"/> to grant permissions on.</param>
+		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
+		/// <returns>A <see cref="Task"/> representing the running operation.</returns>
+		Task GrantPermissions(Instance instance, CancellationToken cancellationToken);
+
+		/// <summary>
 		/// Create an <see cref="IInstanceClient"/> for a given <see cref="Instance"/>
 		/// </summary>
 		/// <param name="instance">The <see cref="Instance"/> to create an <see cref="IInstanceClient"/> for</param>

--- a/src/Tgstation.Server.Client/InstanceManagerClient.cs
+++ b/src/Tgstation.Server.Client/InstanceManagerClient.cs
@@ -48,6 +48,9 @@ namespace Tgstation.Server.Client
 		public Task<Instance> GetId(Instance instance, CancellationToken cancellationToken) => apiClient.Read<Instance>(Routes.SetID(Routes.InstanceManager, instance?.Id ?? throw new ArgumentNullException(nameof(instance))), cancellationToken);
 
 		/// <inheritdoc />
+		public Task GrantPermissions(Instance instance, CancellationToken cancellationToken) => apiClient.Patch(Routes.SetID(Routes.InstanceManager, instance?.Id ?? throw new ArgumentNullException(nameof(instance))), cancellationToken);
+
+		/// <inheritdoc />
 		public IInstanceClient CreateClient(Instance instance)
 		{
 			if (!cachedClients.TryGetValue(instance?.Id ?? throw new ArgumentNullException(nameof(instance)), out var client))

--- a/src/Tgstation.Server.Host/Components/Repository/Repository.cs
+++ b/src/Tgstation.Server.Host/Components/Repository/Repository.cs
@@ -274,7 +274,7 @@ namespace Tgstation.Server.Host.Components.Repository
 				committerEmail);
 
 			if (!IsGitHubRepository)
-				throw new InvalidOperationException("Test merging is only available on GitHub hosted origin repositories!");
+				throw new JobException(ErrorCode.RepoTestMergeInvalidRemote);
 
 			var commitMessage = String.Format(
 				CultureInfo.InvariantCulture,

--- a/src/Tgstation.Server.Host/Core/Application.cs
+++ b/src/Tgstation.Server.Host/Core/Application.cs
@@ -211,7 +211,7 @@ namespace Tgstation.Server.Host.Core
 				// HACK HACK HACK HACK HACK
 				const string ConfigureMethodName = nameof(SqlServerDatabaseContext.ConfigureWith);
 				var configureFunction = typeof(TContext).GetMethod(
-					nameof(SqlServerDatabaseContext.ConfigureWith),
+					ConfigureMethodName,
 					BindingFlags.Public | BindingFlags.Static);
 
 				if (configureFunction == null)

--- a/src/Tgstation.Server.Host/appsettings.json
+++ b/src/Tgstation.Server.Host/appsettings.json
@@ -1,6 +1,5 @@
 ﻿{
   "General": {
-    "ApiPort": 5000,
     "MinimumPasswordLength": 15,
     "GitHubAccessToken": null,
     "SetupWizardMode": "AutoDetect",
@@ -30,6 +29,13 @@
       "LogLevel": {
         "Default": "Trace",
         "Microsoft": "Warning"
+      }
+    }
+  },
+  "Kestrel": {
+    "EndPoints": {
+      "Http": {
+        "Url": "http://0.0.0.0:80"
       }
     }
   },

--- a/tests/Tgstation.Server.Tests/Instance/RepositoryTest.cs
+++ b/tests/Tgstation.Server.Tests/Instance/RepositoryTest.cs
@@ -80,26 +80,26 @@ namespace Tgstation.Server.Tests.Instance
 
 			// checkout V3 and back
 			cloned.Reference = "V3";
-			var updated = await Checkout(cloned, false, true, true, cancellationToken);
+			var updated = await Checkout(cloned, false, true, cancellationToken);
 
 			// Specific SHA
 			updated.CheckoutSha = "f43f5bd";
-			await ApiAssert.ThrowsException<ApiConflictException>(() => Checkout(updated, false, false, false, cancellationToken), ErrorCode.RepoMismatchShaAndReference);
+			await ApiAssert.ThrowsException<ApiConflictException>(() => Checkout(updated, false, false, cancellationToken), ErrorCode.RepoMismatchShaAndReference);
 			updated.Reference = null;
-			updated = await Checkout(updated, false, false, false, cancellationToken);
+			updated = await Checkout(updated, false, false, cancellationToken);
 
 			// Fake SHA
 			updated.Reference = null;
 			updated.CheckoutSha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-			updated = await Checkout(updated, true, false, false, cancellationToken);
+			updated = await Checkout(updated, true, false, cancellationToken);
 
 			// Fake ref
 			updated.Reference = "Tgs4IntegrationTestFakeBranchNeverNameABranchThis";
-			updated = await Checkout(updated, true, true, false, cancellationToken);
+			updated = await Checkout(updated, true, true, cancellationToken);
 
 			// Back
 			updated.Reference = workingBranch;
-			updated = await Checkout(updated, false, true, false, cancellationToken);
+			updated = await Checkout(updated, false, true, cancellationToken);
 
 			var testPRString = Environment.GetEnvironmentVariable("TGS4_TEST_PULL_REQUEST_NUMBER");
 			if (String.IsNullOrWhiteSpace(testPRString))
@@ -118,13 +118,11 @@ namespace Tgstation.Server.Tests.Instance
 			await TestMergeTests(updated, prNumber, cancellationToken);
 		}
 
-		async Task<Repository> Checkout(Repository updated, bool expectFailure, bool isRef, bool checkBusy, CancellationToken cancellationToken)
+		async Task<Repository> Checkout(Repository updated, bool expectFailure, bool isRef, CancellationToken cancellationToken)
 		{
 			var newRef = isRef ? updated.Reference : updated.CheckoutSha;
 			var checkingOut = await repositoryClient.Update(updated, cancellationToken);
 			Assert.IsNotNull(checkingOut.ActiveJob);
-			if(checkBusy)
-				await ApiAssert.ThrowsException<ConflictException>(() => repositoryClient.Read(cancellationToken), ErrorCode.RepoBusy);
 
 			await WaitForJob(checkingOut.ActiveJob, 30, expectFailure, cancellationToken);
 			var result = await repositoryClient.Read(cancellationToken);

--- a/tests/Tgstation.Server.Tests/InstanceManagerTest.cs
+++ b/tests/Tgstation.Server.Tests/InstanceManagerTest.cs
@@ -143,11 +143,13 @@ namespace Tgstation.Server.Tests
 
 			await Assert.ThrowsExceptionAsync<InsufficientPermissionsException>(() => instanceClient.Users.Read(cancellationToken)).ConfigureAwait(false);
 
-			await instanceManagerClient.Update(new Api.Models.Instance
+			await instanceManagerClient.GrantPermissions(new Api.Models.Instance
 			{
 				Id = firstTest.Id
 			}, cancellationToken).ConfigureAwait(false);
 			ourInstanceUser = await instanceClient.Users.Read(cancellationToken).ConfigureAwait(false);
+
+			Assert.AreEqual(RightsHelper.AllRights<DreamDaemonRights>(), ourInstanceUser.DreamDaemonRights.Value);
 
 			//can't detach online instance
 			await ApiAssert.ThrowsException<ConflictException>(() => instanceManagerClient.Detach(firstTest, cancellationToken), ErrorCode.InstanceDetachOnline).ConfigureAwait(false);


### PR DESCRIPTION
:cl: HTTP API
POST /Instance will no longer create/grant instance user permissions on that instance for the current user.
PATCH /Instance/{id} will now give full instance user permissions on the target instance. This uses the new instance manager right 1024.
Added error code 87 for attempting to test merge with an unsupported remote. Currently the only supported remote is GitHub.com.
/:cl:

Closes #1009 