### PR TITLE
Refactor watchdog running into status enum

### DIFF
--- a/src/Tgstation.Server.Api/Models/DreamDaemon.cs
+++ b/src/Tgstation.Server.Api/Models/DreamDaemon.cs
@@ -19,9 +19,10 @@ namespace Tgstation.Server.Api.Models
 		public CompileJob? StagedCompileJob { get; set; }
 
 		/// <summary>
-		/// The current status of <see cref="DreamDaemon"/>
+		/// The current <see cref="WatchdogStatus"/>.
 		/// </summary>
-		public bool? Running { get; set; }
+		[EnumDataType(typeof(WatchdogStatus))]
+		public WatchdogStatus? Status { get; set; }
 
 		/// <summary>
 		/// The current <see cref="DreamDaemonSecurity"/> of <see cref="DreamDaemon"/>. May be downgraded due to requirements of <see cref="ActiveCompileJob"/>

--- a/src/Tgstation.Server.Api/Models/WatchdogStatus.cs
+++ b/src/Tgstation.Server.Api/Models/WatchdogStatus.cs
@@ -1,0 +1,28 @@
+﻿namespace Tgstation.Server.Api.Models
+{
+	/// <summary>
+	/// The current status of the watchdog.
+	/// </summary>
+	public enum WatchdogStatus
+	{
+		/// <summary>
+		/// The watchdog is not running.
+		/// </summary>
+		Offline,
+
+		/// <summary>
+		/// The watchdog is online and attempting to bring DreamDaemon back to operational status.
+		/// </summary>
+		Restoring,
+
+		/// <summary>
+		/// The watchdog is online and DreamDaemon is running.
+		/// </summary>
+		Online,
+
+		/// <summary>
+		/// The watchdog is online and in a delayed sleep to bring DreamDaemon back.
+		/// </summary>
+		DelayedRestart,
+	}
+}

--- a/src/Tgstation.Server.Api/Rights/DreamDaemonRights.cs
+++ b/src/Tgstation.Server.Api/Rights/DreamDaemonRights.cs
@@ -34,7 +34,7 @@ namespace Tgstation.Server.Api.Rights
 		SetSecurity = 8,
 
 		/// <summary>
-		/// User can read all ports, <see cref="Models.DreamDaemon.SoftRestart"/>, <see cref="Models.DreamDaemon.SoftShutdown"/>, <see cref="Models.DreamDaemon.Running"/>, <see cref="Models.Internal.DreamDaemonLaunchParameters.AllowWebClient"/>, and <see cref="Models.Internal.DreamDaemonSettings.AutoStart"/>
+		/// User can read all ports, <see cref="Models.DreamDaemon.SoftRestart"/>, <see cref="Models.DreamDaemon.SoftShutdown"/>, <see cref="Models.DreamDaemon.Status"/>, <see cref="Models.Internal.DreamDaemonLaunchParameters.AllowWebClient"/>, and <see cref="Models.Internal.DreamDaemonSettings.AutoStart"/>
 		/// </summary>
 		ReadMetadata = 16,
 

--- a/src/Tgstation.Server.Host/Components/Chat/Commands/ByondCommand.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Commands/ByondCommand.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Tgstation.Server.Api.Models;
 using Tgstation.Server.Host.Components.Byond;
 using Tgstation.Server.Host.Components.Watchdog;
 
@@ -48,7 +49,7 @@ namespace Tgstation.Server.Host.Components.Chat.Commands
 		{
 			if (arguments.Split(' ').Any(x => x.ToUpperInvariant() == "--ACTIVE"))
 				return Task.FromResult(byondManager.ActiveVersion == null ? "None!" : String.Format(CultureInfo.InvariantCulture, "{0}.{1}", byondManager.ActiveVersion.Major, byondManager.ActiveVersion.Minor));
-			if (!watchdog.Running)
+			if (watchdog.Status == WatchdogStatus.Offline)
 				return Task.FromResult("Server offline!");
 			return Task.FromResult(watchdog.ActiveCompileJob.ByondVersion);
 		}

--- a/src/Tgstation.Server.Host/Components/Chat/Commands/PullRequestsCommand.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Commands/PullRequestsCommand.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Tgstation.Server.Api.Models;
 using Tgstation.Server.Host.Components.Repository;
 using Tgstation.Server.Host.Components.Watchdog;
 using Tgstation.Server.Host.Database;
