### PR TITLE
Adds log downloading endpoint

### DIFF
--- a/.github/workflows/stable-merge.yml
+++ b/.github/workflows/stable-merge.yml
@@ -1,4 +1,4 @@
-name: 'Stable Merge'
+name: 'Master Merge'
 
 on:
     push:
@@ -6,7 +6,7 @@ on:
         - master
 
 jobs:
-  nightly-merge:
+  master-merge:
 
     runs-on: ubuntu-latest
 
@@ -14,7 +14,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v1
 
-    - name: Nightly Merge
+    - name: Merge master into dev
       uses: robotology/gh-action-nightly-merge@v1.2.0
       with:
         stable_branch: 'master'

--- a/src/Tgstation.Server.Api/Models/ConfigurationFile.cs
+++ b/src/Tgstation.Server.Api/Models/ConfigurationFile.cs
@@ -1,11 +1,12 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using Tgstation.Server.Api.Models.Internal;
 
 namespace Tgstation.Server.Api.Models
 {
 	/// <summary>
 	/// Represents a game configuration file. Create and delete actions uncerimonuously overwrite/delete files
 	/// </summary>
-	public sealed class ConfigurationFile
+	public sealed class ConfigurationFile : RawData
 	{
 		/// <summary>
 		/// The path to the <see cref="ConfigurationFile"/> file
@@ -27,12 +28,5 @@ namespace Tgstation.Server.Api.Models
 		/// The MD5 hash of the file when last read by the user. If this doesn't match during update actions, the write will be denied with <see cref="System.Net.HttpStatusCode.Conflict"/>
 		/// </summary>
 		public string? LastReadHash { get; set; }
-
-		/// <summary>
-		/// The content of the <see cref="ConfigurationFile"/>. Will be <see langword="null"/> if <see cref="AccessDenied"/> is <see langword="true"/> or during listing and write operations
-		/// </summary>
-#pragma warning disable CA1819, SA1011 // Properties should not return arrays, Closing square bracket should be followed by a space
-		public byte[]? Content { get; set; }
-#pragma warning restore CA1819, SA1011 // Properties should not return arrays, Closing square bracket should be followed by a space
 	}
 }

--- a/src/Tgstation.Server.Api/Models/Internal/RawData.cs
+++ b/src/Tgstation.Server.Api/Models/Internal/RawData.cs
@@ -1,0 +1,15 @@
+﻿namespace Tgstation.Server.Api.Models.Internal
+{
+	/// <summary>
+	/// Represents raw bytes.
+	/// </summary>
+	public abstract class RawData
+	{
+		/// <summary>
+		/// The bytes of the <see cref="RawData"/>.
+		/// </summary>
+#pragma warning disable CA1819, SA1011 // Properties should not return arrays, Closing square bracket should be followed by a space
+		public byte[]? Content { get; set; }
+#pragma warning restore CA1819, SA1011 // Properties should not return arrays, Closing square bracket should be followed by a space
+	}
+}

--- a/src/Tgstation.Server.Api/Models/LogFile.cs
+++ b/src/Tgstation.Server.Api/Models/LogFile.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Tgstation.Server.Api.Models.Internal;
+
+namespace Tgstation.Server.Api.Models
+{
+	/// <summary>
+	/// Represents a server log file.
+	/// </summary>
+	public sealed class LogFile : RawData
+	{
+		/// <summary>
+		/// The name of the log file.
+		/// </summary>
+		public string? Name { get; set; }
+
+		/// <summary>
+		/// The <see cref="DateTimeOffset"/> of when the log file was modified.
+		/// </summary>
+		public DateTimeOffset LastModified { get; set; }
+	}
+}

--- a/src/Tgstation.Server.Api/Rights/AdministrationRights.cs
+++ b/src/Tgstation.Server.Api/Rights/AdministrationRights.cs
@@ -36,6 +36,11 @@ namespace Tgstation.Server.Api.Rights
 		/// <summary>
 		/// User can read info and rights of other users
 		/// </summary>
-		ReadUsers = 16
+		ReadUsers = 16,
+
+		/// <summary>
+		/// User can list and download <see cref="Models.LogFile"/>s.
+		/// </summary>
+		DownloadLogs = 32,
 	}
 }

--- a/src/Tgstation.Server.Api/Routes.cs
+++ b/src/Tgstation.Server.Api/Routes.cs
@@ -19,6 +19,11 @@ namespace Tgstation.Server.Api
 		public const string Administration = Root + nameof(Models.Administration);
 
 		/// <summary>
+		/// The <see cref="Models.Administration"/> controller
+		/// </summary>
+		public const string Logs = Administration + "/Logs";
+
+		/// <summary>
 		/// The <see cref="Models.User"/> controller
 		/// </summary>
 		public const string User = Root + nameof(Models.User);
@@ -102,5 +107,19 @@ namespace Tgstation.Server.Api
 		/// <param name="route">The route</param>
 		/// <returns>The <paramref name="route"/> with /List appended</returns>
 		public static string ListRoute(string route) => String.Format(CultureInfo.InvariantCulture, "{0}/{1}", route, List);
+
+		/// <summary>
+		/// Sanitize a <see cref="Models.Internal.RawData"/> path for use in a GET <see cref="Uri"/>.
+		/// </summary>
+		/// <param name="path">The path to sanitize.</param>
+		/// <returns>The sanitized path.</returns>
+		public static string SanitizeGetPath(string path)
+		{
+			if (path == null)
+				path = String.Empty;
+			if (path.Length == 0 || path[0] != '/')
+				path = '/' + path;
+			return path;
+		}
 	}
 }

--- a/src/Tgstation.Server.Client/AdministrationClient.cs
+++ b/src/Tgstation.Server.Client/AdministrationClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Tgstation.Server.Api;
@@ -31,5 +32,14 @@ namespace Tgstation.Server.Client
 
 		/// <inheritdoc />
 		public Task Restart(CancellationToken cancellationToken) => apiClient.Delete(Routes.Administration, cancellationToken);
+
+		/// <inheritdoc />
+		public Task<IReadOnlyList<LogFile>> ListLogs(CancellationToken cancellationToken) => apiClient.Read<IReadOnlyList<LogFile>>(Routes.Logs, cancellationToken);
+
+		/// <inheritdoc />
+		public Task<LogFile> GetLog(LogFile logFile, CancellationToken cancellationToken) => apiClient.Read<LogFile>(
+			Routes.Logs + Routes.SanitizeGetPath(
+				logFile?.Name ?? throw new ArgumentNullException(nameof(logFile))),
+			cancellationToken);
 	}
 }

--- a/src/Tgstation.Server.Client/Components/ConfigurationClient.cs
+++ b/src/Tgstation.Server.Client/Components/ConfigurationClient.cs
@@ -21,20 +21,6 @@ namespace Tgstation.Server.Client.Components
 		readonly Instance instance;
 
 		/// <summary>
-		/// Sanitize a <see cref="ConfigurationFile"/> path for use in a GET <see cref="Uri"/>
-		/// </summary>
-		/// <param name="path">The path to sanitize</param>
-		/// <returns>The sanitized path</returns>
-		static string SanitizeGetPath(string path)
-		{
-			if (path == null)
-				path = String.Empty;
-			if (path.Length == 0 || path[0] != '/')
-				path = '/' + path;
-			return path;
-		}
-
-		/// <summary>
 		/// Construct a <see cref="ConfigurationClient"/>
 		/// </summary>
 		/// <param name="apiClient">The value of <see cref="apiClient"/></param>
@@ -52,7 +38,7 @@ namespace Tgstation.Server.Client.Components
 		public Task<ConfigurationFile> CreateDirectory(ConfigurationFile directory, CancellationToken cancellationToken) => apiClient.Create<ConfigurationFile, ConfigurationFile>(Routes.Configuration, directory, instance.Id, cancellationToken);
 
 		/// <inheritdoc />
-		public Task<IReadOnlyList<ConfigurationFile>> List(string directory, CancellationToken cancellationToken) => apiClient.Read<IReadOnlyList<ConfigurationFile>>(Routes.ListRoute(Routes.Configuration) + SanitizeGetPath(directory), instance.Id, cancellationToken);
+		public Task<IReadOnlyList<ConfigurationFile>> List(string directory, CancellationToken cancellationToken) => apiClient.Read<IReadOnlyList<ConfigurationFile>>(Routes.ListRoute(Routes.Configuration) + Routes.SanitizeGetPath(directory), instance.Id, cancellationToken);
 
 		/// <inheritdoc />
 		public Task<ConfigurationFile> Read(ConfigurationFile file, CancellationToken cancellationToken)
@@ -60,7 +46,7 @@ namespace Tgstation.Server.Client.Components
 			if (file == null)
 				throw new ArgumentNullException(nameof(file));
 			return apiClient.Read<ConfigurationFile>(
-				Routes.ConfigurationFile + SanitizeGetPath(file.Path ?? throw new ArgumentException("file.Path should not be null!", nameof(file))),
+				Routes.ConfigurationFile + Routes.SanitizeGetPath(file.Path ?? throw new ArgumentException("file.Path should not be null!", nameof(file))),
 				instance.Id,
 				cancellationToken);
 		}

--- a/src/Tgstation.Server.Client/IAdministrationClient.cs
+++ b/src/Tgstation.Server.Client/IAdministrationClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Tgstation.Server.Api.Models;
 
@@ -30,5 +31,20 @@ namespace Tgstation.Server.Client
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="Task"/> representing the running operation</returns>
 		Task Restart(CancellationToken cancellationToken);
+
+		/// <summary>
+		/// Lists the log files available for download.
+		/// </summary>
+		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
+		/// <returns>A <see cref="Task{TResult}"/> resulting in an <see cref="IReadOnlyList{T}"/> of <see cref="LogFile"/> metadata.</returns>
+		Task<IReadOnlyList<LogFile>> ListLogs(CancellationToken cancellationToken);
+
+		/// <summary>
+		/// Download a given <paramref name="logFile"/>.
+		/// </summary>
+		/// <param name="logFile">The <see cref="LogFile"/> to download.</param>
+		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
+		/// <returns>A <see cref="Task{TResult}"/> resulting in the downloaded <see cref="LogFile"/>.</returns>
+		Task<LogFile> GetLog(LogFile logFile, CancellationToken cancellationToken);
 	}
 }

--- a/src/Tgstation.Server.Host/Components/StaticFiles/IConfiguration.cs
+++ b/src/Tgstation.Server.Host/Components/StaticFiles/IConfiguration.cs
@@ -37,7 +37,7 @@ namespace Tgstation.Server.Host.Components.StaticFiles
 		/// <param name="configurationRelativePath">The relative path in the Configuration directory</param>
 		/// <param name="systemIdentity">The <see cref="ISystemIdentity"/> for the operation. If <see langword="null"/>, the operation will be performed as the user of the <see cref="Core.Application"/></param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
-		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="ConfigurationFile"/>s for the items in the directory. <see cref="ConfigurationFile.Content"/> and <see cref="ConfigurationFile.LastReadHash"/> will both be <see langword="null"/></returns>
+		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="ConfigurationFile"/>s for the items in the directory. <see cref="Api.Models.Internal.RawData.Content"/> and <see cref="ConfigurationFile.LastReadHash"/> will both be <see langword="null"/></returns>
 		Task<IReadOnlyList<ConfigurationFile>> ListDirectory(string configurationRelativePath, ISystemIdentity systemIdentity, CancellationToken cancellationToken);
 
 		/// <summary>

