### PR TITLE
Add event for watchdog launches

### DIFF
--- a/src/DMAPI/tgs.dm
+++ b/src/DMAPI/tgs.dm
@@ -95,6 +95,8 @@
 #define TGS_EVENT_WATCHDOG_SHUTDOWN 15
 /// Before the watchdog detaches for a TGS update/restart. No parameters.
 #define TGS_EVENT_WATCHDOG_DETACH 16
+// We don't actually implement this value as the DMAPI can never receive it
+// #define TGS_EVENT_WATCHDOG_LAUNCH 17
 
 // OTHER ENUMS
 

--- a/src/Tgstation.Server.Client/Components/InstanceClient.cs
+++ b/src/Tgstation.Server.Client/Components/InstanceClient.cs
@@ -34,18 +34,15 @@ namespace Tgstation.Server.Client.Components
 		public IJobsClient Jobs { get; }
 
 		/// <summary>
-		/// The <see cref="IApiClient"/> for the <see cref="InstanceClient"/>
-		/// </summary>
-		readonly IApiClient apiClient;
-
-		/// <summary>
 		/// Construct a <see cref="InstanceClient"/>
 		/// </summary>
-		/// <param name="apiClient">The value of <see cref="apiClient"/></param>
+		/// <param name="apiClient">The <see cref="IApiClient"/> used to construct component clients.</param>
 		/// <param name="instance">The value of <see cref="Metadata"/></param>
 		public InstanceClient(IApiClient apiClient, Instance instance)
 		{
-			this.apiClient = apiClient ?? throw new ArgumentNullException(nameof(apiClient));
+			if (apiClient == null)
+				throw new ArgumentNullException(nameof(apiClient));
+
 			Metadata = instance ?? throw new ArgumentNullException(nameof(instance));
 
 			Byond = new ByondClient(apiClient, instance);

--- a/src/Tgstation.Server.Host/Components/Events/EventType.cs
+++ b/src/Tgstation.Server.Host/Components/Events/EventType.cs
@@ -106,5 +106,11 @@
 		/// </summary>
 		[EventScript("WatchdogDetach")]
 		WatchdogDetach,
+
+		/// <summary>
+		/// Before the watchdog launches. No parameters.
+		/// </summary>
+		[EventScript("WatchdogLaunch")]
+		WatchdogLaunch
 	}
 }

--- a/src/Tgstation.Server.Host/Components/InstanceFactory.cs
+++ b/src/Tgstation.Server.Host/Components/InstanceFactory.cs
@@ -250,6 +250,7 @@ namespace Tgstation.Server.Host.Components
 							sessionControllerFactory,
 							gameIoManager,
 							diagnosticsIOManager,
+							eventConsumer,
 							metadata.CloneMetadata(),
 							metadata.DreamDaemonSettings);
 						eventConsumer.SetWatchdog(watchdog);

--- a/src/Tgstation.Server.Host/Components/Watchdog/BasicWatchdog.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/BasicWatchdog.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Tgstation.Server.Api.Models.Internal;
 using Tgstation.Server.Host.Components.Chat;
 using Tgstation.Server.Host.Components.Deployment;
+using Tgstation.Server.Host.Components.Events;
 using Tgstation.Server.Host.Components.Session;
 using Tgstation.Server.Host.Core;
 using Tgstation.Server.Host.Database;
@@ -51,6 +52,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 		/// <param name="serverControl">The <see cref="IServerControl"/> for the <see cref="WatchdogBase"/>.</param>
 		/// <param name="asyncDelayer">The <see cref="IAsyncDelayer"/> for the <see cref="WatchdogBase"/>.</param>
 		/// <param name="diagnosticsIOManager">The <see cref="IIOManager"/> for the <see cref="WatchdogBase"/>.</param>
+		/// <param name="eventConsumer">The <see cref="IEventConsumer"/> for the <see cref="WatchdogBase"/>.</param>
 		/// <param name="logger">The <see cref="ILogger"/> for the <see cref="WatchdogBase"/>.</param>
 		/// <param name="initialLaunchParameters">The <see cref="DreamDaemonLaunchParameters"/> for the <see cref="WatchdogBase"/>.</param>
 		/// <param name="instance">The <see cref="Api.Models.Instance"/> for the <see cref="WatchdogBase"/>.</param>
@@ -65,6 +67,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 			IServerControl serverControl,
 			IAsyncDelayer asyncDelayer,
 			IIOManager diagnosticsIOManager,
+			IEventConsumer eventConsumer,
 			ILogger<BasicWatchdog> logger,
 			DreamDaemonLaunchParameters initialLaunchParameters,
 			Api.Models.Instance instance,
@@ -79,6 +82,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 				 serverControl,
 				 asyncDelayer,
 				 diagnosticsIOManager,
+				 eventConsumer,
 				 logger,
 				 initialLaunchParameters,
 				 instance,

