### PR TITLE
Adds custom BYOND version installing

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -34,17 +34,19 @@ You can of course, as always, ask for help at [#coderbus](irc://irc.rizon.net/co
 
 ### Development Environment
 
-You need the Dotnet 2.2 SDK and npm>=v5.7 (in your PATH) to compile the server. In order to build the service version you also need a .NET 4.7.1 build chain
+You need the Dotnet 3.1 SDK and npm>=v5.7 (in your PATH) to compile the server. In order to build the service version you also need a .NET 4.7.1 build chain
 
 The recommended IDE is Visual Studio 2019 which has installation options for both of these.
 
 In order to run the integration tests you must have the following environment variables set:
-- `TGS4_TEST_DATABASE_TYPE`: `MySql`, `MariaDB` or `SqlServer`.
+- `TGS4_TEST_DATABASE_TYPE`: `MySql`, `MariaDB`, `PostgresSql`, or `SqlServer`.
 - `TGS4_TEST_CONNECTION_STRING`: To a valid database connection string. You can use the setup wizard to create one.
-
-The following environment variables aren't required but enable more tests.
 - `TSG4_TEST_DISCORD_TOKEN`: To a valid discord bot token.
 - `TGS4_TEST_DISCORD_CHANNEL`: To a valid discord channel ID that the above bot can access.
+- `TGS4_TEST_IRC_CONNECTION_STRING`: To a valid TGS4 IRC connection string. See the code for [IrcConnectionStringBuilder](../src/Tgstation.Server.Api/Models/IrcConnectionStringBuilder.cs) for details.
+- `TGS4_TEST_IRC_CHANNEL`: To a valid IRC channel accessible with the above connection.
+- `TGS4_TEST_BRANCH`: Should be either `dev` or `master` depending on what you are working off of. Used for repository tests.
+- (Optional) `TGS4_TEST_GITHUB_TOKEN`: A GitHub personal access token with no scopes used to bypass rate limits.
 
 ### Know your Code
 
@@ -55,7 +57,7 @@ The `/src` folder at the root of this repository contains a series of `README.md
 
 ## Specifications
 
-As mentioned before, you are expected to follow these specifications in order to make everyone's lives easier. It'll save both your time and ours, by making sure you don't have to make any changes and we don't have to ask you to. Thank you for reading this section!
+You are expected to follow these specifications in order to make everyone's lives easier. It'll save both your time and ours, by making sure you don't have to make any changes and we don't have to ask you to. Thank you for reading this section!
 
 ### Object Oriented Code
 As C# is an object-oriented language, code must be object-oriented when possible in order to be more flexible when adding content to it. If you don't know what "object-oriented" means, we highly recommend you do some light research to grasp the basics.
@@ -79,13 +81,16 @@ DO:
 
 - Use the sealed keyword where possible
 - Use the readonly keyword where possible
+- Use automatic getters where possible.
+- Prefer fields to properties where stylecop allows.
 - Use 1 line bodies (void X() => Y();) where possible (Excluding constructors)
 - Use the factory pattern where reasonable
 - Use the const keyword where possible
 - Use the var keyword where possible
-- Use the static keyword on member functions where possible
+- Use the static keyword on member and inline functions where possible
 - Use CancellationTokens where possible
 - Throw appropriate ArgumentExceptions for public functions
+- Use nullable references approprately
 
 DON'T:
 
@@ -94,14 +99,6 @@ DON'T:
 - Use the static keyword on fields where avoidable
 - Use the public keyword where avoidable
 - Handle Tasks in a synchronous fashion
-
-### Versioning
-
-The version format we use is 4.\<major\>.\<minor\>.\<patch\>. The first number never changes and TGS 1/2/3/4 are to be considered seperate products. The numbers that follow are the semver. The criteria for changing a version number is as follows
-
-- Major: A breaking change to the DMAPI
-- Minor: Additions or changes to the API or DMAPI or feature additions to the service
-- Patch: Non-breaking changes internal to each of the 3 modules (Service, API, DMAPI)
 
 ### Formatting
 
@@ -191,34 +188,61 @@ You should now have MY/MS migration files generated in `/src/Tgstation.Server.Ho
 
 We use this attribute to ensure EFCore generated tables are not nullable for specific properties. They are valid to be null in API communication. Do not use this attribute expecting the model validator to prevent null data in API request.
 
-## Code Versioning
+## Versioning
 
-Any backwards compatible fixes made should be committed to the `master` branch if possible. These will be automatically merged into the `dev` branch.
+The version format we use is 4.\<minor\>.\<patch\>. The first number never changes and TGS 1/2/3/4 are to be considered seperate products. The numbers that follow are the semver. The criteria for changing a version number is as follows
+
+- Minor: A feature addition to the core server functionality.
+- Patch: Patch changes.
+
+Patch changes should be committed to the `master` branch if possible. These will be automatically merged into the `dev` branch.
 All other changes should be made directly to the `dev` branch. These will be merged to `master` on the next minor release cycle.
 
-## Deployment Process
+We have several subcomponent APIs we ship with the core server that have their own versions.
 
-Every issue/pull request in a release should share a common milestone named with the release version i.e. `4.5.3.5`
+- HTTP API
+- DreamMaker API
+- Configuration File
+- Host Watchdog
+- Web Control Panel
 
-When every issue and PR in the milestone is closed. Create a version bump PR that changes the version numbers. At the time of this writing they exist in the following files
+These are represent as standard [semver](https://semver.org/)s and don't affect the core version. The only stipulation is major changes to the HTTP and DreamMaker APIs or the configuration must coincide with a minor core version bump.
 
-- `/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj`
-- `/src/Tgstation.Server.Host.Console/Tgstation.Server.Host.Console.csproj`
-- 2 in `/src/Tgstation.Server.Host.Service/Properties/AssemblyInfo.cs`
-- `/src/Tgstation.Server.Host.Watchdog/Tgstation.Server.Host.Watchdog.csproj`
+All versions are stored in the master file [build/Version.props](../build/Version.props). They are repeatedly defined in a few other places, but integration tests will make sure they are consistent.
 
-Merge the pull request with `[TGSDeploy]` somewhere in the commit title. The scripts will handle amalgamating release notes, building, closing the milestone, and publishing the release. This will also trigger update notifications on existing TGS deployments.
+#### Nuget Versioning
 
-### API/Client Deployment
+The NuGet package Tgstation.Server.Client is another part of the suite which should be versioned separately. However, Tgstation.Server.Api is also a package that is published, and breaking changes can happen independantly of each other.
 
-The Api/Client project versions must be updated on nuget when changed. The numbers exist in the following files:
+- Consider Tgstation.Server.Client it's own product, perform major and minor bumps according to semver semantics including the Tgstation.Server.Api code (but not the version).
+- Tgstation.Server.Api is a bit tricky as breaking code changes may occur without affecting the actual HTTP contract. For this reason, all code changes that do this should be pushed out as patches, even if they contain breaking changes.
 
-- `/src/Tgstation.Server.Api/Tgstation.Server.Api.csproj`
-- `/src/Tgstation.Server.Client/Tgstation.Server.Client.csproj`
+## Triage, Deployment, and Releasing
 
-These should not be the same numbers as the main suite. When bumping the API version the client should only receive a minor (3rd number) version bump unless major changes to CLIENT code were made.
+_This section mainly applies to people with write access to the repository. Anyone is free to propose their work and maintainers will triage it appropriately._
 
-Merge these alongside regular deployments with `[NugetDeploy]` in the commit title (Won't work without an accompanying `[TGSDeploy]`). This will handle the nuget publishing.
+When issues affecting the server come in, they should be lebeled appropriately and either put into the `V4 Backlog` milestone or current patch milestone depending on if it's a feature request or bug.
+
+After a minor release, the team should decide at that time what will go into it and setup the milestone accordingly. At this point the `Backlog` label should be removed and replaced with `Ready` and the milestone changed from `V4 Backlog` to `v4.X.0` with X being the minor release version.
+
+Assign work before beginning on it. When work is started, replace the `Ready` label with the `Work In Progress` label.
+
+Word commit names descriptively. Only submit work through pull requests. When doing so, link the issue you'll be closing and set the milestone appropriately. Don't forget a changelog. **WARNING** Remember to submit patches to the `master` branch. Also at the time of this writing there appears to be an issue where GitHub won't close issues with PRs to the non-default branch. Maintainers may need to do this manually after merging.
+
+At the time of this writing, the repository is configured to automate much of the deployment/release process.
+
+When the new API or client is ready to be released, update the `Version.props` file appropriately and merge the pull request with the text `[APIDeploy]` or `[NuGetDeploy]` respectively in the commit message (or both!). The release will be published automatically.
+
+That step should be taken for the latest API and client before releasing the core version that uses them if applicable.
+
+Before releasing the core version, ensure the following:
+
+- For minor releases, ensure your changes are merging `dev` into `master`.
+- Ensure all issues and pull requests in the associated milestone are closed (aside from the PR you are using to cut the release).
+
+To perform the release, merge the PR with `[TGSDeploy]` in the commit message. The build system will handle generating release notes, packaging, and pushing the build to GitHub releases. This will also make it available for servers to self update.
+
+The build system will also handle closing the current milestone and creating new minor/patch milestones where applicable.
 
 ## Banned content
 

--- a/docs/API.dox
+++ b/docs/API.dox
@@ -265,6 +265,8 @@ To set the active Byond version:
 
 I POST "/Byond" @ref Tgstation.Server.Api.Models.Byond => @ref Tgstation.Server.Api.Models.Byond
 
+This will queue up a job to install the byond version if it doesn't exist which will be returned in the response. The @ref Tgstation.Server.Api.Models.Internal.RawData.Content field can be used to upload custom zip files.
+
 To list all installed Byond versions use the following request:
 
 I GET "/Byond/List" => Array of @ref Tgstation.Server.Api.Models.Byond

--- a/src/Tgstation.Server.Api/Models/Byond.cs
+++ b/src/Tgstation.Server.Api/Models/Byond.cs
@@ -1,11 +1,12 @@
 ﻿using System;
+using Tgstation.Server.Api.Models.Internal;
 
 namespace Tgstation.Server.Api.Models
 {
 	/// <summary>
-	/// Represents a BYOND installation
+	/// Represents a BYOND installation. <see cref="RawData.Content"/> is used to upload custom BYOND version zip files, though <see cref="Version"/> must still be set.
 	/// </summary>
-	public sealed class Byond
+	public sealed class Byond : RawData
 	{
 		/// <summary>
 		/// The <see cref="System.Version"/> of the <see cref="Byond"/> installation used for new compiles. Will be <see langword="null"/> if the user does not have permission to view it or there is no BYOND version installed. Only considers the <see cref="Version.Major"/> and <see cref="Version.Minor"/> numbers.

--- a/src/Tgstation.Server.Api/Models/ErrorCode.cs
+++ b/src/Tgstation.Server.Api/Models/ErrorCode.cs
@@ -537,5 +537,11 @@ namespace Tgstation.Server.Api.Models
 		/// </summary>
 		[Description("Test merging cannot be performed with this remote!")]
 		RepoTestMergeInvalidRemote,
+
+		/// <summary>
+		/// Attempted to switch to a custom BYOND version that does not exist.
+		/// </summary>
+		[Description("Cannot switch to requested custom BYOND version as it is not currently installed.")]
+		ByondNonExistentCustomVersion,
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Byond/ByondManager.cs
+++ b/src/Tgstation.Server.Host/Components/Byond/ByondManager.cs
@@ -34,12 +34,12 @@ namespace Tgstation.Server.Host.Components.Byond
 		const string TrustedDmbFileName = "trusted.txt";
 
 		/// <summary>
-		/// The file in which we store the <see cref="VersionKey(Version)"/> for installations
+		/// The file in which we store the <see cref="VersionKey(Version, bool)"/> for installations
 		/// </summary>
 		const string VersionFileName = "Version.txt";
 
 		/// <summary>
-		/// The file in which we store the <see cref="VersionKey(Version)"/> for the active installation
+		/// The file in which we store the <see cref="VersionKey(Version, bool)"/> for the active installation
 		/// </summary>
 		const string ActiveVersionFileName = "ActiveVersion.txt";
 
@@ -89,9 +89,12 @@ namespace Tgstation.Server.Host.Components.Byond
 		/// <summary>
 		/// Converts a BYOND <paramref name="version"/> to a <see cref="string"/>
 		/// </summary>
-		/// <param name="version">The <see cref="Version"/> to convert</param>
+		/// <param name="version">The <see cref="Version"/> to convert.</param>
+		/// <param name="allowPatch">If the <see cref="Version.Build"/> property of <paramref name="version"/> should be kept.</param>
 		/// <returns>The <see cref="string"/> representation of <paramref name="version"/></returns>
-		static string VersionKey(Version version) => new Version(version.Major, version.Minor).ToString();
+		static string VersionKey(Version version, bool allowPatch) => (allowPatch && version.Build > 0
+			? new Version(version.Major, version.Minor, version.Build)
+			: new Version(version.Major, version.Minor)).ToString();
 
 		/// <summary>
 		/// Construct a <see cref="ByondManager"/>
@@ -118,17 +121,29 @@ namespace Tgstation.Server.Host.Components.Byond
 		/// Installs a BYOND <paramref name="version"/> if it isn't already
 		/// </summary>
 		/// <param name="version">The BYOND <see cref="Version"/> to install</param>
+		/// <param name="versionZipBytes">Custom zip file bytes to use. Will cause a <see cref="Version.Build"/> number to be added.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="Task"/> representing the running operation</returns>
-		async Task InstallVersion(Version version, CancellationToken cancellationToken)
+		async Task<string> InstallVersion(Version version, byte[] versionZipBytes, CancellationToken cancellationToken)
 		{
 			var ourTcs = new TaskCompletionSource<object>();
 			Task inProgressTask;
-
-			var versionKey = VersionKey(version);
+			string versionKey;
 			bool installed;
 			lock (installedVersions)
 			{
+				if (versionZipBytes != null)
+				{
+					int customInstallationNumber = 1;
+					do
+					{
+						versionKey = $"{VersionKey(version, false)}.{customInstallationNumber++}";
+					}
+					while (installedVersions.ContainsKey(versionKey));
+				}
+				else
+					versionKey = VersionKey(version, true);
+
 				installed = installedVersions.TryGetValue(versionKey, out inProgressTask);
 				if (!installed)
 					installedVersions.Add(versionKey, ourTcs.Task);
@@ -139,8 +154,13 @@ namespace Tgstation.Server.Host.Components.Byond
 				{
 					await Task.WhenAny(ourTcs.Task, inProgressTask).ConfigureAwait(false);
 					cancellationToken.ThrowIfCancellationRequested();
-					return;
+					return versionKey;
 				}
+
+			if (versionZipBytes != null)
+				logger.LogInformation("Installing custom BYOND version as {0}...", versionKey);
+			else if (version.Build > 0)
+				throw new JobException(ErrorCode.ByondNonExistentCustomVersion);
 			else
 				logger.LogDebug("Requested BYOND version {0} not currently installed. Doing so now...");
 
@@ -148,18 +168,22 @@ namespace Tgstation.Server.Host.Components.Byond
 			try
 			{
 				await eventConsumer.HandleEvent(EventType.ByondInstallStart, new List<string> { versionKey }, cancellationToken).ConfigureAwait(false);
-				var downloadTask = byondInstaller.DownloadVersion(version, cancellationToken);
+				var zipFileBytesTask = versionZipBytes == null
+					? byondInstaller.DownloadVersion(version, cancellationToken)
+					: Task.FromResult(versionZipBytes);
 
 				await ioManager.DeleteDirectory(versionKey, cancellationToken).ConfigureAwait(false);
 
 				try
 				{
-					var download = await downloadTask.ConfigureAwait(false);
+					versionZipBytes = await zipFileBytesTask.ConfigureAwait(false);
 					await ioManager.CreateDirectory(versionKey, cancellationToken).ConfigureAwait(false);
 
 					var extractPath = ioManager.ResolvePath(versionKey);
 					logger.LogTrace("Extracting downloaded BYOND zip to {0}...", extractPath);
-					await ioManager.ZipToDirectory(extractPath, download, cancellationToken).ConfigureAwait(false);
+					await ioManager.ZipToDirectory(extractPath, versionZipBytes, cancellationToken).ConfigureAwait(false);
+					versionZipBytes = null;
+
 					await byondInstaller.InstallByond(extractPath, version, cancellationToken).ConfigureAwait(false);
 
 					// make sure to do this last because this is what tells us we have a valid version in the future
@@ -191,20 +215,34 @@ namespace Tgstation.Server.Host.Components.Byond
 				ourTcs.SetException(e);
 				throw;
 			}
+
+			return versionKey;
 		}
 
 		/// <inheritdoc />
-		public async Task ChangeVersion(Version version, CancellationToken cancellationToken)
+		public async Task ChangeVersion(Version version, byte[] customVersionBytes, CancellationToken cancellationToken)
 		{
 			if (version == null)
 				throw new ArgumentNullException(nameof(version));
-			var versionKey = VersionKey(version);
-			await InstallVersion(version, cancellationToken).ConfigureAwait(false);
+
+			var versionKey = await InstallVersion(version, customVersionBytes, cancellationToken).ConfigureAwait(false);
 			using (await SemaphoreSlimContext.Lock(semaphore, cancellationToken).ConfigureAwait(false))
 			{
 				await ioManager.WriteAllBytes(ActiveVersionFileName, Encoding.UTF8.GetBytes(versionKey), cancellationToken).ConfigureAwait(false);
-				await eventConsumer.HandleEvent(EventType.ByondActiveVersionChange, new List<string> { ActiveVersion != null ? VersionKey(ActiveVersion) : null, versionKey }, cancellationToken).ConfigureAwait(false);
-				ActiveVersion = version;
+				await eventConsumer.HandleEvent(
+					EventType.ByondActiveVersionChange,
+					new List<string>
+					{
+						ActiveVersion != null
+							? VersionKey(ActiveVersion, true)
+							: null,
+						versionKey
+					},
+					cancellationToken)
+					.ConfigureAwait(false);
+
+				// We reparse the version key because it could be changed after a custom install.
+				ActiveVersion = Version.Parse(versionKey);
 			}
 		}
 
@@ -214,9 +252,9 @@ namespace Tgstation.Server.Host.Components.Byond
 			var versionToUse = requiredVersion ?? ActiveVersion;
 			if (versionToUse == null)
 				throw new JobException(ErrorCode.ByondNoVersionsInstalled);
-			await InstallVersion(versionToUse, cancellationToken).ConfigureAwait(false);
+			await InstallVersion(versionToUse, null, cancellationToken).ConfigureAwait(false);
 
-			var versionKey = VersionKey(versionToUse);
+			var versionKey = VersionKey(versionToUse, true);
 			var binPathForVersion = ioManager.ConcatPath(versionKey, BinPath);
 
 			logger.LogTrace("Creating ByondExecutableLock lock for version {0}", requiredVersion);
@@ -286,7 +324,7 @@ namespace Tgstation.Server.Host.Components.Byond
 				var text = Encoding.UTF8.GetString(bytes);
 				if (Version.TryParse(text, out var version))
 				{
-					var key = VersionKey(version);
+					var key = VersionKey(version, true);
 					lock (installedVersions)
 						if (!installedVersions.ContainsKey(key))
 						{

--- a/src/Tgstation.Server.Host/Components/Byond/ByondManager.cs
+++ b/src/Tgstation.Server.Host/Components/Byond/ByondManager.cs
@@ -187,7 +187,7 @@ namespace Tgstation.Server.Host.Components.Byond
 					await byondInstaller.InstallByond(extractPath, version, cancellationToken).ConfigureAwait(false);
 
 					// make sure to do this last because this is what tells us we have a valid version in the future
-					await ioManager.WriteAllBytes(ioManager.ConcatPath(versionKey, VersionFileName), Encoding.UTF8.GetBytes(version.ToString()), cancellationToken).ConfigureAwait(false);
+					await ioManager.WriteAllBytes(ioManager.ConcatPath(versionKey, VersionFileName), Encoding.UTF8.GetBytes(versionKey), cancellationToken).ConfigureAwait(false);
 				}
 				catch (WebException e)
 				{

--- a/src/Tgstation.Server.Host/Components/Byond/IByondManager.cs
+++ b/src/Tgstation.Server.Host/Components/Byond/IByondManager.cs
@@ -25,9 +25,10 @@ namespace Tgstation.Server.Host.Components.Byond
 		/// Change the active BYOND version
 		/// </summary>
 		/// <param name="version">The new <see cref="Version"/></param>
+		/// <param name="customVersionBytes">Optional <see cref="byte"/>s of a custom BYOND version zip file.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="Task"/> representing the running operation</returns>
-		Task ChangeVersion(Version version, CancellationToken cancellationToken);
+		Task ChangeVersion(Version version, byte[] customVersionBytes, CancellationToken cancellationToken);
 
 		/// <summary>
 		/// Lock the current installation's location and return a <see cref="IByondExecutableLock"/>

--- a/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
@@ -580,7 +580,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 									ActiveTestMerges = new List<RevInfoTestMerge>()
 								};
 
-								logger.LogWarning(Repository.Repository.OriginTrackingErrorTemplate, repoSha);
+								logger.LogInformation(Repository.Repository.OriginTrackingErrorTemplate, repoSha);
 								databaseContext.Instances.Attach(revInfo.Instance);
 								await databaseContext.Save(cancellationToken).ConfigureAwait(false);
 							}

--- a/src/Tgstation.Server.Host/Components/Instance.cs
+++ b/src/Tgstation.Server.Host/Components/Instance.cs
@@ -248,7 +248,7 @@ namespace Tgstation.Server.Host.Components
 
 										if (currentRevInfo == default)
 										{
-											logger.LogWarning(Repository.Repository.OriginTrackingErrorTemplate, currentHead);
+											logger.LogInformation(Repository.Repository.OriginTrackingErrorTemplate, currentHead);
 											onOrigin = true;
 										}
 

--- a/src/Tgstation.Server.Host/Controllers/RepositoryController.cs
+++ b/src/Tgstation.Server.Host/Controllers/RepositoryController.cs
@@ -108,7 +108,7 @@ namespace Tgstation.Server.Host.Controllers
 			if (revisionInfo.OriginCommitSha == null)
 			{
 				revisionInfo.OriginCommitSha = repoSha;
-				Logger.LogWarning(Components.Repository.Repository.OriginTrackingErrorTemplate, repoSha);
+				Logger.LogInformation(Components.Repository.Repository.OriginTrackingErrorTemplate, repoSha);
 			}
 
 			revInfoSink?.Invoke(revisionInfo);

--- a/tests/Tgstation.Server.Tests/Instance/ByondTest.cs
+++ b/tests/Tgstation.Server.Tests/Instance/ByondTest.cs
@@ -1,16 +1,25 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Castle.Core.Logging;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
 using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Tgstation.Server.Api;
+using Tgstation.Server.Api.Models;
+using Tgstation.Server.Client;
 using Tgstation.Server.Client.Components;
+using Tgstation.Server.Host.Components.Byond;
+using Tgstation.Server.Host.IO;
 using Tgstation.Server.Host.System;
 
 namespace Tgstation.Server.Tests.Instance
 {
 	sealed class ByondTest : JobsRequiredTest
 	{
+		public static readonly Version TestVersion = new Version(513, 1526);
+
 		readonly IByondClient byondClient;
 
 		readonly Api.Models.Instance metadata;
@@ -27,6 +36,7 @@ namespace Tgstation.Server.Tests.Instance
 			await TestNoVersion(cancellationToken).ConfigureAwait(false);
 			await TestInstallStable(cancellationToken).ConfigureAwait(false);
 			await TestInstallFakeVersion(cancellationToken).ConfigureAwait(false);
+			await TestCustomInstalls(cancellationToken);
 		}
 
 		async Task TestInstallFakeVersion(CancellationToken cancellationToken)
@@ -44,7 +54,7 @@ namespace Tgstation.Server.Tests.Instance
 		{
 			var newModel = new Api.Models.Byond
 			{
-				Version = new Version(513, 1514)
+				Version = TestVersion
 			};
 			var test = await byondClient.SetActiveVersion(newModel, cancellationToken).ConfigureAwait(false);
 			Assert.IsNotNull(test.InstallJob);
@@ -73,6 +83,49 @@ namespace Tgstation.Server.Tests.Instance
 			var otherShit = await allVersionsTask.ConfigureAwait(false);
 			Assert.IsNotNull(otherShit);
 			Assert.AreEqual(0, otherShit.Count);
+		}
+
+		async Task TestCustomInstalls(CancellationToken cancellationToken)
+		{
+			var byondInstaller = new PlatformIdentifier().IsWindows
+				? (IByondInstaller)new WindowsByondInstaller(
+					Mock.Of<IProcessExecutor>(),
+					new DefaultIOManager(),
+					Mock.Of<ILogger<WindowsByondInstaller>>())
+				: new PosixByondInstaller(
+					Mock.Of<IPostWriteHandler>(),
+					new DefaultIOManager(),
+					Mock.Of<ILogger<PosixByondInstaller>>());
+
+			// get the bytes for stable
+			var test = await byondClient.SetActiveVersion(new Api.Models.Byond
+			{
+				Version = TestVersion,
+				Content = await byondInstaller.DownloadVersion(TestVersion, cancellationToken)
+			}, cancellationToken).ConfigureAwait(false);
+
+			Assert.IsNotNull(test.InstallJob);
+			await WaitForJob(test.InstallJob, 60, false, cancellationToken).ConfigureAwait(false);
+
+			var newSettings = await byondClient.ActiveVersion(cancellationToken);
+			Assert.AreEqual(new Version(TestVersion.Major, TestVersion.Minor, 1), newSettings.Version);
+
+			// test a few switches
+			newSettings = await byondClient.SetActiveVersion(new Api.Models.Byond
+			{
+				Version = TestVersion
+			}, cancellationToken);
+			Assert.IsNull(newSettings.InstallJob);
+			await ApiAssert.ThrowsException<ApiConflictException>(() => byondClient.SetActiveVersion(new Api.Models.Byond
+			{
+				Version = new Version(TestVersion.Major, TestVersion.Minor, 2)
+			}, cancellationToken), ErrorCode.ByondNonExistentCustomVersion);
+
+			newSettings = await byondClient.SetActiveVersion(new Api.Models.Byond
+			{
+				Version = new Version(TestVersion.Major, TestVersion.Minor, 1)
+			}, cancellationToken);
+			Assert.IsNull(newSettings.InstallJob);
 		}
 	}
 }

--- a/tests/Tgstation.Server.Tests/Instance/RepositoryTest.cs
+++ b/tests/Tgstation.Server.Tests/Instance/RepositoryTest.cs
@@ -58,7 +58,7 @@ namespace Tgstation.Server.Tests.Instance
 
 			clone = await repositoryClient.Clone(initalRepo, cancellationToken).ConfigureAwait(false);
 
-			await WaitForJob(clone.ActiveJob, 120, false, cancellationToken).ConfigureAwait(false);
+			await WaitForJob(clone.ActiveJob, 180, false, cancellationToken).ConfigureAwait(false);
 			var cloned = await repositoryClient.Read(cancellationToken);
 
 			Assert.AreEqual(Origin, cloned.Origin);

--- a/tests/Tgstation.Server.Tests/Instance/WatchdogTest.cs
+++ b/tests/Tgstation.Server.Tests/Instance/WatchdogTest.cs
@@ -48,6 +48,12 @@ namespace Tgstation.Server.Tests.Instance
 
 			await RunBasicTest(cancellationToken);
 
+			// That was using the custom BYOND version, let's switch back to a regular one now
+			await instanceClient.Byond.SetActiveVersion(new Api.Models.Byond
+			{
+				Version = ByondTest.TestVersion
+			}, cancellationToken);
+
 			// await RunLongRunningTestThenUpdate(cancellationToken);
 			// await RunLongRunningTestThenUpdateWithByondVersionSwitch(cancellationToken);
 			// Remove this deploy when the above tests are reenabled

--- a/tests/Tgstation.Server.Tests/IntegrationTest.cs
+++ b/tests/Tgstation.Server.Tests/IntegrationTest.cs
@@ -73,7 +73,7 @@ namespace Tgstation.Server.Tests
 				//wait up to 3 minutes for the dl and install
 				await Task.WhenAny(serverTask, Task.Delay(TimeSpan.FromMinutes(3), cancellationToken)).ConfigureAwait(false);
 
-				Assert.IsTrue(serverTask.IsCompleted, "Sever still running!");
+				Assert.IsTrue(serverTask.IsCompleted, "Server still running!");
 
 				Assert.IsTrue(Directory.Exists(server.UpdatePath), "Update directory not present!");
 

--- a/tests/Tgstation.Server.Tests/TestingServer.cs
+++ b/tests/Tgstation.Server.Tests/TestingServer.cs
@@ -36,17 +36,16 @@ namespace Tgstation.Server.Tests
 			if (String.IsNullOrWhiteSpace(Directory))
 			{
 				Directory = Path.Combine(Path.GetTempPath(), "TGS4_INTEGRATION_TEST");
-				if(System.IO.Directory.Exists(Directory))
+				if (System.IO.Directory.Exists(Directory))
 					try
 					{
 						System.IO.Directory.Delete(Directory, true);
 					}
-					catch
-					{
-						Directory = Path.Combine(Directory, Guid.NewGuid().ToString());
-					}
+					catch { }
+
 			}
 
+			Directory = Path.Combine(Directory, Guid.NewGuid().ToString());
 			System.IO.Directory.CreateDirectory(Directory);
 			const string UrlString = "http://localhost:5010";
 			Url = new Uri(UrlString);


### PR DESCRIPTION
Closes #731
Closes #899 

:cl: HTTP API
Custom BYOND versions may now be installed and used. Upload a zip as a base64 encoded string in the new `content` field of the Byond model when initially installing. The custom version will have a patch value >= 1 applied to it to indicate that it is not official. Use this version to switch back to it without reuploading.
/:cl:

- Fully document the maintaining process
- Release notes now generate new milestones \o/