--- a/src/Tgstation.Server.Host/Configuration/FileLoggingConfiguration.cs
+++ b/src/Tgstation.Server.Host/Configuration/FileLoggingConfiguration.cs
@@ -1,13 +1,16 @@
 ﻿using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using System;
+using Tgstation.Server.Host.IO;
+using Tgstation.Server.Host.System;
 
 namespace Tgstation.Server.Host.Configuration
 {
 	/// <summary>
 	/// File logging configuration options
 	/// </summary>
-	sealed class FileLoggingConfiguration
+	public sealed class FileLoggingConfiguration
 	{
 		/// <summary>
 		/// The key for the <see cref="Microsoft.Extensions.Configuration.IConfigurationSection"/> the <see cref="FileLoggingConfiguration"/> resides in
@@ -45,5 +48,26 @@ namespace Tgstation.Server.Host.Configuration
 		/// </summary>
 		[JsonConverter(typeof(StringEnumConverter))]
 		public LogLevel MicrosoftLogLevel { get; set; } = DefaultMicrosoftLogLevel;
+
+		/// <summary>
+		/// Gets the evaluated log <see cref="Directory"/>.
+		/// </summary>
+		/// <param name="ioManager">The <see cref="IIOManager"/> to use.</param>
+		/// <param name="assemblyInformationProvider">The <see cref="IAssemblyInformationProvider"/> to use.</param>
+		/// <returns>The evaluated log <see cref="Directory"/>.</returns>
+		public string GetFullLogDirectory(IIOManager ioManager, IAssemblyInformationProvider assemblyInformationProvider)
+		{
+			if (ioManager == null)
+				throw new ArgumentNullException(nameof(ioManager));
+			if (assemblyInformationProvider == null)
+				throw new ArgumentNullException(nameof(assemblyInformationProvider));
+
+			return !String.IsNullOrEmpty(Directory)
+				? Directory
+				: ioManager.ConcatPath(
+					Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), // common app data is C:/ProgramData on windows, else /usr/share
+					assemblyInformationProvider.VersionPrefix,
+					"Logs");
+		}
 	}
 }

--- a/src/Tgstation.Server.Host/Core/Application.cs
+++ b/src/Tgstation.Server.Host/Core/Application.cs
@@ -122,13 +122,7 @@ namespace Tgstation.Server.Host.Core
 					if (postSetupServices.FileLoggingConfiguration.Disable)
 						return;
 
-					// common app data is C:/ProgramData on windows, else /usr/share
-					var logPath = !String.IsNullOrEmpty(postSetupServices.FileLoggingConfiguration.Directory)
-						? postSetupServices.FileLoggingConfiguration.Directory
-						: IOManager.ConcatPath(
-							Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
-							AssemblyInformationProvider.VersionPrefix,
-							"Logs");
+					var logPath = postSetupServices.FileLoggingConfiguration.GetFullLogDirectory(IOManager, AssemblyInformationProvider);
 
 					var logEventLevel = ConvertSeriLogLevel(postSetupServices.FileLoggingConfiguration.LogLevel);
 

--- a/src/Tgstation.Server.Host/IO/DefaultIOManager.cs
+++ b/src/Tgstation.Server.Host/IO/DefaultIOManager.cs
@@ -222,7 +222,7 @@ namespace Tgstation.Server.Host.IO
 		public async Task<byte[]> ReadAllBytes(string path, CancellationToken cancellationToken)
 		{
 			path = ResolvePath(path);
-			using var file = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete, DefaultBufferSize, true);
+			using var file = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete, DefaultBufferSize, true);
 			byte[] buf;
 			buf = new byte[file.Length];
 			await file.ReadAsync(buf, 0, (int)file.Length, cancellationToken).ConfigureAwait(false);
@@ -311,5 +311,13 @@ namespace Tgstation.Server.Host.IO
 
 		/// <inheritdoc />
 		public bool PathContainsParentAccess(string path) => path?.Split(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar }).Any(x => x == "..") ?? throw new ArgumentNullException(nameof(path));
+
+		/// <inheritdoc />
+		public Task<DateTimeOffset> GetLastModified(string path, CancellationToken cancellationToken) => Task.Factory.StartNew(() =>
+		{
+			path = ResolvePath(path ?? throw new ArgumentNullException(nameof(path)));
+			var fileInfo = new FileInfo(path);
+			return new DateTimeOffset(fileInfo.LastWriteTimeUtc);
+		}, cancellationToken, TaskCreationOptions.LongRunning, TaskScheduler.Current);
 	}
 }

--- a/src/Tgstation.Server.Host/IO/IIOManager.cs
+++ b/src/Tgstation.Server.Host/IO/IIOManager.cs
@@ -194,5 +194,13 @@ namespace Tgstation.Server.Host.IO
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="Task"/> representing the running operation</returns>
 		Task ZipToDirectory(string path, byte[] zipFileBytes, CancellationToken cancellationToken);
+
+		/// <summary>
+		/// Get the <see cref="DateTimeOffset"/> of when a given <paramref name="path"/> was last modified.
+		/// </summary>
+		/// <param name="path">The path to get metadata for.</param>
+		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
+		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="DateTimeOffset"/> of when the file was last modified.</returns>
+		Task<DateTimeOffset> GetLastModified(string path, CancellationToken cancellationToken);
 	}
 }

--- a/tests/Tgstation.Server.Tests/AdministrationTest.cs
+++ b/tests/Tgstation.Server.Tests/AdministrationTest.cs
@@ -28,7 +28,7 @@ namespace Tgstation.Server.Tests
 		async Task TestLogs(CancellationToken cancellationToken)
 		{
 			var logs = await client.ListLogs(cancellationToken);
-			Assert.AreEqual(1, logs.Count);
+			Assert.AreNotEqual(0, logs.Count);
 			var logFile = logs.Single();
 			Assert.IsNotNull(logFile);
 			Assert.IsFalse(String.IsNullOrWhiteSpace(logFile.Name));

--- a/tests/Tgstation.Server.Tests/AdministrationTest.cs
+++ b/tests/Tgstation.Server.Tests/AdministrationTest.cs
@@ -29,7 +29,7 @@ namespace Tgstation.Server.Tests
 		{
 			var logs = await client.ListLogs(cancellationToken);
 			Assert.AreNotEqual(0, logs.Count);
-			var logFile = logs.Single();
+			var logFile = logs.First();
 			Assert.IsNotNull(logFile);
 			Assert.IsFalse(String.IsNullOrWhiteSpace(logFile.Name));
 			Assert.IsNull(logFile.Content);

--- a/tests/Tgstation.Server.Tests/TestingServer.cs
+++ b/tests/Tgstation.Server.Tests/TestingServer.cs
@@ -79,6 +79,7 @@ namespace Tgstation.Server.Tests
 				String.Format(CultureInfo.InvariantCulture, "General:MinimumPasswordLength={0}", 10),
 				String.Format(CultureInfo.InvariantCulture, "General:InstanceLimit={0}", 11),
 				String.Format(CultureInfo.InvariantCulture, "General:UserLimit={0}", 150),
+				String.Format(CultureInfo.InvariantCulture, "FileLogging:Directory={0}", Path.Combine(Directory, "Logs")),
 				String.Format(CultureInfo.InvariantCulture, "General:ValidInstancePaths:0={0}", Directory),
 				"General:ByondTopicTimeout=3000"
 			};


### PR DESCRIPTION
:cl: HTTP API
Added a new model, `LogFile`, for accessing server logs.
GET /Administration/Logs now returns a list of `LogFile` models without their contents. GET /Administration/Logs/<filename> can be used to retrieve the contents.
Added new Administration right 32 for retrieving `LogFile`s.
/:cl:

Closes #884