--- a/src/Tgstation.Server.Host/Components/Watchdog/ExperimentalWatchdog.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/ExperimentalWatchdog.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Tgstation.Server.Api.Models.Internal;
 using Tgstation.Server.Host.Components.Chat;
 using Tgstation.Server.Host.Components.Deployment;
+using Tgstation.Server.Host.Components.Events;
 using Tgstation.Server.Host.Components.Session;
 using Tgstation.Server.Host.Core;
 using Tgstation.Server.Host.Database;
@@ -62,6 +63,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 		/// <param name="serverControl">The <see cref="IServerControl"/> for the <see cref="WatchdogBase"/>.</param>
 		/// <param name="asyncDelayer">The <see cref="IAsyncDelayer"/> for the <see cref="WatchdogBase"/>.</param>
 		/// <param name="diagnosticsIOManager">The <see cref="IIOManager"/> for the <see cref="WatchdogBase"/>.</param>
+		/// <param name="eventConsumer">The <see cref="IEventConsumer"/> for the <see cref="WatchdogBase"/>.</param>
 		/// <param name="logger">The <see cref="ILogger"/> for the <see cref="WatchdogBase"/>.</param>
 		/// <param name="initialLaunchParameters">The <see cref="DreamDaemonLaunchParameters"/> for the <see cref="WatchdogBase"/>.</param>
 		/// <param name="instance">The <see cref="Api.Models.Instance"/> for the <see cref="WatchdogBase"/>.</param>
@@ -76,6 +78,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 			IServerControl serverControl,
 			IAsyncDelayer asyncDelayer,
 			IIOManager diagnosticsIOManager,
+			IEventConsumer eventConsumer,
 			ILogger<ExperimentalWatchdog> logger,
 			DreamDaemonLaunchParameters initialLaunchParameters,
 			Api.Models.Instance instance, bool autoStart)
@@ -89,6 +92,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 				 serverControl,
 				 asyncDelayer,
 				 diagnosticsIOManager,
+				 eventConsumer,
 				 logger,
 				 initialLaunchParameters,
 				 instance,

--- a/src/Tgstation.Server.Host/Components/Watchdog/IWatchdogFactory.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/IWatchdogFactory.cs
@@ -1,6 +1,7 @@
 ﻿using Tgstation.Server.Api.Models.Internal;
 using Tgstation.Server.Host.Components.Chat;
 using Tgstation.Server.Host.Components.Deployment;
+using Tgstation.Server.Host.Components.Events;
 using Tgstation.Server.Host.Components.Session;
 using Tgstation.Server.Host.IO;
 
@@ -20,6 +21,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 		/// <param name="sessionControllerFactory">The <see cref="ISessionControllerFactory"/> for the <see cref="IWatchdog"/></param>
 		/// <param name="gameIOManager">The <see cref="IIOManager"/> pointing to the Game directory for the <see cref="IWatchdog"/>.</param>
 		/// <param name="diagnosticsIOManager">The <see cref="IIOManager"/> pointing to the Diagnostics directory for the <see cref="IWatchdog"/>.</param>
+		/// <param name="eventConsumer">The <see cref="IEventConsumer"/> for the <see cref="IWatchdog"/>.</param>
 		/// <param name="instance">The <see cref="Instance"/> for the <see cref="IWatchdog"/></param>
 		/// <param name="settings">The initial <see cref="DreamDaemonSettings"/> for the <see cref="IWatchdog"/></param>
 		/// <returns>A new <see cref="IWatchdog"/></returns>
@@ -30,6 +32,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 			ISessionControllerFactory sessionControllerFactory,
 			IIOManager gameIOManager,
 			IIOManager diagnosticsIOManager,
+			IEventConsumer eventConsumer,
 			Api.Models.Instance instance,
 			DreamDaemonSettings settings);
 	}

--- a/src/Tgstation.Server.Host/Components/Watchdog/WatchdogFactory.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/WatchdogFactory.cs
@@ -4,6 +4,7 @@ using System;
 using Tgstation.Server.Api.Models.Internal;
 using Tgstation.Server.Host.Components.Chat;
 using Tgstation.Server.Host.Components.Deployment;
+using Tgstation.Server.Host.Components.Events;
 using Tgstation.Server.Host.Components.Session;
 using Tgstation.Server.Host.Configuration;
 using Tgstation.Server.Host.Core;
@@ -79,6 +80,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 			ISessionControllerFactory sessionControllerFactory,
 			IIOManager gameIOManager,
 			IIOManager diagnosticsIOManager,
+			IEventConsumer eventConsumer,
 			Api.Models.Instance instance,
 			DreamDaemonSettings settings)
 		{
@@ -93,6 +95,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 					ServerControl,
 					AsyncDelayer,
 					diagnosticsIOManager,
+					eventConsumer,
 					LoggerFactory.CreateLogger<ExperimentalWatchdog>(),
 					settings,
 					instance,
@@ -105,6 +108,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 				sessionControllerFactory,
 				gameIOManager,
 				diagnosticsIOManager,
+				eventConsumer,
 				instance,
 				settings);
 		}
@@ -118,6 +122,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 		/// <param name="sessionControllerFactory">The <see cref="ISessionControllerFactory"/> for the <see cref="IWatchdog"/></param>
 		/// <param name="gameIOManager">The <see cref="IIOManager"/> pointing to the Game directory for the <see cref="IWatchdog"/>.</param>
 		/// <param name="diagnosticsIOManager">The <see cref="IIOManager"/> pointing to the Diagnostics directory for the <see cref="IWatchdog"/>.</param>
+		/// <param name="eventConsumer">The <see cref="IEventConsumer"/> for the <see cref="IWatchdog"/>.</param>
 		/// <param name="instance">The <see cref="Instance"/> for the <see cref="IWatchdog"/></param>
 		/// <param name="settings">The initial <see cref="DreamDaemonSettings"/> for the <see cref="IWatchdog"/></param>
 		/// <returns>A new <see cref="IWatchdog"/></returns>
@@ -128,6 +133,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 			ISessionControllerFactory sessionControllerFactory,
 			IIOManager gameIOManager,
 			IIOManager diagnosticsIOManager,
+			IEventConsumer eventConsumer,
 			Api.Models.Instance instance,
 			DreamDaemonSettings settings)
 			=> new BasicWatchdog(
@@ -140,6 +146,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 				ServerControl,
 				AsyncDelayer,
 				diagnosticsIOManager,
+				eventConsumer,
 				LoggerFactory.CreateLogger<BasicWatchdog>(),
 				settings,
 				instance,

--- a/src/Tgstation.Server.Host/Components/Watchdog/WindowsWatchdog.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/WindowsWatchdog.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Tgstation.Server.Api.Models.Internal;
 using Tgstation.Server.Host.Components.Chat;
 using Tgstation.Server.Host.Components.Deployment;
+using Tgstation.Server.Host.Components.Events;
 using Tgstation.Server.Host.Components.Session;
 using Tgstation.Server.Host.Core;
 using Tgstation.Server.Host.Database;
@@ -55,6 +56,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 		/// <param name="serverControl">The <see cref="IServerControl"/> for the <see cref="WatchdogBase"/>.</param>
 		/// <param name="asyncDelayer">The <see cref="IAsyncDelayer"/> for the <see cref="WatchdogBase"/>.</param>
 		/// <param name="diagnosticsIOManager">The <see cref="IIOManager"/> for the <see cref="WatchdogBase"/>.</param>
+		/// <param name="eventConsumer">The <see cref="IEventConsumer"/> for the <see cref="WatchdogBase"/>.</param>
 		/// <param name="gameIOManager">The value of <see cref="gameIOManager"/>.</param>
 		/// <param name="symlinkFactory">The value of <see cref="symlinkFactory"/>.</param>
 		/// <param name="logger">The <see cref="ILogger"/> for the <see cref="WatchdogBase"/>.</param>
@@ -71,6 +73,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 			IServerControl serverControl,
 			IAsyncDelayer asyncDelayer,
 			IIOManager diagnosticsIOManager,
+			IEventConsumer eventConsumer,
 			IIOManager gameIOManager,
 			ISymlinkFactory symlinkFactory,
 			ILogger<WindowsWatchdog> logger,
@@ -86,6 +89,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 				serverControl,
 				asyncDelayer,
 				diagnosticsIOManager,
+				eventConsumer,
 				logger,
 				initialLaunchParameters,
 				instance,

--- a/src/Tgstation.Server.Host/Components/Watchdog/WindowsWatchdogFactory.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/WindowsWatchdogFactory.cs
@@ -4,6 +4,7 @@ using System;
 using Tgstation.Server.Api.Models.Internal;
 using Tgstation.Server.Host.Components.Chat;
 using Tgstation.Server.Host.Components.Deployment;
+using Tgstation.Server.Host.Components.Events;
 using Tgstation.Server.Host.Components.Session;
 using Tgstation.Server.Host.Configuration;
 using Tgstation.Server.Host.Core;
@@ -60,6 +61,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 			ISessionControllerFactory sessionControllerFactory,
 			IIOManager gameIOManager,
 			IIOManager diagnosticsIOManager,
+			IEventConsumer eventConsumer,
 			Api.Models.Instance instance,
 			DreamDaemonSettings settings)
 			=> new WindowsWatchdog(
@@ -72,6 +74,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 				ServerControl,
 				AsyncDelayer,
 				diagnosticsIOManager,
+				eventConsumer,
 				gameIOManager,
 				symlinkFactory,
 				LoggerFactory.CreateLogger<WindowsWatchdog>(),


### PR DESCRIPTION
:cl:
Added an event script for when the watchdog launches: `WatchdogLaunch`.
Fixed watchdog shutdown and reattach event scripts not being invoked.
/:cl: