### PR TITLE
Add config versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ This wizard will, generally, run whenever the server is launched without detecti
 
 Create an `appsettings.Production.json` file next to `appsettings.json`. This will override the default settings in appsettings.json with your production settings. There are a few keys meant to be changed by hosts. Modifying any config files while the server is running will trigger a safe restart (Keeps DreamDaemon's running). Note these are all case-sensitive: 
 
+- `General:ConfigVersion`: Suppresses warnings about out of date config versions. You should change this after updating TGS to one with a new config version. The current version can be found on the releases page for your server version (This field did not exist before v4.4.0).
+
 - `General:MinimumPasswordLength`: Minimum password length requirement for database users
 
 - `General:ValidInstancePaths`: Array meant to limit the directories in which instances may be created.

--- a/build/Version.props
+++ b/build/Version.props
@@ -3,6 +3,7 @@
     <!-- This is the authorative version list -->
     <!-- Integration tests will ensure they match across the board -->
     <TgsCoreVersion>4.4.0</TgsCoreVersion>
+    <TgsConfigVersion>2.0.0</TgsConfigVersion>
     <TgsApiVersion>7.0.0</TgsApiVersion>
     <TgsClientVersion>7.3.0</TgsClientVersion>
     <TgsDmapiVersion>5.2.2</TgsDmapiVersion>

--- a/src/Tgstation.Server.Host/Components/InstanceManager.cs
+++ b/src/Tgstation.Server.Host/Components/InstanceManager.cs
@@ -280,6 +280,8 @@ namespace Tgstation.Server.Host.Components
 
 			try
 			{
+				generalConfiguration.CheckCompatibility(logger);
+
 				CheckSystemCompatibility();
 				var factoryStartup = instanceFactory.StartAsync(cancellationToken);
 				await databaseSeeder.Initialize(databaseContext, cancellationToken).ConfigureAwait(false);

--- a/src/Tgstation.Server.Host/Configuration/GeneralConfiguration.cs
+++ b/src/Tgstation.Server.Host/Configuration/GeneralConfiguration.cs
@@ -1,5 +1,7 @@
-﻿using Newtonsoft.Json;
+﻿using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using System;
 using Tgstation.Server.Api.Models.Internal;
 
 namespace Tgstation.Server.Host.Configuration
@@ -18,6 +20,11 @@ namespace Tgstation.Server.Host.Configuration
 		/// The default value of <see cref="ApiPort"/>.
 		/// </summary>
 		public const ushort DefaultApiPort = 5000;
+
+		/// <summary>
+		/// The current <see cref="ConfigVersion"/>.
+		/// </summary>
+		public static readonly Version CurrentConfigVersion = new Version(2, 0, 0);
 
 		/// <summary>
 		/// The default value for <see cref="ServerInformation.MinimumPasswordLength"/>.
@@ -43,6 +50,11 @@ namespace Tgstation.Server.Host.Configuration
 		/// The default value for <see cref="RestartTimeout"/>
 		/// </summary>
 		const uint DefaultRestartTimeout = 60000;
+
+		/// <summary>
+		/// The <see cref="Version"/> the file says it is.
+		/// </summary>
+		public Version ConfigVersion { get; set; }
 
 		/// <summary>
 		/// The port the TGS API listens on.
@@ -88,6 +100,28 @@ namespace Tgstation.Server.Host.Configuration
 			MinimumPasswordLength = DefaultMinimumPasswordLength;
 			InstanceLimit = DefaultInstanceLimit;
 			UserLimit = DefaultUserLimit;
+		}
+
+		/// <summary>
+		/// Validates the current <see cref="ConfigVersion"/>'s compatibility and provides migration instructions.
+		/// </summary>
+		/// <param name="logger">The <see cref="ILogger"/> to use.</param>
+		public void CheckCompatibility(ILogger logger)
+		{
+			if (logger == null)
+				throw new ArgumentNullException(nameof(logger));
+
+			if (ConfigVersion == null)
+				logger.LogCritical(
+					"No `ConfigVersion` specified, your configuration may be out of date! The current version is \"{0}\"",
+					CurrentConfigVersion);
+			else if (ConfigVersion != CurrentConfigVersion)
+				if (ConfigVersion.Major != CurrentConfigVersion.Major)
+					logger.LogCritical(
+						"Your `ConfigVersion` is majorly out-of-date and may potentially cause issues running the server. Please follow migration instructions from the TGS release notes.",
+						CurrentConfigVersion);
+				else
+					logger.LogWarning("Your `ConfigVersion` is out-of-date. Please follow migration instructions from the TGS release notes.");
 		}
 	}
 }

--- a/src/Tgstation.Server.Host/Configuration/README.md
+++ b/src/Tgstation.Server.Host/Configuration/README.md
@@ -1,0 +1,5 @@
+# Configuration Classes
+
+These types map directly to the settings used in the [appsettings.json](../appsettings.json) file and its derivatives. See the [Microsoft Docs on the ASP .NET Core configuration system](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-3.1) for details.
+
+When making changes here, it's important to also update the config version in [build/Version.props](../../../build/Version.props) according to semver semantics. You'll also need to update the constant in [GeneralConfiguration.cs](./GeneralConfigration.cs).

--- a/src/Tgstation.Server.Host/Core/Application.cs
+++ b/src/Tgstation.Server.Host/Core/Application.cs
@@ -409,6 +409,8 @@ namespace Tgstation.Server.Host.Core
 			else
 				logger.LogDebug("Web control panel disabled!");
 
+			logger.LogDebug("Starting hosting...");
+
 			// authenticate JWT tokens using our security pipeline if present, returns 401 if bad
 			applicationBuilder.UseAuthentication();
 

--- a/src/Tgstation.Server.Host/Setup/SetupWizard.cs
+++ b/src/Tgstation.Server.Host/Setup/SetupWizard.cs
@@ -745,6 +745,7 @@ namespace Tgstation.Server.Host.Setup
 			await console.WriteAsync(String.Format(CultureInfo.InvariantCulture, "Configuration complete! Saving to {0}", userConfigFileName), true, cancellationToken).ConfigureAwait(false);
 
 			newGeneralConfiguration.ApiPort = hostingPort ?? GeneralConfiguration.DefaultApiPort;
+			newGeneralConfiguration.ConfigVersion = GeneralConfiguration.CurrentConfigVersion;
 			var map = new Dictionary<string, object>()
 			{
 				{ DatabaseConfiguration.Section, databaseConfiguration },

--- a/tests/Tgstation.Server.Tests/VersionsTest.cs
+++ b/tests/Tgstation.Server.Tests/VersionsTest.cs
@@ -9,6 +9,7 @@ using Tgstation.Server.Client;
 using Tgstation.Server.Host;
 using Tgstation.Server.Host.Components.Interop;
 using Tgstation.Server.Host.Components.Watchdog;
+using Tgstation.Server.Host.Configuration;
 
 namespace Tgstation.Server.Tests
 {
@@ -37,6 +38,16 @@ namespace Tgstation.Server.Tests
 			Assert.IsNotNull(versionString);
 			Assert.IsTrue(Version.TryParse(versionString, out var expected));
 			var actual = typeof(Program).Assembly.GetName().Version;
+			Assert.AreEqual(expected, actual);
+		}
+
+		[TestMethod]
+		public void TestConfigVersion()
+		{
+			var versionString = versionsPropertyGroup.Element(xmlNamespace + "TgsConfigVersion").Value;
+			Assert.IsNotNull(versionString);
+			Assert.IsTrue(Version.TryParse(versionString, out var expected));
+			var actual = GeneralConfiguration.CurrentConfigVersion;
 			Assert.AreEqual(expected, actual);
 		}
 

--- a/tools/ReleaseNotes/Program.cs
+++ b/tools/ReleaseNotes/Program.cs
@@ -250,6 +250,7 @@ namespace ReleaseNotes
 						}
 
 						var apiVersion = Version.Parse(versionsPropertyGroup.Element(xmlNamespace + "TgsApiVersion").Value);
+						var configVersion = Version.Parse(versionsPropertyGroup.Element(xmlNamespace + "TgsConfigVersion").Value);
 						var dmApiVersion = Version.Parse(versionsPropertyGroup.Element(xmlNamespace + "TgsDmapiVersion").Value);
 						var webControlVersion = Version.Parse(versionsPropertyGroup.Element(xmlNamespace + "TgsControlPanelVersion").Value);
 						var hostWatchdogVersion = Version.Parse(versionsPropertyGroup.Element(xmlNamespace + "TgsHostWatchdogVersion").Value);
@@ -257,7 +258,7 @@ namespace ReleaseNotes
 						if (webControlVersion.Major == 0)
 							postControlPanelMessage = true;
 
-						prefix = $"Please refer to the [README](https://github.com/tgstation/tgstation-server#setup) for setup instructions.{Environment.NewLine}{Environment.NewLine}#### Component Versions\nCore: {coreVersion}\nHTTP API: {apiVersion}\nDreamMaker API: {dmApiVersion}\n[Web Control Panel](https://github.com/tgstation/tgstation-server-control-panel): {webControlVersion}\nHost Watchdog: {hostWatchdogVersion}";
+						prefix = $"Please refer to the [README](https://github.com/tgstation/tgstation-server#setup) for setup instructions.{Environment.NewLine}{Environment.NewLine}#### Component Versions\nCore: {coreVersion}\nConfiguration: {configVersion}\nHTTP API: {apiVersion}\nDreamMaker API: {dmApiVersion}\n[Web Control Panel](https://github.com/tgstation/tgstation-server-control-panel): {webControlVersion}\nHost Watchdog: {hostWatchdogVersion}";
 						break;
 					case 3:
 						prefix = "The /tg/station server suite";


### PR DESCRIPTION
:cl: **Configuration**
The initial config version is `2.0.0`.
Future release notes will contain this section to indicate changes to be made to the configuration file.
Configuration is now versioned in the field `General:ConfigVersion`. Having this up-to-date will prevent warnings during server startup.
/:cl:

:cl:
The setup wizard will now automatically fill in the current `General:ConfigVersion`.
/:cl:

Closes #1059 