@@ -12,7 +13,7 @@ using Tgstation.Server.Host.Database;
 namespace Tgstation.Server.Host.Components.Chat.Commands
 {
 	/// <summary>
-	/// Command for reading the active <see cref="Api.Models.TestMerge"/>s
+	/// Command for reading the active <see cref="TestMerge"/>s
 	/// </summary>
 	sealed class PullRequestsCommand : ICommand
 	{
@@ -94,7 +95,7 @@ namespace Tgstation.Server.Host.Components.Chat.Commands
 			}
 			else
 			{
-				if (!watchdog.Running)
+				if (watchdog.Status == WatchdogStatus.Offline)
 					return "Server offline!";
 				results = watchdog.ActiveCompileJob?.RevisionInformation.ActiveTestMerges.Select(x => x.TestMerge).ToList() ?? new List<Models.TestMerge>();
 			}

--- a/src/Tgstation.Server.Host/Components/Chat/Commands/RevisionCommand.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Commands/RevisionCommand.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Tgstation.Server.Api.Models;
 using Tgstation.Server.Host.Components.Repository;
 using Tgstation.Server.Host.Components.Watchdog;
 
@@ -56,7 +57,7 @@ namespace Tgstation.Server.Host.Components.Chat.Commands
 				}
 			else
 			{
-				if (!watchdog.Running)
+				if (watchdog.Status == WatchdogStatus.Offline)
 					return "Server offline!";
 				result = watchdog.ActiveCompileJob?.RevisionInformation.CommitSha;
 			}

--- a/src/Tgstation.Server.Host/Components/Watchdog/IWatchdog.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/IWatchdog.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Tgstation.Server.Api.Models;
 using Tgstation.Server.Api.Models.Internal;
 using Tgstation.Server.Host.Components.Events;
 using Tgstation.Server.Host.Components.Session;
@@ -14,9 +15,9 @@ namespace Tgstation.Server.Host.Components.Watchdog
 	public interface IWatchdog : IHostedService, IDisposable, IEventConsumer, IRenameNotifyee
 	{
 		/// <summary>
-		/// If the watchdog is running
+		/// The current <see cref="WatchdogStatus"/>.
 		/// </summary>
-		bool Running { get; }
+		WatchdogStatus Status { get; }
 
 		/// <summary>
 		/// If the alpha server is the active server
@@ -24,7 +25,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 		bool AlphaIsActive { get; }
 
 		/// <summary>
-		/// The <see cref="CompileJob"/> currently running on the server
+		/// The <see cref="Models.CompileJob"/> currently running on the server
 		/// </summary>
 		Models.CompileJob ActiveCompileJob { get; }
 
@@ -51,7 +52,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 		Task Launch(CancellationToken cancellationToken);
 
 		/// <summary>
-		/// Changes the <see cref="ActiveLaunchParameters"/>. If currently <see cref="Running"/> triggers a graceful restart
+		/// Changes the <see cref="ActiveLaunchParameters"/>. If currently running, may trigger a graceful restart.
 		/// </summary>
 		/// <param name="launchParameters">The new <see cref="DreamDaemonLaunchParameters"/>. May be modified</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>

--- a/tests/Tgstation.Server.Tests/IntegrationTest.cs
+++ b/tests/Tgstation.Server.Tests/IntegrationTest.cs
@@ -247,7 +247,7 @@ namespace Tgstation.Server.Tests
 					await new JobsRequiredTest(instanceClient.Jobs).WaitForJob(reattachJob, 40, false, cancellationToken);
 
 					var dd = await instanceClient.DreamDaemon.Read(cancellationToken);
-					Assert.IsTrue(dd.Running.Value);
+					Assert.AreEqual(WatchdogStatus.Online, dd.Status.Value);
 
 					await instanceClient.DreamDaemon.Shutdown(cancellationToken);
 					await instanceClient.DreamDaemon.Update(new DreamDaemon
@@ -291,7 +291,7 @@ namespace Tgstation.Server.Tests
 
 					var dd = await instanceClient.DreamDaemon.Read(cancellationToken);
 
-					Assert.IsTrue(dd.Running.Value);
+					Assert.AreEqual(WatchdogStatus.Online, dd.Status.Value);
 
 					var repoTest = new RepositoryTest(instanceClient.Repository, instanceClient.Jobs).RunPostTest(cancellationToken);
 					await new ChatTest(instanceClient.ChatBots, adminClient.Instances, instance).RunPostTest(cancellationToken);


### PR DESCRIPTION
Closes #976 

:cl:
Fixed some inconsistencies with watchdog reattaching.
/:cl:

:cl: HTTP API
DreamDaemon `running` field replaced with more verbose `status` enum.
/:cl: