### PR TITLE
Make BYOND topic timeouts database backed

### DIFF
--- a/docs/Features.dox
+++ b/docs/Features.dox
@@ -54,7 +54,7 @@ tgstation-server is a BYOND server managment suite. It includes all the followin
 		- Checking out SHAs and references
 		- Local Merging
 		- Hard resetting to references
-		- Merging GitHub pull requests, optionally commenting on them
+		- Merging GitHub pull requests locally, optionally commenting on them
 		- Optionally pushing commits for GitHub visibility
 		- Can be deleted and changed to a different origin
 	- BYOND version management
@@ -69,13 +69,15 @@ tgstation-server is a BYOND server managment suite. It includes all the followin
 	- The Watchdog, a DreamDaemon uptime monitor
 		- Automatically restarts the server when crashed until told to stop
 		- "Heartbeat" system for checking DreamDaemon isn't hung
-		- Automatic application of new deployments on /world/Reboot
+		- Seamless automatic application of new deployments on /world/Reboot
 		- Automatic startup at server boot time
 		- Automatically handles Windows prompts related to trusted mode
 		- TGS restarts/updates do not interrupt the DreamDaemon process
+		- Raises process priority of DreamDaemon for increased performance
 	- Chat System
 		- Support multiple chat bots per instance. Current providers:
 			- Discord
+				- Supports rich embeds when deployments occur
 			- IRC
 		- Bots come out of the box with some basic commands like showing the server revision
 		- Support different chat channel types & tags for use in DM code

--- a/src/Tgstation.Server.Api/Models/Internal/DreamDaemonLaunchParameters.cs
+++ b/src/Tgstation.Server.Api/Models/Internal/DreamDaemonLaunchParameters.cs
@@ -25,20 +25,21 @@ namespace Tgstation.Server.Api.Models.Internal
 		/// The first port <see cref="DreamDaemon"/> uses. This should be the publically advertised port
 		/// </summary>
 		[Required]
-		[Range(1, 65535)]
+		[Range(1, UInt16.MaxValue)]
 		public ushort? PrimaryPort { get; set; }
 
 		/// <summary>
 		/// The second port <see cref="DreamDaemon"/> uses
 		/// </summary>
 		[Required]
-		[Range(1, 65535)]
+		[Range(1, UInt16.MaxValue)]
 		public ushort? SecondaryPort { get; set; }
 
 		/// <summary>
 		/// The DreamDaemon startup timeout in seconds
 		/// </summary>
 		[Required]
+		[Range(1, UInt32.MaxValue)]
 		public uint? StartupTimeout { get; set; }
 
 		/// <summary>
@@ -46,6 +47,13 @@ namespace Tgstation.Server.Api.Models.Internal
 		/// </summary>
 		[Required]
 		public uint? HeartbeatSeconds { get; set; }
+
+		/// <summary>
+		/// The timeout for sending and receiving BYOND topics in milliseconds.
+		/// </summary>
+		[Required]
+		[Range(1, UInt32.MaxValue)]
+		public uint? TopicRequestTimeout { get; set; }
 
 		/// <summary>
 		/// Check if we match a given set of <paramref name="otherParameters"/>. <see cref="StartupTimeout"/> is excluded.
@@ -56,6 +64,7 @@ namespace Tgstation.Server.Api.Models.Internal
 			AllowWebClient == (otherParameters?.AllowWebClient ?? throw new ArgumentNullException(nameof(otherParameters)))
 				&& SecurityLevel == otherParameters.SecurityLevel
 				&& PrimaryPort == otherParameters.PrimaryPort
-				&& SecondaryPort == otherParameters.SecondaryPort; // We intentionally don't check StartupTimeout or heartbeat seconds as it doesn't matter in terms of the watchdog
+				&& SecondaryPort == otherParameters.SecondaryPort
+				&& TopicRequestTimeout == otherParameters.TopicRequestTimeout; // We intentionally don't check StartupTimeout or heartbeat seconds as it doesn't matter in terms of the watchdog
 	}
 }

--- a/src/Tgstation.Server.Api/Rights/DreamDaemonRights.cs
+++ b/src/Tgstation.Server.Api/Rights/DreamDaemonRights.cs
@@ -82,5 +82,10 @@ namespace Tgstation.Server.Api.Rights
 		/// User can create DreamDaemon process dumps.
 		/// </summary>
 		CreateDump = 8192,
+
+		/// <summary>
+		/// User can change <see cref="Models.Internal.DreamDaemonLaunchParameters.TopicRequestTimeout"/>.
+		/// </summary>
+		SetTopicTimeout = 16384,
 	}
 }

--- a/src/Tgstation.Server.Api/Tgstation.Server.Api.csproj
+++ b/src/Tgstation.Server.Api/Tgstation.Server.Api.csproj
@@ -33,7 +33,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Tgstation.Server.Host.Console/Tgstation.Server.Host.Console.csproj
+++ b/src/Tgstation.Server.Host.Console/Tgstation.Server.Host.Console.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../../build/Version.props" />
   
   <PropertyGroup>
@@ -23,11 +23,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>compile; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.5" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Tgstation.Server.Host.Console/Tgstation.Server.Host.Console.csproj
+++ b/src/Tgstation.Server.Host.Console/Tgstation.Server.Host.Console.csproj
@@ -27,7 +27,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>compile; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Tgstation.Server.Host.Service/Tgstation.Server.Host.Service.csproj
+++ b/src/Tgstation.Server.Host.Service/Tgstation.Server.Host.Service.csproj
@@ -28,7 +28,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.EventLog" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.EventLog" Version="2.2.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Tgstation.Server.Host.Service/Tgstation.Server.Host.Service.csproj
+++ b/src/Tgstation.Server.Host.Service/Tgstation.Server.Host.Service.csproj
@@ -23,12 +23,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.6.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.EventLog" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.EventLog" Version="3.1.5" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Tgstation.Server.Host.Watchdog/Tgstation.Server.Host.Watchdog.csproj
+++ b/src/Tgstation.Server.Host.Watchdog/Tgstation.Server.Host.Watchdog.csproj
@@ -27,7 +27,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>compile; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Tgstation.Server.Host.Watchdog/Tgstation.Server.Host.Watchdog.csproj
+++ b/src/Tgstation.Server.Host.Watchdog/Tgstation.Server.Host.Watchdog.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../../build/Version.props" />
 
   <PropertyGroup>
@@ -23,11 +23,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>compile; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.5" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Tgstation.Server.Host/Components/Chat/ChatTrackingContext.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/ChatTrackingContext.cs
@@ -128,6 +128,7 @@ namespace Tgstation.Server.Host.Components.Chat
 		/// <inheritdoc />
 		public Task UpdateChannels(IEnumerable<ChannelRepresentation> newChannels, CancellationToken cancellationToken)
 		{
+			logger.LogTrace("UpdateChannels...");
 			var completed = newChannels.ToList();
 			Task updateTask;
 			lock (synchronizationLock)

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordProvider.cs
@@ -383,10 +383,15 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 						Value = errorMessage
 					});
 
+				var updatedMessage = $"DM: Deployment {completionString}!";
 				try
 				{
 					await message.ModifyAsync(
-						props => props.Embed = builder.Build())
+						props =>
+						{
+							props.Content = updatedMessage;
+							props.Embed = builder.Build();
+						})
 						.ConfigureAwait(false);
 				}
 				catch (Exception ex)
@@ -395,7 +400,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 					try
 					{
 						await channel.SendMessageAsync(
-							$"DM: Deployment {completionString}!",
+							updatedMessage,
 							false,
 							builder.Build())
 							.ConfigureAwait(false);

--- a/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
@@ -208,7 +208,8 @@ namespace Tgstation.Server.Host.Components.Deployment
 				AllowWebClient = false,
 				PrimaryPort = portToUse,
 				SecurityLevel = securityLevel,
-				StartupTimeout = timeout
+				StartupTimeout = timeout,
+				TopicRequestTimeout = 0 // not used
 			};
 
 			var dirA = ioManager.ConcatPath(job.DirectoryName.ToString(), ADirectoryName);

--- a/src/Tgstation.Server.Host/Components/InstanceFactory.cs
+++ b/src/Tgstation.Server.Host/Components/InstanceFactory.cs
@@ -1,5 +1,4 @@
-﻿using Byond.TopicSender;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -45,9 +44,9 @@ namespace Tgstation.Server.Host.Components
 		readonly ILoggerFactory loggerFactory;
 
 		/// <summary>
-		/// The <see cref="ITopicClient"/> for the <see cref="InstanceFactory"/>
+		/// The <see cref="ITopicClientFactory"/> for the <see cref="InstanceFactory"/>
 		/// </summary>
-		readonly ITopicClient byondTopicSender;
+		readonly ITopicClientFactory topicClientFactory;
 
 		/// <summary>
 		/// The <see cref="ICryptographySuite"/> for the <see cref="InstanceFactory"/>
@@ -131,7 +130,7 @@ namespace Tgstation.Server.Host.Components
 		/// <param name="databaseContextFactory">The value of <see cref="databaseContextFactory"/></param>
 		/// <param name="assemblyInformationProvider">The value of <see cref="assemblyInformationProvider"/></param>
 		/// <param name="loggerFactory">The value of <see cref="loggerFactory"/></param>
-		/// <param name="byondTopicSender">The value of <see cref="byondTopicSender"/></param>
+		/// <param name="topicClientFactory">The value of <see cref="topicClientFactory"/></param>
 		/// <param name="cryptographySuite">The value of <see cref="cryptographySuite"/></param>
 		/// <param name="synchronousIOManager">The value of <see cref="synchronousIOManager"/></param>
 		/// <param name="symlinkFactory">The value of <see cref="symlinkFactory"/></param>
@@ -152,7 +151,7 @@ namespace Tgstation.Server.Host.Components
 			IDatabaseContextFactory databaseContextFactory,
 			IAssemblyInformationProvider assemblyInformationProvider,
 			ILoggerFactory loggerFactory,
-			ITopicClient byondTopicSender,
+			ITopicClientFactory topicClientFactory,
 			ICryptographySuite cryptographySuite,
 			ISynchronousIOManager synchronousIOManager,
 			ISymlinkFactory symlinkFactory,
@@ -173,7 +172,7 @@ namespace Tgstation.Server.Host.Components
 			this.databaseContextFactory = databaseContextFactory ?? throw new ArgumentNullException(nameof(databaseContextFactory));
 			this.assemblyInformationProvider = assemblyInformationProvider ?? throw new ArgumentNullException(nameof(assemblyInformationProvider));
 			this.loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
-			this.byondTopicSender = byondTopicSender ?? throw new ArgumentNullException(nameof(byondTopicSender));
+			this.topicClientFactory = topicClientFactory ?? throw new ArgumentNullException(nameof(topicClientFactory));
 			this.cryptographySuite = cryptographySuite ?? throw new ArgumentNullException(nameof(cryptographySuite));
 			this.synchronousIOManager = synchronousIOManager ?? throw new ArgumentNullException(nameof(synchronousIOManager));
 			this.symlinkFactory = symlinkFactory ?? throw new ArgumentNullException(nameof(symlinkFactory));
@@ -226,7 +225,7 @@ namespace Tgstation.Server.Host.Components
 					var sessionControllerFactory = new SessionControllerFactory(
 						processExecutor,
 						byond,
-						byondTopicSender,
+						topicClientFactory,
 						cryptographySuite,
 						assemblyInformationProvider,
 						gameIoManager,

--- a/src/Tgstation.Server.Host/Components/Session/DualReattachInformation.cs
+++ b/src/Tgstation.Server.Host/Components/Session/DualReattachInformation.cs
@@ -21,6 +21,11 @@ namespace Tgstation.Server.Host.Components.Session
 		public ReattachInformation Bravo { get; set; }
 
 		/// <summary>
+		/// The timeout used for topic request.
+		/// </summary>
+		public TimeSpan TopicRequestTimeout { get; set; }
+
+		/// <summary>
 		/// Construct a <see cref="DualReattachInformation"/>
 		/// </summary>
 		public DualReattachInformation() { }

--- a/src/Tgstation.Server.Host/Components/Session/ISessionControllerFactory.cs
+++ b/src/Tgstation.Server.Host/Components/Session/ISessionControllerFactory.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Tgstation.Server.Api.Models.Internal;
 using Tgstation.Server.Host.Components.Byond;
@@ -35,10 +36,12 @@ namespace Tgstation.Server.Host.Components.Session
 		/// Create a <see cref="ISessionController"/> from an existing DreamDaemon instance
 		/// </summary>
 		/// <param name="reattachInformation">The <see cref="ReattachInformation"/> to use</param>
+		/// <param name="topicRequestTimeout">The timeout for sending topic requests.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in a new <see cref="ISessionController"/> on success or <see langword="null"/> on failure to reattach</returns>
 		Task<ISessionController> Reattach(
 			ReattachInformation reattachInformation,
+			TimeSpan topicRequestTimeout,
 			CancellationToken cancellationToken);
 
 		/// <summary>

--- a/src/Tgstation.Server.Host/Components/Session/ITopicClientFactory.cs
+++ b/src/Tgstation.Server.Host/Components/Session/ITopicClientFactory.cs
@@ -1,0 +1,18 @@
+﻿using Byond.TopicSender;
+using System;
+
+namespace Tgstation.Server.Host.Components.Session
+{
+	/// <summary>
+	/// Factory for <see cref="ITopicClient"/>s
+	/// </summary>
+	interface ITopicClientFactory
+	{
+		/// <summary>
+		/// Create a <see cref="ITopicClient"/>.
+		/// </summary>
+		/// <param name="timeout">The request timeout.</param>
+		/// <returns>A new <see cref="ITopicClient"/>.</returns>
+		ITopicClient CreateTopicClient(TimeSpan timeout);
+	}
+}

--- a/src/Tgstation.Server.Host/Components/Session/TopicClientFactory.cs
+++ b/src/Tgstation.Server.Host/Components/Session/TopicClientFactory.cs
@@ -1,0 +1,36 @@
+﻿using Byond.TopicSender;
+using Microsoft.Extensions.Logging;
+using System;
+
+namespace Tgstation.Server.Host.Components.Session
+{
+	/// <inheritdoc />
+	sealed class TopicClientFactory : ITopicClientFactory
+	{
+		/// <summary>
+		/// The <see cref="ILogger"/> for created <see cref="ITopicClient"/>s.
+		/// </summary>
+		readonly ILogger<TopicClient> logger;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="TopicClientFactory"/> <see langword="class"/>.
+		/// </summary>
+		/// <param name="logger">The value of <see cref="logger"/>.</param>
+		public TopicClientFactory(ILogger<TopicClient> logger)
+		{
+			this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+		}
+
+		/// <inheritdoc />
+		public ITopicClient CreateTopicClient(TimeSpan timeout)
+			=> new TopicClient(
+				new SocketParameters
+				{
+					ConnectTimeout = timeout,
+					DisconnectTimeout = timeout,
+					ReceiveTimeout = timeout,
+					SendTimeout = timeout
+				},
+				logger);
+	}
+}

--- a/src/Tgstation.Server.Host/Components/Watchdog/BasicWatchdog.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/BasicWatchdog.cs
@@ -253,11 +253,11 @@ namespace Tgstation.Server.Host.Components.Watchdog
 						cancellationToken);
 				}
 				else
-					serverLaunchTask = SessionControllerFactory.Reattach(serverToReattach, cancellationToken);
+					serverLaunchTask = SessionControllerFactory.Reattach(serverToReattach, reattachInfo.TopicRequestTimeout, cancellationToken);
 
 				bool thereIsAnInactiveServerToKill = serverToKill != null;
 				if (thereIsAnInactiveServerToKill)
-					inactiveReattachTask = SessionControllerFactory.Reattach(serverToKill, cancellationToken);
+					inactiveReattachTask = SessionControllerFactory.Reattach(serverToKill, reattachInfo.TopicRequestTimeout, cancellationToken);
 				else
 					inactiveReattachTask = Task.FromResult<ISessionController>(null);
 

--- a/src/Tgstation.Server.Host/Components/Watchdog/ExperimentalWatchdog.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/ExperimentalWatchdog.cs
@@ -470,7 +470,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 						false,
 						cancellationToken);
 				else
-					alphaServerTask = SessionControllerFactory.Reattach(reattachInfo.Alpha, cancellationToken);
+					alphaServerTask = SessionControllerFactory.Reattach(reattachInfo.Alpha, reattachInfo.TopicRequestTimeout, cancellationToken);
 
 				// retrieve the session controller
 				var startTime = DateTimeOffset.Now;
@@ -499,7 +499,10 @@ namespace Tgstation.Server.Host.Components.Watchdog
 						cancellationToken)
 						.ConfigureAwait(false);
 				else
-					bravoServer = await SessionControllerFactory.Reattach(reattachInfo.Bravo, cancellationToken).ConfigureAwait(false);
+					bravoServer = await SessionControllerFactory.Reattach(
+						reattachInfo.Bravo,
+						reattachInfo.TopicRequestTimeout,
+						cancellationToken).ConfigureAwait(false);
 
 				// failed reattaches will return null
 				bravoServer?.SetHighPriority();

--- a/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
@@ -860,14 +860,15 @@ namespace Tgstation.Server.Host.Components.Watchdog
 				if (!graceful)
 				{
 					Task chatTask;
-					if (Running)
+					bool hard = Running;
+					if (hard)
 					{
 						chatTask = Chat.SendWatchdogMessage("Manual restart triggered...", false, cancellationToken);
 						await TerminateNoLock(false, false, cancellationToken).ConfigureAwait(false);
 					}
 					else
 						chatTask = Task.CompletedTask;
-					await LaunchNoLock(true, !Running, null, cancellationToken).ConfigureAwait(false);
+					await LaunchNoLock(true, !hard, null, cancellationToken).ConfigureAwait(false);
 					await chatTask.ConfigureAwait(false);
 				}
 

--- a/src/Tgstation.Server.Host/Configuration/DatabaseConfiguration.cs
+++ b/src/Tgstation.Server.Host/Configuration/DatabaseConfiguration.cs
@@ -6,7 +6,7 @@ namespace Tgstation.Server.Host.Configuration
 	/// <summary>
 	/// Configuration options for the <see cref="Database.DatabaseContext"/>
 	/// </summary>
-	sealed class DatabaseConfiguration
+	public sealed class DatabaseConfiguration
 	{
 		/// <summary>
 		/// The key for the <see cref="Microsoft.Extensions.Configuration.IConfigurationSection"/> the <see cref="DatabaseConfiguration"/> resides in

--- a/src/Tgstation.Server.Host/Configuration/GeneralConfiguration.cs
+++ b/src/Tgstation.Server.Host/Configuration/GeneralConfiguration.cs
@@ -37,12 +37,12 @@ namespace Tgstation.Server.Host.Configuration
 		/// <summary>
 		/// The default value for <see cref="ByondTopicTimeout"/>
 		/// </summary>
-		const int DefaultByondTopicTimeout = 5000;
+		const uint DefaultByondTopicTimeout = 5000;
 
 		/// <summary>
 		/// The default value for <see cref="RestartTimeout"/>
 		/// </summary>
-		const int DefaultRestartTimeout = 60000;
+		const uint DefaultRestartTimeout = 60000;
 
 		/// <summary>
 		/// The port the TGS API listens on.
@@ -63,12 +63,12 @@ namespace Tgstation.Server.Host.Configuration
 		/// <summary>
 		/// The timeout in milliseconds for sending and receiving topics to/from DreamDaemon. Note that a single topic exchange can take up to twice this value
 		/// </summary>
-		public int ByondTopicTimeout { get; set; } = DefaultByondTopicTimeout;
+		public uint ByondTopicTimeout { get; set; } = DefaultByondTopicTimeout;
 
 		/// <summary>
 		/// The timeout milliseconds for restarting the server
 		/// </summary>
-		public int RestartTimeout { get; set; } = DefaultRestartTimeout;
+		public uint RestartTimeout { get; set; } = DefaultRestartTimeout;
 
 		/// <summary>
 		/// If the <see cref="Components.Watchdog.ExperimentalWatchdog"/> should be used.

--- a/src/Tgstation.Server.Host/Controllers/DreamDaemonController.cs
+++ b/src/Tgstation.Server.Host/Controllers/DreamDaemonController.cs
@@ -137,6 +137,7 @@ namespace Tgstation.Server.Host.Controllers
 				result.SoftShutdown = rstate == RebootState.Shutdown;
 				result.StartupTimeout = settings.StartupTimeout.Value;
 				result.HeartbeatSeconds = settings.HeartbeatSeconds.Value;
+				result.TopicRequestTimeout = settings.TopicRequestTimeout.Value;
 			}
 
 			if (revision)
@@ -175,7 +176,17 @@ namespace Tgstation.Server.Host.Controllers
 		/// <response code="200">Settings applied successfully.</response>
 		/// <response code="410">The database entity for the requested instance could not be retrieved. The instance was likely detached.</response>
 		[HttpPost]
-		[TgsAuthorize(DreamDaemonRights.SetAutoStart | DreamDaemonRights.SetPorts | DreamDaemonRights.SetSecurity | DreamDaemonRights.SetWebClient | DreamDaemonRights.SoftRestart | DreamDaemonRights.SoftShutdown | DreamDaemonRights.Start | DreamDaemonRights.SetStartupTimeout | DreamDaemonRights.SetHeartbeatInterval)]
+		[TgsAuthorize(
+			DreamDaemonRights.SetAutoStart
+			| DreamDaemonRights.SetPorts
+			| DreamDaemonRights.SetSecurity
+			| DreamDaemonRights.SetWebClient
+			| DreamDaemonRights.SoftRestart
+			| DreamDaemonRights.SoftShutdown
+			| DreamDaemonRights.Start
+			| DreamDaemonRights.SetStartupTimeout
+			| DreamDaemonRights.SetHeartbeatInterval
+			| DreamDaemonRights.SetTopicTimeout)]
 		[ProducesResponseType(typeof(DreamDaemon), 200)]
 		[ProducesResponseType(typeof(ErrorMessage), 410)]
 		#pragma warning disable CA1502 // TODO: Decomplexify
@@ -237,7 +248,8 @@ namespace Tgstation.Server.Host.Controllers
 				|| (model.SoftRestart.HasValue && !AuthenticationContext.InstanceUser.DreamDaemonRights.Value.HasFlag(DreamDaemonRights.SoftRestart))
 				|| (model.SoftShutdown.HasValue && !AuthenticationContext.InstanceUser.DreamDaemonRights.Value.HasFlag(DreamDaemonRights.SoftShutdown))
 				|| CheckModified(x => x.StartupTimeout, DreamDaemonRights.SetStartupTimeout)
-				|| CheckModified(x => x.HeartbeatSeconds, DreamDaemonRights.SetHeartbeatInterval))
+				|| CheckModified(x => x.HeartbeatSeconds, DreamDaemonRights.SetHeartbeatInterval)
+				|| CheckModified(x => x.TopicRequestTimeout, DreamDaemonRights.SetTopicTimeout))
 				return Forbid();
 
 			if (current.PrimaryPort == current.SecondaryPort)

--- a/src/Tgstation.Server.Host/Controllers/InstanceController.cs
+++ b/src/Tgstation.Server.Host/Controllers/InstanceController.cs
@@ -248,7 +248,8 @@ namespace Tgstation.Server.Host.Controllers
 					SecondaryPort = 1338,
 					SecurityLevel = DreamDaemonSecurity.Safe,
 					StartupTimeout = 60,
-					HeartbeatSeconds = 60
+					HeartbeatSeconds = 60,
+					TopicRequestTimeout = generalConfiguration.ByondTopicTimeout
 				},
 				DreamMakerSettings = new DreamMakerSettings
 				{

--- a/src/Tgstation.Server.Host/Controllers/JobController.cs
+++ b/src/Tgstation.Server.Host/Controllers/JobController.cs
@@ -52,6 +52,7 @@ namespace Tgstation.Server.Host.Controllers
 			var result = await DatabaseContext
 				.Jobs
 				.AsQueryable()
+				.Include(x => x.StartedBy)
 				.Where(x => x.Instance.Id == Instance.Id && !x.StoppedAt.HasValue)
 				.OrderByDescending(x => x.StartedAt)
 				.ToListAsync(cancellationToken)

--- a/src/Tgstation.Server.Host/Database/DatabaseSeeder.cs
+++ b/src/Tgstation.Server.Host/Database/DatabaseSeeder.cs
@@ -10,6 +10,7 @@ using Tgstation.Server.Host.Configuration;
 using Tgstation.Server.Host.Models;
 using Tgstation.Server.Host.Security;
 using Tgstation.Server.Host.System;
+using Z.EntityFramework.Plus;
 
 namespace Tgstation.Server.Host.Database
 {
@@ -37,6 +38,11 @@ namespace Tgstation.Server.Host.Database
 		readonly ILogger<DatabaseSeeder> logger;
 
 		/// <summary>
+		/// The <see cref="GeneralConfiguration"/> for the <see cref="DatabaseSeeder"/>.
+		/// </summary>
+		readonly GeneralConfiguration generalConfiguration;
+
+		/// <summary>
 		/// The <see cref="DatabaseConfiguration"/> for the <see cref="DatabaseSeeder"/>.
 		/// </summary>
 		readonly DatabaseConfiguration databaseConfiguration;
@@ -46,12 +52,14 @@ namespace Tgstation.Server.Host.Database
 		/// </summary>
 		/// <param name="cryptographySuite">The value of <see cref="cryptographySuite"/></param>
 		/// <param name="platformIdentifier">The value of <see cref="platformIdentifier"/>.</param>
+		/// <param name="generalConfigurationOptions">The <see cref="IOptions{TOptions}"/> containing the value of <see cref="generalConfiguration"/>.</param>
 		/// <param name="databaseConfigurationOptions">The <see cref="IOptions{TOptions}"/> containing the value of <see cref="databaseConfiguration"/>.</param>
 		/// <param name="databaseLogger">The value of <see cref="databaseLogger"/></param>
 		/// <param name="logger">The value of <see cref="logger"/>.</param>
 		public DatabaseSeeder(
 			ICryptographySuite cryptographySuite,
 			IPlatformIdentifier platformIdentifier,
+			IOptions<GeneralConfiguration> generalConfigurationOptions,
 			IOptions<DatabaseConfiguration> databaseConfigurationOptions,
 			ILogger<DatabaseContext> databaseLogger,
 			ILogger<DatabaseSeeder> logger)
@@ -59,6 +67,7 @@ namespace Tgstation.Server.Host.Database
 			this.cryptographySuite = cryptographySuite ?? throw new ArgumentNullException(nameof(cryptographySuite));
 			this.platformIdentifier = platformIdentifier ?? throw new ArgumentNullException(nameof(platformIdentifier));
 			databaseConfiguration = databaseConfigurationOptions?.Value ?? throw new ArgumentNullException(nameof(databaseConfigurationOptions));
+			generalConfiguration = generalConfigurationOptions?.Value ?? throw new ArgumentNullException(nameof(generalConfigurationOptions));
 			this.databaseLogger = databaseLogger ?? throw new ArgumentNullException(nameof(databaseLogger));
 			this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
 		}
@@ -123,6 +132,22 @@ namespace Tgstation.Server.Host.Database
 				foreach (var instance in allInstances)
 					instance.Path = instance.Path.Replace('\\', '/');
 			}
+
+			// Update settings from config
+			var rowsUpdated = await databaseContext
+				.DreamDaemonSettings
+				.AsQueryable()
+				.Where(x => x.TopicRequestTimeout == 0)
+				.UpdateAsync(
+					settings => new DreamDaemonSettings { TopicRequestTimeout = generalConfiguration.ByondTopicTimeout },
+					cancellationToken)
+				.ConfigureAwait(false);
+
+			if (rowsUpdated > 0)
+				logger.LogInformation(
+					"Updated {0} instances to use database backed BYOND topic timeouts from configuration setting of {1}",
+					rowsUpdated,
+					generalConfiguration.ByondTopicTimeout);
 
 			await databaseContext.Save(cancellationToken).ConfigureAwait(false);
 		}

--- a/src/Tgstation.Server.Host/Database/Design/DesignTimeDbContextFactoryHelpers.cs
+++ b/src/Tgstation.Server.Host/Database/Design/DesignTimeDbContextFactoryHelpers.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Options;
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 using Tgstation.Server.Host.Configuration;
 
 namespace Tgstation.Server.Host.Database.Design
@@ -11,10 +12,14 @@ namespace Tgstation.Server.Host.Database.Design
 		/// <summary>
 		/// Get the <see cref="IOptions{TOptions}"/> for the <see cref="DatabaseConfiguration"/>
 		/// </summary>
+		/// <typeparam name="TDatabaseContext">The <see cref="DatabaseContext"/> to create <see cref="DbContextOptions"/> for.</typeparam>
 		/// <param name="databaseType">The <see cref="DatabaseConfiguration.DatabaseType"/>.</param>
 		/// <param name="connectionString">The <see cref="DatabaseConfiguration.ConnectionString"/>.</param>
 		/// <returns>The <see cref="IOptions{TOptions}"/> for the <see cref="DatabaseConfiguration"/></returns>
-		public static IOptions<DatabaseConfiguration> GetDatabaseConfiguration(DatabaseType databaseType, string connectionString)
+		public static DbContextOptions<TDatabaseContext> CreateDatabaseContextOptions<TDatabaseContext>(
+			DatabaseType databaseType,
+			string connectionString)
+			where TDatabaseContext : DatabaseContext
 		{
 			var dbConfig = new DatabaseConfiguration
 			{
@@ -23,7 +28,12 @@ namespace Tgstation.Server.Host.Database.Design
 				ConnectionString = connectionString
 			};
 
-			return Options.Create(dbConfig);
+			var optionsFac = new DbContextOptionsBuilder<TDatabaseContext>();
+			var configureAction = DatabaseContext.GetConfigureAction<TDatabaseContext>();
+
+			configureAction(optionsFac, dbConfig);
+
+			return optionsFac.Options;
 		}
 	}
 }

--- a/src/Tgstation.Server.Host/Database/Design/MySqlDesignTimeDbContextFactory.cs
+++ b/src/Tgstation.Server.Host/Database/Design/MySqlDesignTimeDbContextFactory.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.EntityFrameworkCore.Design;
+using Tgstation.Server.Host.Configuration;
+
+namespace Tgstation.Server.Host.Database.Design
+{
+	/// <summary>
+	/// <see cref="IDesignTimeDbContextFactory{TContext}"/> for creating <see cref="MySqlDatabaseContext"/>s.
+	/// </summary>
+	sealed class MySqlDesignTimeDbContextFactory : IDesignTimeDbContextFactory<MySqlDatabaseContext>
+	{
+		/// <inheritdoc />
+		public MySqlDatabaseContext CreateDbContext(string[] args)
+			=> new MySqlDatabaseContext(
+				DesignTimeDbContextFactoryHelpers.CreateDatabaseContextOptions<MySqlDatabaseContext>(
+					DatabaseType.MariaDB,
+					"Server=127.0.0.1;User Id=root;Password=fake;Database=TGS_Design"));
+	}
+}

--- a/src/Tgstation.Server.Host/Database/Design/PostgresSqlDesignTimeDbContextFactory.cs
+++ b/src/Tgstation.Server.Host/Database/Design/PostgresSqlDesignTimeDbContextFactory.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.EntityFrameworkCore.Design;
+using Tgstation.Server.Host.Configuration;
+
+namespace Tgstation.Server.Host.Database.Design
+{
+	/// <summary>
+	/// <see cref="IDesignTimeDbContextFactory{TContext}"/> for creating <see cref="PostgresSqlDatabaseContext"/>s.
+	/// </summary>
+	sealed class PostgresSqlDesignTimeDbContextFactory : IDesignTimeDbContextFactory<PostgresSqlDatabaseContext>
+	{
+		/// <inheritdoc />
+		public PostgresSqlDatabaseContext CreateDbContext(string[] args)
+			=> new PostgresSqlDatabaseContext(
+				DesignTimeDbContextFactoryHelpers.CreateDatabaseContextOptions<PostgresSqlDatabaseContext>(
+					DatabaseType.PostgresSql,
+					"Application Name=tgstation-server;Host=127.0.0.1;Password=fake;Username=postgres;Database=TGS_Design"));
+	}
+}

--- a/src/Tgstation.Server.Host/Database/Design/SqlServerDesignTimeDbContextFactory.cs
+++ b/src/Tgstation.Server.Host/Database/Design/SqlServerDesignTimeDbContextFactory.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.EntityFrameworkCore.Design;
+using Tgstation.Server.Host.Configuration;
+
+namespace Tgstation.Server.Host.Database.Design
+{
+	/// <summary>
+	/// <see cref="IDesignTimeDbContextFactory{TContext}"/> for creating <see cref="SqlServerDatabaseContext"/>s.
+	/// </summary>
+	sealed class SqlServerDesignTimeDbContextFactory : IDesignTimeDbContextFactory<SqlServerDatabaseContext>
+	{
+		/// <inheritdoc />
+		public SqlServerDatabaseContext CreateDbContext(string[] args)
+			=> new SqlServerDatabaseContext(
+				DesignTimeDbContextFactoryHelpers.CreateDatabaseContextOptions<SqlServerDatabaseContext>(
+					DatabaseType.SqlServer,
+					"Data Source=fake;Initial Catalog=TGS_Design;Integrated Security=True;Application Name=tgstation-server"));
+	}
+}

--- a/src/Tgstation.Server.Host/Database/Design/SqliteDesignTimeDbContextFactory.cs
+++ b/src/Tgstation.Server.Host/Database/Design/SqliteDesignTimeDbContextFactory.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Design;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.EntityFrameworkCore.Design;
 using Tgstation.Server.Host.Configuration;
 
 namespace Tgstation.Server.Host.Database.Design
@@ -13,14 +11,11 @@ namespace Tgstation.Server.Host.Database.Design
 		/// <inheritdoc />
 		public SqliteDatabaseContext CreateDbContext(string[] args)
 		{
-			using var loggerFactory = new LoggerFactory();
-			var config =
-				DesignTimeDbContextFactoryHelpers.GetDatabaseConfiguration(
-					DatabaseType.Sqlite,
-					"Data Source=tgs_design.sqlite3;Mode=ReadWriteCreate");
-			SqliteDatabaseContext.DesignTime = config.Value.DesignTime;
+			SqliteDatabaseContext.DesignTime = true;
 			return new SqliteDatabaseContext(
-				new DbContextOptions<SqliteDatabaseContext>());
+				DesignTimeDbContextFactoryHelpers.CreateDatabaseContextOptions<SqliteDatabaseContext>(
+					DatabaseType.Sqlite,
+					"Data Source=tgs_design.sqlite3;Mode=ReadWriteCreate"));
 		}
 	}
 }

--- a/src/Tgstation.Server.Host/Database/Migrations/20200516111712_PGCreate.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20200516111712_PGCreate.cs
@@ -5,7 +5,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Tgstation.Server.Host.Database.Migrations
 {
 	/// <summary>
-	/// Create initial schema for PostgreSQL.
+	/// Create initial schema for PostgresSQL.
 	/// </summary>
 	public partial class PGCreate : Migration
 	{

--- a/src/Tgstation.Server.Host/Database/Migrations/20200616175424_MSTopicTimeout.Designer.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20200616175424_MSTopicTimeout.Designer.cs
@@ -2,50 +2,52 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Tgstation.Server.Host.Database.Migrations
 {
-	[DbContext(typeof(PostgresSqlDatabaseContext))]
-	partial class PostgresSqlDatabaseContextModelSnapshot : ModelSnapshot
+	[DbContext(typeof(SqlServerDatabaseContext))]
+	[Migration("20200616175424_MSTopicTimeout")]
+	partial class MSTopicTimeout
 	{
 		/// <inheritdoc />
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder
-				.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn)
 				.HasAnnotation("ProductVersion", "3.1.4")
-				.HasAnnotation("Relational:MaxIdentifierLength", 63);
+				.HasAnnotation("Relational:MaxIdentifierLength", 128)
+				.HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.ChatBot", b =>
 				{
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
 						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
 					b.Property<int>("ChannelLimit")
-						.HasColumnType("integer");
+						.HasColumnType("int");
 
 					b.Property<string>("ConnectionString")
 						.IsRequired()
-						.HasColumnType("character varying(10000)")
+						.HasColumnType("nvarchar(max)")
 						.HasMaxLength(10000);
 
 					b.Property<bool?>("Enabled")
-						.HasColumnType("boolean");
+						.HasColumnType("bit");
 
 					b.Property<long>("InstanceId")
 						.HasColumnType("bigint");
 
 					b.Property<string>("Name")
 						.IsRequired()
-						.HasColumnType("character varying(100)")
+						.HasColumnType("nvarchar(100)")
 						.HasMaxLength(100);
 
 					b.Property<int>("Provider")
-						.HasColumnType("integer");
+						.HasColumnType("int");
 
 					b.Property<long>("ReconnectionInterval")
 						.HasColumnType("bigint");
@@ -63,41 +65,43 @@ namespace Tgstation.Server.Host.Database.Migrations
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
 						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
 					b.Property<long>("ChatSettingsId")
 						.HasColumnType("bigint");
 
 					b.Property<decimal?>("DiscordChannelId")
-						.HasColumnType("numeric(20,0)");
+						.HasColumnType("decimal(20,0)");
 
 					b.Property<string>("IrcChannel")
-						.HasColumnType("character varying(100)")
+						.HasColumnType("nvarchar(100)")
 						.HasMaxLength(100);
 
 					b.Property<bool?>("IsAdminChannel")
 						.IsRequired()
-						.HasColumnType("boolean");
+						.HasColumnType("bit");
 
 					b.Property<bool?>("IsUpdatesChannel")
 						.IsRequired()
-						.HasColumnType("boolean");
+						.HasColumnType("bit");
 
 					b.Property<bool?>("IsWatchdogChannel")
 						.IsRequired()
-						.HasColumnType("boolean");
+						.HasColumnType("bit");
 
 					b.Property<string>("Tag")
-						.HasColumnType("character varying(10000)")
+						.HasColumnType("nvarchar(max)")
 						.HasMaxLength(10000);
 
 					b.HasKey("Id");
 
 					b.HasIndex("ChatSettingsId", "DiscordChannelId")
-						.IsUnique();
+						.IsUnique()
+						.HasFilter("[DiscordChannelId] IS NOT NULL");
 
 					b.HasIndex("ChatSettingsId", "IrcChannel")
-						.IsUnique();
+						.IsUnique()
+						.HasFilter("[IrcChannel] IS NOT NULL");
 
 					b.ToTable("ChatChannels");
 				});
@@ -107,38 +111,38 @@ namespace Tgstation.Server.Host.Database.Migrations
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
 						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
 					b.Property<string>("ByondVersion")
 						.IsRequired()
-						.HasColumnType("text");
+						.HasColumnType("nvarchar(max)");
 
 					b.Property<int?>("DMApiMajorVersion")
-						.HasColumnType("integer");
+						.HasColumnType("int");
 
 					b.Property<int?>("DMApiMinorVersion")
-						.HasColumnType("integer");
+						.HasColumnType("int");
 
 					b.Property<int?>("DMApiPatchVersion")
-						.HasColumnType("integer");
+						.HasColumnType("int");
 
 					b.Property<Guid?>("DirectoryName")
 						.IsRequired()
-						.HasColumnType("uuid");
+						.HasColumnType("uniqueidentifier");
 
 					b.Property<string>("DmeName")
 						.IsRequired()
-						.HasColumnType("text");
+						.HasColumnType("nvarchar(max)");
 
 					b.Property<long>("JobId")
 						.HasColumnType("bigint");
 
 					b.Property<int>("MinimumSecurityLevel")
-						.HasColumnType("integer");
+						.HasColumnType("int");
 
 					b.Property<string>("Output")
 						.IsRequired()
-						.HasColumnType("text");
+						.HasColumnType("nvarchar(max)");
 
 					b.Property<long>("RevisionInformationId")
 						.HasColumnType("bigint");
@@ -160,15 +164,15 @@ namespace Tgstation.Server.Host.Database.Migrations
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
 						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
 					b.Property<bool?>("AllowWebClient")
 						.IsRequired()
-						.HasColumnType("boolean");
+						.HasColumnType("bit");
 
 					b.Property<bool?>("AutoStart")
 						.IsRequired()
-						.HasColumnType("boolean");
+						.HasColumnType("bit");
 
 					b.Property<long>("HeartbeatSeconds")
 						.HasColumnType("bigint");
@@ -177,13 +181,13 @@ namespace Tgstation.Server.Host.Database.Migrations
 						.HasColumnType("bigint");
 
 					b.Property<int>("PrimaryPort")
-						.HasColumnType("integer");
+						.HasColumnType("int");
 
 					b.Property<int>("SecondaryPort")
-						.HasColumnType("integer");
+						.HasColumnType("int");
 
 					b.Property<int>("SecurityLevel")
-						.HasColumnType("integer");
+						.HasColumnType("int");
 
 					b.Property<long>("StartupTimeout")
 						.HasColumnType("bigint");
@@ -204,19 +208,19 @@ namespace Tgstation.Server.Host.Database.Migrations
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
 						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
 					b.Property<int>("ApiValidationPort")
-						.HasColumnType("integer");
+						.HasColumnType("int");
 
 					b.Property<int>("ApiValidationSecurityLevel")
-						.HasColumnType("integer");
+						.HasColumnType("int");
 
 					b.Property<long>("InstanceId")
 						.HasColumnType("bigint");
 
 					b.Property<string>("ProjectName")
-						.HasColumnType("character varying(10000)")
+						.HasColumnType("nvarchar(max)")
 						.HasMaxLength(10000);
 
 					b.HasKey("Id");
@@ -232,13 +236,13 @@ namespace Tgstation.Server.Host.Database.Migrations
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
 						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
 					b.Property<long?>("AlphaId")
 						.HasColumnType("bigint");
 
 					b.Property<bool>("AlphaIsActive")
-						.HasColumnType("boolean");
+						.HasColumnType("bit");
 
 					b.Property<long?>("BravoId")
 						.HasColumnType("bigint");
@@ -263,29 +267,29 @@ namespace Tgstation.Server.Host.Database.Migrations
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
 						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
 					b.Property<long>("AutoUpdateInterval")
 						.HasColumnType("bigint");
 
 					b.Property<int>("ChatBotLimit")
-						.HasColumnType("integer");
+						.HasColumnType("int");
 
 					b.Property<int>("ConfigurationType")
-						.HasColumnType("integer");
+						.HasColumnType("int");
 
 					b.Property<string>("Name")
 						.IsRequired()
-						.HasColumnType("character varying(10000)")
+						.HasColumnType("nvarchar(max)")
 						.HasMaxLength(10000);
 
 					b.Property<bool?>("Online")
 						.IsRequired()
-						.HasColumnType("boolean");
+						.HasColumnType("bit");
 
 					b.Property<string>("Path")
 						.IsRequired()
-						.HasColumnType("text");
+						.HasColumnType("nvarchar(450)");
 
 					b.HasKey("Id");
 
@@ -300,31 +304,31 @@ namespace Tgstation.Server.Host.Database.Migrations
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
 						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
 					b.Property<decimal>("ByondRights")
-						.HasColumnType("numeric(20,0)");
+						.HasColumnType("decimal(20,0)");
 
 					b.Property<decimal>("ChatBotRights")
-						.HasColumnType("numeric(20,0)");
+						.HasColumnType("decimal(20,0)");
 
 					b.Property<decimal>("ConfigurationRights")
-						.HasColumnType("numeric(20,0)");
+						.HasColumnType("decimal(20,0)");
 
 					b.Property<decimal>("DreamDaemonRights")
-						.HasColumnType("numeric(20,0)");
+						.HasColumnType("decimal(20,0)");
 
 					b.Property<decimal>("DreamMakerRights")
-						.HasColumnType("numeric(20,0)");
+						.HasColumnType("decimal(20,0)");
 
 					b.Property<long>("InstanceId")
 						.HasColumnType("bigint");
 
 					b.Property<decimal>("InstanceUserRights")
-						.HasColumnType("numeric(20,0)");
+						.HasColumnType("decimal(20,0)");
 
 					b.Property<decimal>("RepositoryRights")
-						.HasColumnType("numeric(20,0)");
+						.HasColumnType("decimal(20,0)");
 
 					b.Property<long?>("UserId")
 						.IsRequired()
@@ -345,43 +349,43 @@ namespace Tgstation.Server.Host.Database.Migrations
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
 						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
 					b.Property<decimal?>("CancelRight")
-						.HasColumnType("numeric(20,0)");
+						.HasColumnType("decimal(20,0)");
 
 					b.Property<decimal?>("CancelRightsType")
-						.HasColumnType("numeric(20,0)");
+						.HasColumnType("decimal(20,0)");
 
 					b.Property<bool?>("Cancelled")
 						.IsRequired()
-						.HasColumnType("boolean");
+						.HasColumnType("bit");
 
 					b.Property<long?>("CancelledById")
 						.HasColumnType("bigint");
 
 					b.Property<string>("Description")
 						.IsRequired()
-						.HasColumnType("text");
+						.HasColumnType("nvarchar(max)");
 
 					b.Property<long?>("ErrorCode")
 						.HasColumnType("bigint");
 
 					b.Property<string>("ExceptionDetails")
-						.HasColumnType("text");
+						.HasColumnType("nvarchar(max)");
 
 					b.Property<long>("InstanceId")
 						.HasColumnType("bigint");
 
 					b.Property<DateTimeOffset?>("StartedAt")
 						.IsRequired()
-						.HasColumnType("timestamp with time zone");
+						.HasColumnType("datetimeoffset");
 
 					b.Property<long>("StartedById")
 						.HasColumnType("bigint");
 
 					b.Property<DateTimeOffset?>("StoppedAt")
-						.HasColumnType("timestamp with time zone");
+						.HasColumnType("datetimeoffset");
 
 					b.HasKey("Id");
 
@@ -399,29 +403,29 @@ namespace Tgstation.Server.Host.Database.Migrations
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
 						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
 					b.Property<string>("AccessIdentifier")
 						.IsRequired()
-						.HasColumnType("text");
+						.HasColumnType("nvarchar(max)");
 
 					b.Property<long>("CompileJobId")
 						.HasColumnType("bigint");
 
 					b.Property<bool>("IsPrimary")
-						.HasColumnType("boolean");
+						.HasColumnType("bit");
 
 					b.Property<int>("LaunchSecurityLevel")
-						.HasColumnType("integer");
+						.HasColumnType("int");
 
 					b.Property<int>("Port")
-						.HasColumnType("integer");
+						.HasColumnType("int");
 
 					b.Property<int>("ProcessId")
-						.HasColumnType("integer");
+						.HasColumnType("int");
 
 					b.Property<int>("RebootState")
-						.HasColumnType("integer");
+						.HasColumnType("int");
 
 					b.HasKey("Id");
 
@@ -435,32 +439,32 @@ namespace Tgstation.Server.Host.Database.Migrations
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
 						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
 					b.Property<string>("AccessToken")
-						.HasColumnType("character varying(10000)")
+						.HasColumnType("nvarchar(max)")
 						.HasMaxLength(10000);
 
 					b.Property<string>("AccessUser")
-						.HasColumnType("character varying(10000)")
+						.HasColumnType("nvarchar(max)")
 						.HasMaxLength(10000);
 
 					b.Property<bool?>("AutoUpdatesKeepTestMerges")
 						.IsRequired()
-						.HasColumnType("boolean");
+						.HasColumnType("bit");
 
 					b.Property<bool?>("AutoUpdatesSynchronize")
 						.IsRequired()
-						.HasColumnType("boolean");
+						.HasColumnType("bit");
 
 					b.Property<string>("CommitterEmail")
 						.IsRequired()
-						.HasColumnType("character varying(10000)")
+						.HasColumnType("nvarchar(max)")
 						.HasMaxLength(10000);
 
 					b.Property<string>("CommitterName")
 						.IsRequired()
-						.HasColumnType("character varying(10000)")
+						.HasColumnType("nvarchar(max)")
 						.HasMaxLength(10000);
 
 					b.Property<long>("InstanceId")
@@ -468,15 +472,15 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 					b.Property<bool?>("PostTestMergeComment")
 						.IsRequired()
-						.HasColumnType("boolean");
+						.HasColumnType("bit");
 
 					b.Property<bool?>("PushTestMergeCommits")
 						.IsRequired()
-						.HasColumnType("boolean");
+						.HasColumnType("bit");
 
 					b.Property<bool?>("ShowTestMergeCommitters")
 						.IsRequired()
-						.HasColumnType("boolean");
+						.HasColumnType("bit");
 
 					b.HasKey("Id");
 
@@ -491,7 +495,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
 						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
 					b.Property<long>("RevisionInformationId")
 						.HasColumnType("bigint");
@@ -513,11 +517,11 @@ namespace Tgstation.Server.Host.Database.Migrations
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
 						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
 					b.Property<string>("CommitSha")
 						.IsRequired()
-						.HasColumnType("character varying(40)")
+						.HasColumnType("nvarchar(40)")
 						.HasMaxLength(40);
 
 					b.Property<long>("InstanceId")
@@ -525,7 +529,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 					b.Property<string>("OriginCommitSha")
 						.IsRequired()
-						.HasColumnType("character varying(40)")
+						.HasColumnType("nvarchar(40)")
 						.HasMaxLength(40);
 
 					b.HasKey("Id");
@@ -541,28 +545,28 @@ namespace Tgstation.Server.Host.Database.Migrations
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
 						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
 					b.Property<string>("Author")
 						.IsRequired()
-						.HasColumnType("text");
+						.HasColumnType("nvarchar(max)");
 
 					b.Property<string>("BodyAtMerge")
 						.IsRequired()
-						.HasColumnType("text");
+						.HasColumnType("nvarchar(max)");
 
 					b.Property<string>("Comment")
-						.HasColumnType("character varying(10000)")
+						.HasColumnType("nvarchar(max)")
 						.HasMaxLength(10000);
 
 					b.Property<DateTimeOffset>("MergedAt")
-						.HasColumnType("timestamp with time zone");
+						.HasColumnType("datetimeoffset");
 
 					b.Property<long>("MergedById")
 						.HasColumnType("bigint");
 
 					b.Property<int>("Number")
-						.HasColumnType("integer");
+						.HasColumnType("int");
 
 					b.Property<long?>("PrimaryRevisionInformationId")
 						.IsRequired()
@@ -570,16 +574,16 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 					b.Property<string>("PullRequestRevision")
 						.IsRequired()
-						.HasColumnType("character varying(40)")
+						.HasColumnType("nvarchar(40)")
 						.HasMaxLength(40);
 
 					b.Property<string>("TitleAtMerge")
 						.IsRequired()
-						.HasColumnType("text");
+						.HasColumnType("nvarchar(max)");
 
 					b.Property<string>("Url")
 						.IsRequired()
-						.HasColumnType("text");
+						.HasColumnType("nvarchar(max)");
 
 					b.HasKey("Id");
 
@@ -596,42 +600,42 @@ namespace Tgstation.Server.Host.Database.Migrations
 					b.Property<long?>("Id")
 						.ValueGeneratedOnAdd()
 						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
 					b.Property<decimal>("AdministrationRights")
-						.HasColumnType("numeric(20,0)");
+						.HasColumnType("decimal(20,0)");
 
 					b.Property<string>("CanonicalName")
 						.IsRequired()
-						.HasColumnType("text");
+						.HasColumnType("nvarchar(450)");
 
 					b.Property<DateTimeOffset?>("CreatedAt")
 						.IsRequired()
-						.HasColumnType("timestamp with time zone");
+						.HasColumnType("datetimeoffset");
 
 					b.Property<long?>("CreatedById")
 						.HasColumnType("bigint");
 
 					b.Property<bool?>("Enabled")
 						.IsRequired()
-						.HasColumnType("boolean");
+						.HasColumnType("bit");
 
 					b.Property<decimal>("InstanceManagerRights")
-						.HasColumnType("numeric(20,0)");
+						.HasColumnType("decimal(20,0)");
 
 					b.Property<DateTimeOffset?>("LastPasswordUpdate")
-						.HasColumnType("timestamp with time zone");
+						.HasColumnType("datetimeoffset");
 
 					b.Property<string>("Name")
 						.IsRequired()
-						.HasColumnType("character varying(10000)")
+						.HasColumnType("nvarchar(max)")
 						.HasMaxLength(10000);
 
 					b.Property<string>("PasswordHash")
-						.HasColumnType("text");
+						.HasColumnType("nvarchar(max)");
 
 					b.Property<string>("SystemIdentifier")
-						.HasColumnType("text");
+						.HasColumnType("nvarchar(450)");
 
 					b.HasKey("Id");
 
@@ -641,7 +645,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					b.HasIndex("CreatedById");
 
 					b.HasIndex("SystemIdentifier")
-						.IsUnique();
+						.IsUnique()
+						.HasFilter("[SystemIdentifier] IS NOT NULL");
 
 					b.ToTable("Users");
 				});
@@ -675,7 +680,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 					b.HasOne("Tgstation.Server.Host.Models.RevisionInformation", "RevisionInformation")
 						.WithMany("CompileJobs")
 						.HasForeignKey("RevisionInformationId")
-						.OnDelete(DeleteBehavior.Cascade)
+						.OnDelete(DeleteBehavior.ClientNoAction)
 						.IsRequired();
 				});
 

--- a/src/Tgstation.Server.Host/Database/Migrations/20200616175424_MSTopicTimeout.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20200616175424_MSTopicTimeout.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using System;
+
+namespace Tgstation.Server.Host.Database.Migrations
+{
+	/// <summary>
+	/// Add BYOND topic timeouts for MSSQL.
+	/// </summary>
+	public partial class MSTopicTimeout : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			if (migrationBuilder == null)
+				throw new ArgumentNullException(nameof(migrationBuilder));
+			migrationBuilder.AddColumn<long>(
+				name: "TopicRequestTimeout",
+				table: "DreamDaemonSettings",
+				nullable: false,
+				defaultValue: 0L);
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			if (migrationBuilder == null)
+				throw new ArgumentNullException(nameof(migrationBuilder));
+			migrationBuilder.DropColumn(
+				name: "TopicRequestTimeout",
+				table: "DreamDaemonSettings");
+		}
+	}
+}

--- a/src/Tgstation.Server.Host/Database/Migrations/20200616175535_MYTopicTimeout.Designer.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20200616175535_MYTopicTimeout.Designer.cs
@@ -2,53 +2,54 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Tgstation.Server.Host.Database.Migrations
 {
-	[DbContext(typeof(PostgresSqlDatabaseContext))]
-	partial class PostgresSqlDatabaseContextModelSnapshot : ModelSnapshot
+	[DbContext(typeof(MySqlDatabaseContext))]
+	[Migration("20200616175535_MYTopicTimeout")]
+	partial class MYTopicTimeout
 	{
 		/// <inheritdoc />
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder
-				.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn)
 				.HasAnnotation("ProductVersion", "3.1.4")
-				.HasAnnotation("Relational:MaxIdentifierLength", 63);
+				.HasAnnotation("Relational:MaxIdentifierLength", 64);
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.ChatBot", b =>
 				{
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
-						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasColumnType("bigint");
 
-					b.Property<int>("ChannelLimit")
-						.HasColumnType("integer");
+					b.Property<ushort?>("ChannelLimit")
+						.IsRequired()
+						.HasColumnType("smallint unsigned");
 
 					b.Property<string>("ConnectionString")
 						.IsRequired()
-						.HasColumnType("character varying(10000)")
+						.HasColumnType("longtext CHARACTER SET utf8mb4")
 						.HasMaxLength(10000);
 
 					b.Property<bool?>("Enabled")
-						.HasColumnType("boolean");
+						.HasColumnType("tinyint(1)");
 
 					b.Property<long>("InstanceId")
 						.HasColumnType("bigint");
 
 					b.Property<string>("Name")
 						.IsRequired()
-						.HasColumnType("character varying(100)")
+						.HasColumnType("varchar(100) CHARACTER SET utf8mb4")
 						.HasMaxLength(100);
 
 					b.Property<int>("Provider")
-						.HasColumnType("integer");
+						.HasColumnType("int");
 
-					b.Property<long>("ReconnectionInterval")
-						.HasColumnType("bigint");
+					b.Property<uint?>("ReconnectionInterval")
+						.IsRequired()
+						.HasColumnType("int unsigned");
 
 					b.HasKey("Id");
 
@@ -62,33 +63,32 @@ namespace Tgstation.Server.Host.Database.Migrations
 				{
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
-						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasColumnType("bigint");
 
 					b.Property<long>("ChatSettingsId")
 						.HasColumnType("bigint");
 
-					b.Property<decimal?>("DiscordChannelId")
-						.HasColumnType("numeric(20,0)");
+					b.Property<ulong?>("DiscordChannelId")
+						.HasColumnType("bigint unsigned");
 
 					b.Property<string>("IrcChannel")
-						.HasColumnType("character varying(100)")
+						.HasColumnType("varchar(100) CHARACTER SET utf8mb4")
 						.HasMaxLength(100);
 
 					b.Property<bool?>("IsAdminChannel")
 						.IsRequired()
-						.HasColumnType("boolean");
+						.HasColumnType("tinyint(1)");
 
 					b.Property<bool?>("IsUpdatesChannel")
 						.IsRequired()
-						.HasColumnType("boolean");
+						.HasColumnType("tinyint(1)");
 
 					b.Property<bool?>("IsWatchdogChannel")
 						.IsRequired()
-						.HasColumnType("boolean");
+						.HasColumnType("tinyint(1)");
 
 					b.Property<string>("Tag")
-						.HasColumnType("character varying(10000)")
+						.HasColumnType("longtext CHARACTER SET utf8mb4")
 						.HasMaxLength(10000);
 
 					b.HasKey("Id");
@@ -106,39 +106,38 @@ namespace Tgstation.Server.Host.Database.Migrations
 				{
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
-						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasColumnType("bigint");
 
 					b.Property<string>("ByondVersion")
 						.IsRequired()
-						.HasColumnType("text");
+						.HasColumnType("longtext CHARACTER SET utf8mb4");
 
 					b.Property<int?>("DMApiMajorVersion")
-						.HasColumnType("integer");
+						.HasColumnType("int");
 
 					b.Property<int?>("DMApiMinorVersion")
-						.HasColumnType("integer");
+						.HasColumnType("int");
 
 					b.Property<int?>("DMApiPatchVersion")
-						.HasColumnType("integer");
+						.HasColumnType("int");
 
 					b.Property<Guid?>("DirectoryName")
 						.IsRequired()
-						.HasColumnType("uuid");
+						.HasColumnType("char(36)");
 
 					b.Property<string>("DmeName")
 						.IsRequired()
-						.HasColumnType("text");
+						.HasColumnType("longtext CHARACTER SET utf8mb4");
 
 					b.Property<long>("JobId")
 						.HasColumnType("bigint");
 
 					b.Property<int>("MinimumSecurityLevel")
-						.HasColumnType("integer");
+						.HasColumnType("int");
 
 					b.Property<string>("Output")
 						.IsRequired()
-						.HasColumnType("text");
+						.HasColumnType("longtext CHARACTER SET utf8mb4");
 
 					b.Property<long>("RevisionInformationId")
 						.HasColumnType("bigint");
@@ -159,37 +158,41 @@ namespace Tgstation.Server.Host.Database.Migrations
 				{
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
-						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasColumnType("bigint");
 
 					b.Property<bool?>("AllowWebClient")
 						.IsRequired()
-						.HasColumnType("boolean");
+						.HasColumnType("tinyint(1)");
 
 					b.Property<bool?>("AutoStart")
 						.IsRequired()
-						.HasColumnType("boolean");
+						.HasColumnType("tinyint(1)");
 
-					b.Property<long>("HeartbeatSeconds")
-						.HasColumnType("bigint");
+					b.Property<uint?>("HeartbeatSeconds")
+						.IsRequired()
+						.HasColumnType("int unsigned");
 
 					b.Property<long>("InstanceId")
 						.HasColumnType("bigint");
 
-					b.Property<int>("PrimaryPort")
-						.HasColumnType("integer");
+					b.Property<ushort?>("PrimaryPort")
+						.IsRequired()
+						.HasColumnType("smallint unsigned");
 
-					b.Property<int>("SecondaryPort")
-						.HasColumnType("integer");
+					b.Property<ushort?>("SecondaryPort")
+						.IsRequired()
+						.HasColumnType("smallint unsigned");
 
 					b.Property<int>("SecurityLevel")
-						.HasColumnType("integer");
+						.HasColumnType("int");
 
-					b.Property<long>("StartupTimeout")
-						.HasColumnType("bigint");
+					b.Property<uint?>("StartupTimeout")
+						.IsRequired()
+						.HasColumnType("int unsigned");
 
-					b.Property<long>("TopicRequestTimeout")
-						.HasColumnType("bigint");
+					b.Property<uint?>("TopicRequestTimeout")
+						.IsRequired()
+						.HasColumnType("int unsigned");
 
 					b.HasKey("Id");
 
@@ -203,20 +206,20 @@ namespace Tgstation.Server.Host.Database.Migrations
 				{
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
-						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasColumnType("bigint");
 
-					b.Property<int>("ApiValidationPort")
-						.HasColumnType("integer");
+					b.Property<ushort?>("ApiValidationPort")
+						.IsRequired()
+						.HasColumnType("smallint unsigned");
 
 					b.Property<int>("ApiValidationSecurityLevel")
-						.HasColumnType("integer");
+						.HasColumnType("int");
 
 					b.Property<long>("InstanceId")
 						.HasColumnType("bigint");
 
 					b.Property<string>("ProjectName")
-						.HasColumnType("character varying(10000)")
+						.HasColumnType("longtext CHARACTER SET utf8mb4")
 						.HasMaxLength(10000);
 
 					b.HasKey("Id");
@@ -231,14 +234,13 @@ namespace Tgstation.Server.Host.Database.Migrations
 				{
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
-						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasColumnType("bigint");
 
 					b.Property<long?>("AlphaId")
 						.HasColumnType("bigint");
 
 					b.Property<bool>("AlphaIsActive")
-						.HasColumnType("boolean");
+						.HasColumnType("tinyint(1)");
 
 					b.Property<long?>("BravoId")
 						.HasColumnType("bigint");
@@ -262,30 +264,31 @@ namespace Tgstation.Server.Host.Database.Migrations
 				{
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
-						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
-
-					b.Property<long>("AutoUpdateInterval")
 						.HasColumnType("bigint");
 
-					b.Property<int>("ChatBotLimit")
-						.HasColumnType("integer");
+					b.Property<uint?>("AutoUpdateInterval")
+						.IsRequired()
+						.HasColumnType("int unsigned");
+
+					b.Property<ushort?>("ChatBotLimit")
+						.IsRequired()
+						.HasColumnType("smallint unsigned");
 
 					b.Property<int>("ConfigurationType")
-						.HasColumnType("integer");
+						.HasColumnType("int");
 
 					b.Property<string>("Name")
 						.IsRequired()
-						.HasColumnType("character varying(10000)")
+						.HasColumnType("longtext CHARACTER SET utf8mb4")
 						.HasMaxLength(10000);
 
 					b.Property<bool?>("Online")
 						.IsRequired()
-						.HasColumnType("boolean");
+						.HasColumnType("tinyint(1)");
 
 					b.Property<string>("Path")
 						.IsRequired()
-						.HasColumnType("text");
+						.HasColumnType("varchar(255) CHARACTER SET utf8mb4");
 
 					b.HasKey("Id");
 
@@ -299,32 +302,31 @@ namespace Tgstation.Server.Host.Database.Migrations
 				{
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
-						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasColumnType("bigint");
 
-					b.Property<decimal>("ByondRights")
-						.HasColumnType("numeric(20,0)");
+					b.Property<ulong>("ByondRights")
+						.HasColumnType("bigint unsigned");
 
-					b.Property<decimal>("ChatBotRights")
-						.HasColumnType("numeric(20,0)");
+					b.Property<ulong>("ChatBotRights")
+						.HasColumnType("bigint unsigned");
 
-					b.Property<decimal>("ConfigurationRights")
-						.HasColumnType("numeric(20,0)");
+					b.Property<ulong>("ConfigurationRights")
+						.HasColumnType("bigint unsigned");
 
-					b.Property<decimal>("DreamDaemonRights")
-						.HasColumnType("numeric(20,0)");
+					b.Property<ulong>("DreamDaemonRights")
+						.HasColumnType("bigint unsigned");
 
-					b.Property<decimal>("DreamMakerRights")
-						.HasColumnType("numeric(20,0)");
+					b.Property<ulong>("DreamMakerRights")
+						.HasColumnType("bigint unsigned");
 
 					b.Property<long>("InstanceId")
 						.HasColumnType("bigint");
 
-					b.Property<decimal>("InstanceUserRights")
-						.HasColumnType("numeric(20,0)");
+					b.Property<ulong>("InstanceUserRights")
+						.HasColumnType("bigint unsigned");
 
-					b.Property<decimal>("RepositoryRights")
-						.HasColumnType("numeric(20,0)");
+					b.Property<ulong>("RepositoryRights")
+						.HasColumnType("bigint unsigned");
 
 					b.Property<long?>("UserId")
 						.IsRequired()
@@ -344,44 +346,43 @@ namespace Tgstation.Server.Host.Database.Migrations
 				{
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
-						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasColumnType("bigint");
 
-					b.Property<decimal?>("CancelRight")
-						.HasColumnType("numeric(20,0)");
+					b.Property<ulong?>("CancelRight")
+						.HasColumnType("bigint unsigned");
 
-					b.Property<decimal?>("CancelRightsType")
-						.HasColumnType("numeric(20,0)");
+					b.Property<ulong?>("CancelRightsType")
+						.HasColumnType("bigint unsigned");
 
 					b.Property<bool?>("Cancelled")
 						.IsRequired()
-						.HasColumnType("boolean");
+						.HasColumnType("tinyint(1)");
 
 					b.Property<long?>("CancelledById")
 						.HasColumnType("bigint");
 
 					b.Property<string>("Description")
 						.IsRequired()
-						.HasColumnType("text");
+						.HasColumnType("longtext CHARACTER SET utf8mb4");
 
-					b.Property<long?>("ErrorCode")
-						.HasColumnType("bigint");
+					b.Property<uint?>("ErrorCode")
+						.HasColumnType("int unsigned");
 
 					b.Property<string>("ExceptionDetails")
-						.HasColumnType("text");
+						.HasColumnType("longtext CHARACTER SET utf8mb4");
 
 					b.Property<long>("InstanceId")
 						.HasColumnType("bigint");
 
 					b.Property<DateTimeOffset?>("StartedAt")
 						.IsRequired()
-						.HasColumnType("timestamp with time zone");
+						.HasColumnType("datetime(6)");
 
 					b.Property<long>("StartedById")
 						.HasColumnType("bigint");
 
 					b.Property<DateTimeOffset?>("StoppedAt")
-						.HasColumnType("timestamp with time zone");
+						.HasColumnType("datetime(6)");
 
 					b.HasKey("Id");
 
@@ -398,30 +399,29 @@ namespace Tgstation.Server.Host.Database.Migrations
 				{
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
-						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasColumnType("bigint");
 
 					b.Property<string>("AccessIdentifier")
 						.IsRequired()
-						.HasColumnType("text");
+						.HasColumnType("longtext CHARACTER SET utf8mb4");
 
 					b.Property<long>("CompileJobId")
 						.HasColumnType("bigint");
 
 					b.Property<bool>("IsPrimary")
-						.HasColumnType("boolean");
+						.HasColumnType("tinyint(1)");
 
 					b.Property<int>("LaunchSecurityLevel")
-						.HasColumnType("integer");
+						.HasColumnType("int");
 
-					b.Property<int>("Port")
-						.HasColumnType("integer");
+					b.Property<ushort>("Port")
+						.HasColumnType("smallint unsigned");
 
 					b.Property<int>("ProcessId")
-						.HasColumnType("integer");
+						.HasColumnType("int");
 
 					b.Property<int>("RebootState")
-						.HasColumnType("integer");
+						.HasColumnType("int");
 
 					b.HasKey("Id");
 
@@ -434,33 +434,32 @@ namespace Tgstation.Server.Host.Database.Migrations
 				{
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
-						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasColumnType("bigint");
 
 					b.Property<string>("AccessToken")
-						.HasColumnType("character varying(10000)")
+						.HasColumnType("longtext CHARACTER SET utf8mb4")
 						.HasMaxLength(10000);
 
 					b.Property<string>("AccessUser")
-						.HasColumnType("character varying(10000)")
+						.HasColumnType("longtext CHARACTER SET utf8mb4")
 						.HasMaxLength(10000);
 
 					b.Property<bool?>("AutoUpdatesKeepTestMerges")
 						.IsRequired()
-						.HasColumnType("boolean");
+						.HasColumnType("tinyint(1)");
 
 					b.Property<bool?>("AutoUpdatesSynchronize")
 						.IsRequired()
-						.HasColumnType("boolean");
+						.HasColumnType("tinyint(1)");
 
 					b.Property<string>("CommitterEmail")
 						.IsRequired()
-						.HasColumnType("character varying(10000)")
+						.HasColumnType("longtext CHARACTER SET utf8mb4")
 						.HasMaxLength(10000);
 
 					b.Property<string>("CommitterName")
 						.IsRequired()
-						.HasColumnType("character varying(10000)")
+						.HasColumnType("longtext CHARACTER SET utf8mb4")
 						.HasMaxLength(10000);
 
 					b.Property<long>("InstanceId")
@@ -468,15 +467,15 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 					b.Property<bool?>("PostTestMergeComment")
 						.IsRequired()
-						.HasColumnType("boolean");
+						.HasColumnType("tinyint(1)");
 
 					b.Property<bool?>("PushTestMergeCommits")
 						.IsRequired()
-						.HasColumnType("boolean");
+						.HasColumnType("tinyint(1)");
 
 					b.Property<bool?>("ShowTestMergeCommitters")
 						.IsRequired()
-						.HasColumnType("boolean");
+						.HasColumnType("tinyint(1)");
 
 					b.HasKey("Id");
 
@@ -490,8 +489,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 				{
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
-						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasColumnType("bigint");
 
 					b.Property<long>("RevisionInformationId")
 						.HasColumnType("bigint");
@@ -512,12 +510,11 @@ namespace Tgstation.Server.Host.Database.Migrations
 				{
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
-						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasColumnType("bigint");
 
 					b.Property<string>("CommitSha")
 						.IsRequired()
-						.HasColumnType("character varying(40)")
+						.HasColumnType("varchar(40) CHARACTER SET utf8mb4")
 						.HasMaxLength(40);
 
 					b.Property<long>("InstanceId")
@@ -525,7 +522,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 					b.Property<string>("OriginCommitSha")
 						.IsRequired()
-						.HasColumnType("character varying(40)")
+						.HasColumnType("varchar(40) CHARACTER SET utf8mb4")
 						.HasMaxLength(40);
 
 					b.HasKey("Id");
@@ -540,29 +537,28 @@ namespace Tgstation.Server.Host.Database.Migrations
 				{
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
-						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasColumnType("bigint");
 
 					b.Property<string>("Author")
 						.IsRequired()
-						.HasColumnType("text");
+						.HasColumnType("longtext CHARACTER SET utf8mb4");
 
 					b.Property<string>("BodyAtMerge")
 						.IsRequired()
-						.HasColumnType("text");
+						.HasColumnType("longtext CHARACTER SET utf8mb4");
 
 					b.Property<string>("Comment")
-						.HasColumnType("character varying(10000)")
+						.HasColumnType("longtext CHARACTER SET utf8mb4")
 						.HasMaxLength(10000);
 
 					b.Property<DateTimeOffset>("MergedAt")
-						.HasColumnType("timestamp with time zone");
+						.HasColumnType("datetime(6)");
 
 					b.Property<long>("MergedById")
 						.HasColumnType("bigint");
 
 					b.Property<int>("Number")
-						.HasColumnType("integer");
+						.HasColumnType("int");
 
 					b.Property<long?>("PrimaryRevisionInformationId")
 						.IsRequired()
@@ -570,16 +566,16 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 					b.Property<string>("PullRequestRevision")
 						.IsRequired()
-						.HasColumnType("character varying(40)")
+						.HasColumnType("varchar(40) CHARACTER SET utf8mb4")
 						.HasMaxLength(40);
 
 					b.Property<string>("TitleAtMerge")
 						.IsRequired()
-						.HasColumnType("text");
+						.HasColumnType("longtext CHARACTER SET utf8mb4");
 
 					b.Property<string>("Url")
 						.IsRequired()
-						.HasColumnType("text");
+						.HasColumnType("longtext CHARACTER SET utf8mb4");
 
 					b.HasKey("Id");
 
@@ -595,43 +591,42 @@ namespace Tgstation.Server.Host.Database.Migrations
 				{
 					b.Property<long?>("Id")
 						.ValueGeneratedOnAdd()
-						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasColumnType("bigint");
 
-					b.Property<decimal>("AdministrationRights")
-						.HasColumnType("numeric(20,0)");
+					b.Property<ulong>("AdministrationRights")
+						.HasColumnType("bigint unsigned");
 
 					b.Property<string>("CanonicalName")
 						.IsRequired()
-						.HasColumnType("text");
+						.HasColumnType("varchar(255) CHARACTER SET utf8mb4");
 
 					b.Property<DateTimeOffset?>("CreatedAt")
 						.IsRequired()
-						.HasColumnType("timestamp with time zone");
+						.HasColumnType("datetime(6)");
 
 					b.Property<long?>("CreatedById")
 						.HasColumnType("bigint");
 
 					b.Property<bool?>("Enabled")
 						.IsRequired()
-						.HasColumnType("boolean");
+						.HasColumnType("tinyint(1)");
 
-					b.Property<decimal>("InstanceManagerRights")
-						.HasColumnType("numeric(20,0)");
+					b.Property<ulong>("InstanceManagerRights")
+						.HasColumnType("bigint unsigned");
 
 					b.Property<DateTimeOffset?>("LastPasswordUpdate")
-						.HasColumnType("timestamp with time zone");
+						.HasColumnType("datetime(6)");
 
 					b.Property<string>("Name")
 						.IsRequired()
-						.HasColumnType("character varying(10000)")
+						.HasColumnType("longtext CHARACTER SET utf8mb4")
 						.HasMaxLength(10000);
 
 					b.Property<string>("PasswordHash")
-						.HasColumnType("text");
+						.HasColumnType("longtext CHARACTER SET utf8mb4");
 
 					b.Property<string>("SystemIdentifier")
-						.HasColumnType("text");
+						.HasColumnType("varchar(255) CHARACTER SET utf8mb4");
 
 					b.HasKey("Id");
 

--- a/src/Tgstation.Server.Host/Database/Migrations/20200616175535_MYTopicTimeout.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20200616175535_MYTopicTimeout.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using System;
+
+namespace Tgstation.Server.Host.Database.Migrations
+{
+	/// <summary>
+	/// Add BYOND topic timeouts for MYSQL.
+	/// </summary>
+	public partial class MYTopicTimeout : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			if (migrationBuilder == null)
+				throw new ArgumentNullException(nameof(migrationBuilder));
+			migrationBuilder.AddColumn<uint>(
+				name: "TopicRequestTimeout",
+				table: "DreamDaemonSettings",
+				nullable: false,
+				defaultValue: 0u);
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			if (migrationBuilder == null)
+				throw new ArgumentNullException(nameof(migrationBuilder));
+			migrationBuilder.DropColumn(
+				name: "TopicRequestTimeout",
+				table: "DreamDaemonSettings");
+		}
+	}
+}

--- a/src/Tgstation.Server.Host/Database/Migrations/20200616180742_SLTopicTimeout.Designer.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20200616180742_SLTopicTimeout.Designer.cs
@@ -2,53 +2,53 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Tgstation.Server.Host.Database.Migrations
 {
-	[DbContext(typeof(PostgresSqlDatabaseContext))]
-	partial class PostgresSqlDatabaseContextModelSnapshot : ModelSnapshot
+	[DbContext(typeof(SqliteDatabaseContext))]
+	[Migration("20200616180742_SLTopicTimeout")]
+	partial class SLTopicTimeout
 	{
 		/// <inheritdoc />
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder
-				.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn)
-				.HasAnnotation("ProductVersion", "3.1.4")
-				.HasAnnotation("Relational:MaxIdentifierLength", 63);
+				.HasAnnotation("ProductVersion", "3.1.4");
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.ChatBot", b =>
 				{
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
-						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasColumnType("INTEGER");
 
-					b.Property<int>("ChannelLimit")
-						.HasColumnType("integer");
+					b.Property<ushort?>("ChannelLimit")
+						.IsRequired()
+						.HasColumnType("INTEGER");
 
 					b.Property<string>("ConnectionString")
 						.IsRequired()
-						.HasColumnType("character varying(10000)")
+						.HasColumnType("TEXT")
 						.HasMaxLength(10000);
 
 					b.Property<bool?>("Enabled")
-						.HasColumnType("boolean");
+						.HasColumnType("INTEGER");
 
 					b.Property<long>("InstanceId")
-						.HasColumnType("bigint");
+						.HasColumnType("INTEGER");
 
 					b.Property<string>("Name")
 						.IsRequired()
-						.HasColumnType("character varying(100)")
+						.HasColumnType("TEXT")
 						.HasMaxLength(100);
 
 					b.Property<int>("Provider")
-						.HasColumnType("integer");
+						.HasColumnType("INTEGER");
 
-					b.Property<long>("ReconnectionInterval")
-						.HasColumnType("bigint");
+					b.Property<uint?>("ReconnectionInterval")
+						.IsRequired()
+						.HasColumnType("INTEGER");
 
 					b.HasKey("Id");
 
@@ -62,33 +62,32 @@ namespace Tgstation.Server.Host.Database.Migrations
 				{
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
-						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasColumnType("INTEGER");
 
 					b.Property<long>("ChatSettingsId")
-						.HasColumnType("bigint");
+						.HasColumnType("INTEGER");
 
-					b.Property<decimal?>("DiscordChannelId")
-						.HasColumnType("numeric(20,0)");
+					b.Property<ulong?>("DiscordChannelId")
+						.HasColumnType("INTEGER");
 
 					b.Property<string>("IrcChannel")
-						.HasColumnType("character varying(100)")
+						.HasColumnType("TEXT")
 						.HasMaxLength(100);
 
 					b.Property<bool?>("IsAdminChannel")
 						.IsRequired()
-						.HasColumnType("boolean");
+						.HasColumnType("INTEGER");
 
 					b.Property<bool?>("IsUpdatesChannel")
 						.IsRequired()
-						.HasColumnType("boolean");
+						.HasColumnType("INTEGER");
 
 					b.Property<bool?>("IsWatchdogChannel")
 						.IsRequired()
-						.HasColumnType("boolean");
+						.HasColumnType("INTEGER");
 
 					b.Property<string>("Tag")
-						.HasColumnType("character varying(10000)")
+						.HasColumnType("TEXT")
 						.HasMaxLength(10000);
 
 					b.HasKey("Id");
@@ -106,42 +105,41 @@ namespace Tgstation.Server.Host.Database.Migrations
 				{
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
-						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasColumnType("INTEGER");
 
 					b.Property<string>("ByondVersion")
 						.IsRequired()
-						.HasColumnType("text");
+						.HasColumnType("TEXT");
 
 					b.Property<int?>("DMApiMajorVersion")
-						.HasColumnType("integer");
+						.HasColumnType("INTEGER");
 
 					b.Property<int?>("DMApiMinorVersion")
-						.HasColumnType("integer");
+						.HasColumnType("INTEGER");
 
 					b.Property<int?>("DMApiPatchVersion")
-						.HasColumnType("integer");
+						.HasColumnType("INTEGER");
 
 					b.Property<Guid?>("DirectoryName")
 						.IsRequired()
-						.HasColumnType("uuid");
+						.HasColumnType("TEXT");
 
 					b.Property<string>("DmeName")
 						.IsRequired()
-						.HasColumnType("text");
+						.HasColumnType("TEXT");
 
 					b.Property<long>("JobId")
-						.HasColumnType("bigint");
+						.HasColumnType("INTEGER");
 
 					b.Property<int>("MinimumSecurityLevel")
-						.HasColumnType("integer");
+						.HasColumnType("INTEGER");
 
 					b.Property<string>("Output")
 						.IsRequired()
-						.HasColumnType("text");
+						.HasColumnType("TEXT");
 
 					b.Property<long>("RevisionInformationId")
-						.HasColumnType("bigint");
+						.HasColumnType("INTEGER");
 
 					b.HasKey("Id");
 
@@ -159,37 +157,41 @@ namespace Tgstation.Server.Host.Database.Migrations
 				{
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
-						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasColumnType("INTEGER");
 
 					b.Property<bool?>("AllowWebClient")
 						.IsRequired()
-						.HasColumnType("boolean");
+						.HasColumnType("INTEGER");
 
 					b.Property<bool?>("AutoStart")
 						.IsRequired()
-						.HasColumnType("boolean");
+						.HasColumnType("INTEGER");
 
-					b.Property<long>("HeartbeatSeconds")
-						.HasColumnType("bigint");
+					b.Property<uint?>("HeartbeatSeconds")
+						.IsRequired()
+						.HasColumnType("INTEGER");
 
 					b.Property<long>("InstanceId")
-						.HasColumnType("bigint");
+						.HasColumnType("INTEGER");
 
-					b.Property<int>("PrimaryPort")
-						.HasColumnType("integer");
+					b.Property<ushort?>("PrimaryPort")
+						.IsRequired()
+						.HasColumnType("INTEGER");
 
-					b.Property<int>("SecondaryPort")
-						.HasColumnType("integer");
+					b.Property<ushort?>("SecondaryPort")
+						.IsRequired()
+						.HasColumnType("INTEGER");
 
 					b.Property<int>("SecurityLevel")
-						.HasColumnType("integer");
+						.HasColumnType("INTEGER");
 
-					b.Property<long>("StartupTimeout")
-						.HasColumnType("bigint");
+					b.Property<uint?>("StartupTimeout")
+						.IsRequired()
+						.HasColumnType("INTEGER");
 
-					b.Property<long>("TopicRequestTimeout")
-						.HasColumnType("bigint");
+					b.Property<uint?>("TopicRequestTimeout")
+						.IsRequired()
+						.HasColumnType("INTEGER");
 
 					b.HasKey("Id");
 
@@ -203,20 +205,20 @@ namespace Tgstation.Server.Host.Database.Migrations
 				{
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
-						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasColumnType("INTEGER");
 
-					b.Property<int>("ApiValidationPort")
-						.HasColumnType("integer");
+					b.Property<ushort?>("ApiValidationPort")
+						.IsRequired()
+						.HasColumnType("INTEGER");
 
 					b.Property<int>("ApiValidationSecurityLevel")
-						.HasColumnType("integer");
+						.HasColumnType("INTEGER");
 
 					b.Property<long>("InstanceId")
-						.HasColumnType("bigint");
+						.HasColumnType("INTEGER");
 
 					b.Property<string>("ProjectName")
-						.HasColumnType("character varying(10000)")
+						.HasColumnType("TEXT")
 						.HasMaxLength(10000);
 
 					b.HasKey("Id");
@@ -231,20 +233,19 @@ namespace Tgstation.Server.Host.Database.Migrations
 				{
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
-						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasColumnType("INTEGER");
 
 					b.Property<long?>("AlphaId")
-						.HasColumnType("bigint");
+						.HasColumnType("INTEGER");
 
 					b.Property<bool>("AlphaIsActive")
-						.HasColumnType("boolean");
+						.HasColumnType("INTEGER");
 
 					b.Property<long?>("BravoId")
-						.HasColumnType("bigint");
+						.HasColumnType("INTEGER");
 
 					b.Property<long>("InstanceId")
-						.HasColumnType("bigint");
+						.HasColumnType("INTEGER");
 
 					b.HasKey("Id");
 
@@ -262,30 +263,31 @@ namespace Tgstation.Server.Host.Database.Migrations
 				{
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
-						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasColumnType("INTEGER");
 
-					b.Property<long>("AutoUpdateInterval")
-						.HasColumnType("bigint");
+					b.Property<uint?>("AutoUpdateInterval")
+						.IsRequired()
+						.HasColumnType("INTEGER");
 
-					b.Property<int>("ChatBotLimit")
-						.HasColumnType("integer");
+					b.Property<ushort?>("ChatBotLimit")
+						.IsRequired()
+						.HasColumnType("INTEGER");
 
 					b.Property<int>("ConfigurationType")
-						.HasColumnType("integer");
+						.HasColumnType("INTEGER");
 
 					b.Property<string>("Name")
 						.IsRequired()
-						.HasColumnType("character varying(10000)")
+						.HasColumnType("TEXT")
 						.HasMaxLength(10000);
 
 					b.Property<bool?>("Online")
 						.IsRequired()
-						.HasColumnType("boolean");
+						.HasColumnType("INTEGER");
 
 					b.Property<string>("Path")
 						.IsRequired()
-						.HasColumnType("text");
+						.HasColumnType("TEXT");
 
 					b.HasKey("Id");
 
@@ -299,36 +301,35 @@ namespace Tgstation.Server.Host.Database.Migrations
 				{
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
-						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasColumnType("INTEGER");
 
-					b.Property<decimal>("ByondRights")
-						.HasColumnType("numeric(20,0)");
+					b.Property<ulong>("ByondRights")
+						.HasColumnType("INTEGER");
 
-					b.Property<decimal>("ChatBotRights")
-						.HasColumnType("numeric(20,0)");
+					b.Property<ulong>("ChatBotRights")
+						.HasColumnType("INTEGER");
 
-					b.Property<decimal>("ConfigurationRights")
-						.HasColumnType("numeric(20,0)");
+					b.Property<ulong>("ConfigurationRights")
+						.HasColumnType("INTEGER");
 
-					b.Property<decimal>("DreamDaemonRights")
-						.HasColumnType("numeric(20,0)");
+					b.Property<ulong>("DreamDaemonRights")
+						.HasColumnType("INTEGER");
 
-					b.Property<decimal>("DreamMakerRights")
-						.HasColumnType("numeric(20,0)");
+					b.Property<ulong>("DreamMakerRights")
+						.HasColumnType("INTEGER");
 
 					b.Property<long>("InstanceId")
-						.HasColumnType("bigint");
+						.HasColumnType("INTEGER");
 
-					b.Property<decimal>("InstanceUserRights")
-						.HasColumnType("numeric(20,0)");
+					b.Property<ulong>("InstanceUserRights")
+						.HasColumnType("INTEGER");
 
-					b.Property<decimal>("RepositoryRights")
-						.HasColumnType("numeric(20,0)");
+					b.Property<ulong>("RepositoryRights")
+						.HasColumnType("INTEGER");
 
 					b.Property<long?>("UserId")
 						.IsRequired()
-						.HasColumnType("bigint");
+						.HasColumnType("INTEGER");
 
 					b.HasKey("Id");
 
@@ -344,44 +345,43 @@ namespace Tgstation.Server.Host.Database.Migrations
 				{
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
-						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasColumnType("INTEGER");
 
-					b.Property<decimal?>("CancelRight")
-						.HasColumnType("numeric(20,0)");
+					b.Property<ulong?>("CancelRight")
+						.HasColumnType("INTEGER");
 
-					b.Property<decimal?>("CancelRightsType")
-						.HasColumnType("numeric(20,0)");
+					b.Property<ulong?>("CancelRightsType")
+						.HasColumnType("INTEGER");
 
 					b.Property<bool?>("Cancelled")
 						.IsRequired()
-						.HasColumnType("boolean");
+						.HasColumnType("INTEGER");
 
 					b.Property<long?>("CancelledById")
-						.HasColumnType("bigint");
+						.HasColumnType("INTEGER");
 
 					b.Property<string>("Description")
 						.IsRequired()
-						.HasColumnType("text");
+						.HasColumnType("TEXT");
 
-					b.Property<long?>("ErrorCode")
-						.HasColumnType("bigint");
+					b.Property<uint?>("ErrorCode")
+						.HasColumnType("INTEGER");
 
 					b.Property<string>("ExceptionDetails")
-						.HasColumnType("text");
+						.HasColumnType("TEXT");
 
 					b.Property<long>("InstanceId")
-						.HasColumnType("bigint");
+						.HasColumnType("INTEGER");
 
 					b.Property<DateTimeOffset?>("StartedAt")
 						.IsRequired()
-						.HasColumnType("timestamp with time zone");
+						.HasColumnType("TEXT");
 
 					b.Property<long>("StartedById")
-						.HasColumnType("bigint");
+						.HasColumnType("INTEGER");
 
 					b.Property<DateTimeOffset?>("StoppedAt")
-						.HasColumnType("timestamp with time zone");
+						.HasColumnType("TEXT");
 
 					b.HasKey("Id");
 
@@ -398,30 +398,29 @@ namespace Tgstation.Server.Host.Database.Migrations
 				{
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
-						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasColumnType("INTEGER");
 
 					b.Property<string>("AccessIdentifier")
 						.IsRequired()
-						.HasColumnType("text");
+						.HasColumnType("TEXT");
 
 					b.Property<long>("CompileJobId")
-						.HasColumnType("bigint");
+						.HasColumnType("INTEGER");
 
 					b.Property<bool>("IsPrimary")
-						.HasColumnType("boolean");
+						.HasColumnType("INTEGER");
 
 					b.Property<int>("LaunchSecurityLevel")
-						.HasColumnType("integer");
+						.HasColumnType("INTEGER");
 
-					b.Property<int>("Port")
-						.HasColumnType("integer");
+					b.Property<ushort>("Port")
+						.HasColumnType("INTEGER");
 
 					b.Property<int>("ProcessId")
-						.HasColumnType("integer");
+						.HasColumnType("INTEGER");
 
 					b.Property<int>("RebootState")
-						.HasColumnType("integer");
+						.HasColumnType("INTEGER");
 
 					b.HasKey("Id");
 
@@ -434,49 +433,48 @@ namespace Tgstation.Server.Host.Database.Migrations
 				{
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
-						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasColumnType("INTEGER");
 
 					b.Property<string>("AccessToken")
-						.HasColumnType("character varying(10000)")
+						.HasColumnType("TEXT")
 						.HasMaxLength(10000);
 
 					b.Property<string>("AccessUser")
-						.HasColumnType("character varying(10000)")
+						.HasColumnType("TEXT")
 						.HasMaxLength(10000);
 
 					b.Property<bool?>("AutoUpdatesKeepTestMerges")
 						.IsRequired()
-						.HasColumnType("boolean");
+						.HasColumnType("INTEGER");
 
 					b.Property<bool?>("AutoUpdatesSynchronize")
 						.IsRequired()
-						.HasColumnType("boolean");
+						.HasColumnType("INTEGER");
 
 					b.Property<string>("CommitterEmail")
 						.IsRequired()
-						.HasColumnType("character varying(10000)")
+						.HasColumnType("TEXT")
 						.HasMaxLength(10000);
 
 					b.Property<string>("CommitterName")
 						.IsRequired()
-						.HasColumnType("character varying(10000)")
+						.HasColumnType("TEXT")
 						.HasMaxLength(10000);
 
 					b.Property<long>("InstanceId")
-						.HasColumnType("bigint");
+						.HasColumnType("INTEGER");
 
 					b.Property<bool?>("PostTestMergeComment")
 						.IsRequired()
-						.HasColumnType("boolean");
+						.HasColumnType("INTEGER");
 
 					b.Property<bool?>("PushTestMergeCommits")
 						.IsRequired()
-						.HasColumnType("boolean");
+						.HasColumnType("INTEGER");
 
 					b.Property<bool?>("ShowTestMergeCommitters")
 						.IsRequired()
-						.HasColumnType("boolean");
+						.HasColumnType("INTEGER");
 
 					b.HasKey("Id");
 
@@ -490,14 +488,13 @@ namespace Tgstation.Server.Host.Database.Migrations
 				{
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
-						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasColumnType("INTEGER");
 
 					b.Property<long>("RevisionInformationId")
-						.HasColumnType("bigint");
+						.HasColumnType("INTEGER");
 
 					b.Property<long>("TestMergeId")
-						.HasColumnType("bigint");
+						.HasColumnType("INTEGER");
 
 					b.HasKey("Id");
 
@@ -512,20 +509,19 @@ namespace Tgstation.Server.Host.Database.Migrations
 				{
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
-						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasColumnType("INTEGER");
 
 					b.Property<string>("CommitSha")
 						.IsRequired()
-						.HasColumnType("character varying(40)")
+						.HasColumnType("TEXT")
 						.HasMaxLength(40);
 
 					b.Property<long>("InstanceId")
-						.HasColumnType("bigint");
+						.HasColumnType("INTEGER");
 
 					b.Property<string>("OriginCommitSha")
 						.IsRequired()
-						.HasColumnType("character varying(40)")
+						.HasColumnType("TEXT")
 						.HasMaxLength(40);
 
 					b.HasKey("Id");
@@ -540,46 +536,45 @@ namespace Tgstation.Server.Host.Database.Migrations
 				{
 					b.Property<long>("Id")
 						.ValueGeneratedOnAdd()
-						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasColumnType("INTEGER");
 
 					b.Property<string>("Author")
 						.IsRequired()
-						.HasColumnType("text");
+						.HasColumnType("TEXT");
 
 					b.Property<string>("BodyAtMerge")
 						.IsRequired()
-						.HasColumnType("text");
+						.HasColumnType("TEXT");
 
 					b.Property<string>("Comment")
-						.HasColumnType("character varying(10000)")
+						.HasColumnType("TEXT")
 						.HasMaxLength(10000);
 
 					b.Property<DateTimeOffset>("MergedAt")
-						.HasColumnType("timestamp with time zone");
+						.HasColumnType("TEXT");
 
 					b.Property<long>("MergedById")
-						.HasColumnType("bigint");
+						.HasColumnType("INTEGER");
 
 					b.Property<int>("Number")
-						.HasColumnType("integer");
+						.HasColumnType("INTEGER");
 
 					b.Property<long?>("PrimaryRevisionInformationId")
 						.IsRequired()
-						.HasColumnType("bigint");
+						.HasColumnType("INTEGER");
 
 					b.Property<string>("PullRequestRevision")
 						.IsRequired()
-						.HasColumnType("character varying(40)")
+						.HasColumnType("TEXT")
 						.HasMaxLength(40);
 
 					b.Property<string>("TitleAtMerge")
 						.IsRequired()
-						.HasColumnType("text");
+						.HasColumnType("TEXT");
 
 					b.Property<string>("Url")
 						.IsRequired()
-						.HasColumnType("text");
+						.HasColumnType("TEXT");
 
 					b.HasKey("Id");
 
@@ -595,43 +590,42 @@ namespace Tgstation.Server.Host.Database.Migrations
 				{
 					b.Property<long?>("Id")
 						.ValueGeneratedOnAdd()
-						.HasColumnType("bigint")
-						.HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+						.HasColumnType("INTEGER");
 
-					b.Property<decimal>("AdministrationRights")
-						.HasColumnType("numeric(20,0)");
+					b.Property<ulong>("AdministrationRights")
+						.HasColumnType("INTEGER");
 
 					b.Property<string>("CanonicalName")
 						.IsRequired()
-						.HasColumnType("text");
+						.HasColumnType("TEXT");
 
 					b.Property<DateTimeOffset?>("CreatedAt")
 						.IsRequired()
-						.HasColumnType("timestamp with time zone");
+						.HasColumnType("TEXT");
 
 					b.Property<long?>("CreatedById")
-						.HasColumnType("bigint");
+						.HasColumnType("INTEGER");
 
 					b.Property<bool?>("Enabled")
 						.IsRequired()
-						.HasColumnType("boolean");
+						.HasColumnType("INTEGER");
 
-					b.Property<decimal>("InstanceManagerRights")
-						.HasColumnType("numeric(20,0)");
+					b.Property<ulong>("InstanceManagerRights")
+						.HasColumnType("INTEGER");
 
 					b.Property<DateTimeOffset?>("LastPasswordUpdate")
-						.HasColumnType("timestamp with time zone");
+						.HasColumnType("TEXT");
 
 					b.Property<string>("Name")
 						.IsRequired()
-						.HasColumnType("character varying(10000)")
+						.HasColumnType("TEXT")
 						.HasMaxLength(10000);
 
 					b.Property<string>("PasswordHash")
-						.HasColumnType("text");
+						.HasColumnType("TEXT");
 
 					b.Property<string>("SystemIdentifier")
-						.HasColumnType("text");
+						.HasColumnType("TEXT");
 
 					b.HasKey("Id");
 
@@ -675,7 +669,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 					b.HasOne("Tgstation.Server.Host.Models.RevisionInformation", "RevisionInformation")
 						.WithMany("CompileJobs")
 						.HasForeignKey("RevisionInformationId")
-						.OnDelete(DeleteBehavior.Cascade)
+						.OnDelete(DeleteBehavior.ClientNoAction)
 						.IsRequired();
 				});
 

--- a/src/Tgstation.Server.Host/Database/Migrations/20200616180742_SLTopicTimeout.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20200616180742_SLTopicTimeout.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using System;
+
+namespace Tgstation.Server.Host.Database.Migrations
+{
+	/// <summary>
+	/// Add BYOND topic timeouts for SQLite.
+	/// </summary>
+	public partial class SLTopicTimeout : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			if (migrationBuilder == null)
+				throw new ArgumentNullException(nameof(migrationBuilder));
+			migrationBuilder.AddColumn<uint>(
+				name: "TopicRequestTimeout",
+				table: "DreamDaemonSettings",
+				nullable: false,
+				defaultValue: 0u);
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			if (migrationBuilder == null)
+				throw new ArgumentNullException(nameof(migrationBuilder));
+			migrationBuilder.DropColumn(
+				name: "TopicRequestTimeout",
+				table: "DreamDaemonSettings");
+		}
+	}
+}

--- a/src/Tgstation.Server.Host/Database/Migrations/20200616180842_PGTopicTimeout.Designer.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20200616180842_PGTopicTimeout.Designer.cs
@@ -2,15 +2,17 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace Tgstation.Server.Host.Database.Migrations
 {
 	[DbContext(typeof(PostgresSqlDatabaseContext))]
-	partial class PostgresSqlDatabaseContextModelSnapshot : ModelSnapshot
+	[Migration("20200616180842_PGTopicTimeout")]
+	partial class PGTopicTimeout
 	{
 		/// <inheritdoc />
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder

--- a/src/Tgstation.Server.Host/Database/Migrations/20200616180842_PGTopicTimeout.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20200616180842_PGTopicTimeout.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using System;
+
+namespace Tgstation.Server.Host.Database.Migrations
+{
+	/// <summary>
+	/// Add BYOND topic timeouts for PostgresSQL.
+	/// </summary>
+	public partial class PGTopicTimeout : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			if (migrationBuilder == null)
+				throw new ArgumentNullException(nameof(migrationBuilder));
+			migrationBuilder.AddColumn<long>(
+				name: "TopicRequestTimeout",
+				table: "DreamDaemonSettings",
+				nullable: false,
+				defaultValue: 0L);
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			if (migrationBuilder == null)
+				throw new ArgumentNullException(nameof(migrationBuilder));
+			migrationBuilder.DropColumn(
+				name: "TopicRequestTimeout",
+				table: "DreamDaemonSettings");
+		}
+	}
+}

--- a/src/Tgstation.Server.Host/Database/Migrations/MySqlDatabaseContextModelSnapshot.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/MySqlDatabaseContextModelSnapshot.cs
@@ -8,6 +8,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 	[DbContext(typeof(MySqlDatabaseContext))]
 	partial class MySqlDatabaseContextModelSnapshot : ModelSnapshot
 	{
+		/// <inheritdoc />
 		protected override void BuildModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
@@ -184,6 +185,10 @@ namespace Tgstation.Server.Host.Database.Migrations
 						.HasColumnType("int");
 
 					b.Property<uint?>("StartupTimeout")
+						.IsRequired()
+						.HasColumnType("int unsigned");
+
+					b.Property<uint?>("TopicRequestTimeout")
 						.IsRequired()
 						.HasColumnType("int unsigned");
 

--- a/src/Tgstation.Server.Host/Database/Migrations/SqlServerDatabaseContextModelSnapshot.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/SqlServerDatabaseContextModelSnapshot.cs
@@ -9,11 +9,12 @@ namespace Tgstation.Server.Host.Database.Migrations
 	[DbContext(typeof(SqlServerDatabaseContext))]
 	partial class SqlServerDatabaseContextModelSnapshot : ModelSnapshot
 	{
+		/// <inheritdoc />
 		protected override void BuildModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder
-				.HasAnnotation("ProductVersion", "3.1.3")
+				.HasAnnotation("ProductVersion", "3.1.4")
 				.HasAnnotation("Relational:MaxIdentifierLength", 128)
 				.HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
@@ -189,6 +190,9 @@ namespace Tgstation.Server.Host.Database.Migrations
 					b.Property<long>("StartupTimeout")
 						.HasColumnType("bigint");
 
+					b.Property<long>("TopicRequestTimeout")
+						.HasColumnType("bigint");
+
 					b.HasKey("Id");
 
 					b.HasIndex("InstanceId")
@@ -223,6 +227,37 @@ namespace Tgstation.Server.Host.Database.Migrations
 						.IsUnique();
 
 					b.ToTable("DreamMakerSettings");
+				});
+
+			modelBuilder.Entity("Tgstation.Server.Host.Models.DualReattachInformation", b =>
+				{
+					b.Property<long>("Id")
+						.ValueGeneratedOnAdd()
+						.HasColumnType("bigint")
+						.HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+
+					b.Property<long?>("AlphaId")
+						.HasColumnType("bigint");
+
+					b.Property<bool>("AlphaIsActive")
+						.HasColumnType("bit");
+
+					b.Property<long?>("BravoId")
+						.HasColumnType("bigint");
+
+					b.Property<long>("InstanceId")
+						.HasColumnType("bigint");
+
+					b.HasKey("Id");
+
+					b.HasIndex("AlphaId");
+
+					b.HasIndex("BravoId");
+
+					b.HasIndex("InstanceId")
+						.IsUnique();
+
+					b.ToTable("WatchdogReattachInformations");
 				});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.Instance", b =>
@@ -614,37 +649,6 @@ namespace Tgstation.Server.Host.Database.Migrations
 					b.ToTable("Users");
 				});
 
-			modelBuilder.Entity("Tgstation.Server.Host.Models.WatchdogReattachInformation", b =>
-				{
-					b.Property<long>("Id")
-						.ValueGeneratedOnAdd()
-						.HasColumnType("bigint")
-						.HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
-
-					b.Property<long?>("AlphaId")
-						.HasColumnType("bigint");
-
-					b.Property<bool>("AlphaIsActive")
-						.HasColumnType("bit");
-
-					b.Property<long?>("BravoId")
-						.HasColumnType("bigint");
-
-					b.Property<long>("InstanceId")
-						.HasColumnType("bigint");
-
-					b.HasKey("Id");
-
-					b.HasIndex("AlphaId");
-
-					b.HasIndex("BravoId");
-
-					b.HasIndex("InstanceId")
-						.IsUnique();
-
-					b.ToTable("WatchdogReattachInformations");
-				});
-
 			modelBuilder.Entity("Tgstation.Server.Host.Models.ChatBot", b =>
 				{
 					b.HasOne("Tgstation.Server.Host.Models.Instance", "Instance")
@@ -692,6 +696,23 @@ namespace Tgstation.Server.Host.Database.Migrations
 					b.HasOne("Tgstation.Server.Host.Models.Instance", "Instance")
 						.WithOne("DreamMakerSettings")
 						.HasForeignKey("Tgstation.Server.Host.Models.DreamMakerSettings", "InstanceId")
+						.OnDelete(DeleteBehavior.Cascade)
+						.IsRequired();
+				});
+
+			modelBuilder.Entity("Tgstation.Server.Host.Models.DualReattachInformation", b =>
+				{
+					b.HasOne("Tgstation.Server.Host.Models.ReattachInformation", "Alpha")
+						.WithMany()
+						.HasForeignKey("AlphaId");
+
+					b.HasOne("Tgstation.Server.Host.Models.ReattachInformation", "Bravo")
+						.WithMany()
+						.HasForeignKey("BravoId");
+
+					b.HasOne("Tgstation.Server.Host.Models.Instance", null)
+						.WithOne("WatchdogReattachInformation")
+						.HasForeignKey("Tgstation.Server.Host.Models.DualReattachInformation", "InstanceId")
 						.OnDelete(DeleteBehavior.Cascade)
 						.IsRequired();
 				});
@@ -792,23 +813,6 @@ namespace Tgstation.Server.Host.Database.Migrations
 					b.HasOne("Tgstation.Server.Host.Models.User", "CreatedBy")
 						.WithMany("CreatedUsers")
 						.HasForeignKey("CreatedById");
-				});
-
-			modelBuilder.Entity("Tgstation.Server.Host.Models.WatchdogReattachInformation", b =>
-				{
-					b.HasOne("Tgstation.Server.Host.Models.ReattachInformation", "Alpha")
-						.WithMany()
-						.HasForeignKey("AlphaId");
-
-					b.HasOne("Tgstation.Server.Host.Models.ReattachInformation", "Bravo")
-						.WithMany()
-						.HasForeignKey("BravoId");
-
-					b.HasOne("Tgstation.Server.Host.Models.Instance", null)
-						.WithOne("WatchdogReattachInformation")
-						.HasForeignKey("Tgstation.Server.Host.Models.WatchdogReattachInformation", "InstanceId")
-						.OnDelete(DeleteBehavior.Cascade)
-						.IsRequired();
 				});
 #pragma warning restore 612, 618
 		}

--- a/src/Tgstation.Server.Host/Database/Migrations/SqliteDatabaseContextModelSnapshot.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/SqliteDatabaseContextModelSnapshot.cs
@@ -8,11 +8,12 @@ namespace Tgstation.Server.Host.Database.Migrations
 	[DbContext(typeof(SqliteDatabaseContext))]
 	partial class SqliteDatabaseContextModelSnapshot : ModelSnapshot
 	{
+		/// <inheritdoc />
 		protected override void BuildModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder
-				.HasAnnotation("ProductVersion", "3.1.3");
+				.HasAnnotation("ProductVersion", "3.1.4");
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.ChatBot", b =>
 				{
@@ -186,6 +187,10 @@ namespace Tgstation.Server.Host.Database.Migrations
 						.IsRequired()
 						.HasColumnType("INTEGER");
 
+					b.Property<uint?>("TopicRequestTimeout")
+						.IsRequired()
+						.HasColumnType("INTEGER");
+
 					b.HasKey("Id");
 
 					b.HasIndex("InstanceId")
@@ -220,6 +225,36 @@ namespace Tgstation.Server.Host.Database.Migrations
 						.IsUnique();
 
 					b.ToTable("DreamMakerSettings");
+				});
+
+			modelBuilder.Entity("Tgstation.Server.Host.Models.DualReattachInformation", b =>
+				{
+					b.Property<long>("Id")
+						.ValueGeneratedOnAdd()
+						.HasColumnType("INTEGER");
+
+					b.Property<long?>("AlphaId")
+						.HasColumnType("INTEGER");
+
+					b.Property<bool>("AlphaIsActive")
+						.HasColumnType("INTEGER");
+
+					b.Property<long?>("BravoId")
+						.HasColumnType("INTEGER");
+
+					b.Property<long>("InstanceId")
+						.HasColumnType("INTEGER");
+
+					b.HasKey("Id");
+
+					b.HasIndex("AlphaId");
+
+					b.HasIndex("BravoId");
+
+					b.HasIndex("InstanceId")
+						.IsUnique();
+
+					b.ToTable("WatchdogReattachInformations");
 				});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.Instance", b =>
@@ -603,36 +638,6 @@ namespace Tgstation.Server.Host.Database.Migrations
 					b.ToTable("Users");
 				});
 
-			modelBuilder.Entity("Tgstation.Server.Host.Models.WatchdogReattachInformation", b =>
-				{
-					b.Property<long>("Id")
-						.ValueGeneratedOnAdd()
-						.HasColumnType("INTEGER");
-
-					b.Property<long?>("AlphaId")
-						.HasColumnType("INTEGER");
-
-					b.Property<bool>("AlphaIsActive")
-						.HasColumnType("INTEGER");
-
-					b.Property<long?>("BravoId")
-						.HasColumnType("INTEGER");
-
-					b.Property<long>("InstanceId")
-						.HasColumnType("INTEGER");
-
-					b.HasKey("Id");
-
-					b.HasIndex("AlphaId");
-
-					b.HasIndex("BravoId");
-
-					b.HasIndex("InstanceId")
-						.IsUnique();
-
-					b.ToTable("WatchdogReattachInformations");
-				});
-
 			modelBuilder.Entity("Tgstation.Server.Host.Models.ChatBot", b =>
 				{
 					b.HasOne("Tgstation.Server.Host.Models.Instance", "Instance")
@@ -680,6 +685,23 @@ namespace Tgstation.Server.Host.Database.Migrations
 					b.HasOne("Tgstation.Server.Host.Models.Instance", "Instance")
 						.WithOne("DreamMakerSettings")
 						.HasForeignKey("Tgstation.Server.Host.Models.DreamMakerSettings", "InstanceId")
+						.OnDelete(DeleteBehavior.Cascade)
+						.IsRequired();
+				});
+
+			modelBuilder.Entity("Tgstation.Server.Host.Models.DualReattachInformation", b =>
+				{
+					b.HasOne("Tgstation.Server.Host.Models.ReattachInformation", "Alpha")
+						.WithMany()
+						.HasForeignKey("AlphaId");
+
+					b.HasOne("Tgstation.Server.Host.Models.ReattachInformation", "Bravo")
+						.WithMany()
+						.HasForeignKey("BravoId");
+
+					b.HasOne("Tgstation.Server.Host.Models.Instance", null)
+						.WithOne("WatchdogReattachInformation")
+						.HasForeignKey("Tgstation.Server.Host.Models.DualReattachInformation", "InstanceId")
 						.OnDelete(DeleteBehavior.Cascade)
 						.IsRequired();
 				});
@@ -780,23 +802,6 @@ namespace Tgstation.Server.Host.Database.Migrations
 					b.HasOne("Tgstation.Server.Host.Models.User", "CreatedBy")
 						.WithMany("CreatedUsers")
 						.HasForeignKey("CreatedById");
-				});
-
-			modelBuilder.Entity("Tgstation.Server.Host.Models.WatchdogReattachInformation", b =>
-				{
-					b.HasOne("Tgstation.Server.Host.Models.ReattachInformation", "Alpha")
-						.WithMany()
-						.HasForeignKey("AlphaId");
-
-					b.HasOne("Tgstation.Server.Host.Models.ReattachInformation", "Bravo")
-						.WithMany()
-						.HasForeignKey("BravoId");
-
-					b.HasOne("Tgstation.Server.Host.Models.Instance", null)
-						.WithOne("WatchdogReattachInformation")
-						.HasForeignKey("Tgstation.Server.Host.Models.WatchdogReattachInformation", "InstanceId")
-						.OnDelete(DeleteBehavior.Cascade)
-						.IsRequired();
 				});
 #pragma warning restore 612, 618
 		}

--- a/src/Tgstation.Server.Host/Setup/SetupWizard.cs
+++ b/src/Tgstation.Server.Host/Setup/SetupWizard.cs
@@ -592,11 +592,11 @@ namespace Tgstation.Server.Host.Setup
 			do
 			{
 				await console.WriteAsync(null, true, cancellationToken).ConfigureAwait(false);
-				await console.WriteAsync(String.Format(CultureInfo.InvariantCulture, "Timeout for sending and receiving BYOND topics (ms, 0 for infinite, leave blank for default of {0}): ", newGeneralConfiguration.ByondTopicTimeout), false, cancellationToken).ConfigureAwait(false);
+				await console.WriteAsync(String.Format(CultureInfo.InvariantCulture, "Default timeout for sending and receiving BYOND topics (ms, 0 for infinite, leave blank for default of {0}): ", newGeneralConfiguration.ByondTopicTimeout), false, cancellationToken).ConfigureAwait(false);
 				var topicTimeoutString = await console.ReadLineAsync(false, cancellationToken).ConfigureAwait(false);
 				if (String.IsNullOrWhiteSpace(topicTimeoutString))
 					break;
-				if (Int32.TryParse(topicTimeoutString, out var topicTimeout) && topicTimeout >= 0)
+				if (UInt32.TryParse(topicTimeoutString, out var topicTimeout) && topicTimeout >= 0)
 				{
 					newGeneralConfiguration.ByondTopicTimeout = topicTimeout;
 					break;

--- a/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
+++ b/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
@@ -48,20 +48,20 @@
     <PackageReference Include="Cyberboss.SmartIrc4net.Standard" Version="0.4.6" />
     <PackageReference Include="Discord.Net.WebSocket" Version="2.2.0" />
     <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0034" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.5" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.4">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.4">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -86,7 +86,7 @@
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.6.0" />
     <PackageReference Include="System.Management" Version="4.7.0" />
     <PackageReference Include="Wangkanai.Detection.Browser" Version="2.0.0" />
-    <PackageReference Include="Z.EntityFramework.Plus.EFCore" Version="3.0.50" />
+    <PackageReference Include="Z.EntityFramework.Plus.EFCore" Version="3.0.51" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tgstation.Server.Host/appsettings.json
+++ b/src/Tgstation.Server.Host/appsettings.json
@@ -5,6 +5,7 @@
     "SetupWizardMode": "AutoDetect",
     "ByondTopicTimeout": 5000,
     "RestartTimeout": 60000,
+    "ApiPort": 5000,
     "UseExperimentalWatchdog": false,
     "UseBasicWatchdogOnWindows": false,
     "UserLimit": 100,
@@ -29,13 +30,6 @@
       "LogLevel": {
         "Default": "Trace",
         "Microsoft": "Warning"
-      }
-    }
-  },
-  "Kestrel": {
-    "EndPoints": {
-      "Http": {
-        "Url": "http://0.0.0.0:80"
       }
     }
   },

--- a/tests/Tgstation.Server.Api.Tests/Tgstation.Server.Api.Tests.csproj
+++ b/tests/Tgstation.Server.Api.Tests/Tgstation.Server.Api.Tests.csproj
@@ -9,9 +9,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Tgstation.Server.Client.Tests/Tgstation.Server.Client.Tests.csproj
+++ b/tests/Tgstation.Server.Client.Tests/Tgstation.Server.Client.Tests.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Moq" Version="4.14.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Tgstation.Server.Host.Console.Tests/Tgstation.Server.Host.Console.Tests.csproj
+++ b/tests/Tgstation.Server.Host.Console.Tests/Tgstation.Server.Host.Console.Tests.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Moq" Version="4.14.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Tgstation.Server.Host.Service.Tests/Tgstation.Server.Host.Service.Tests.csproj
+++ b/tests/Tgstation.Server.Host.Service.Tests/Tgstation.Server.Host.Service.Tests.csproj
@@ -14,9 +14,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="Moq" Version="4.14.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Tgstation.Server.Host.Tests/Tgstation.Server.Host.Tests.csproj
+++ b/tests/Tgstation.Server.Host.Tests/Tgstation.Server.Host.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Moq" Version="4.14.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Tgstation.Server.Host.Watchdog.Tests/Tgstation.Server.Host.Watchdog.Tests.csproj
+++ b/tests/Tgstation.Server.Host.Watchdog.Tests/Tgstation.Server.Host.Watchdog.Tests.csproj
@@ -14,10 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Moq" Version="4.14.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Tgstation.Server.Tests/Instance/WatchdogTest.cs
+++ b/tests/Tgstation.Server.Tests/Instance/WatchdogTest.cs
@@ -34,7 +34,7 @@ namespace Tgstation.Server.Tests.Instance
 			await instanceClient.DreamDaemon.Update(new DreamDaemon
 			{
 				StartupTimeout = 45,
-				HeartbeatSeconds = 0,
+				HeartbeatSeconds = 0
 			}, cancellationToken);
 
 			await ApiAssert.ThrowsException<ApiConflictException>(() => instanceClient.DreamDaemon.Update(new DreamDaemon

--- a/tests/Tgstation.Server.Tests/Tgstation.Server.Tests.csproj
+++ b/tests/Tgstation.Server.Tests/Tgstation.Server.Tests.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Moq" Version="4.14.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/ReleaseNotes/ReleaseNotes.csproj
+++ b/tools/ReleaseNotes/ReleaseNotes.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="octokit" Version="0.36.0" />
+    <PackageReference Include="octokit" Version="0.48.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
:cl:
Topic request timeouts are now stored in the database as a per-instance setting. Initial value will be based off the config which will remain as a default value for new instances.
Fixed manually restarting the watchdog sending two redundant chat messages.
/:cl:

:cl: HTTP API
Added DreamDaemon right 16384 for changing the new `topicRequestTimeout` value in the model.
/:cl:

Closes #1002