### PR TITLE
4.4.1

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- This is the authorative version list -->
     <!-- Integration tests will ensure they match across the board -->
-    <TgsCoreVersion>4.4.0</TgsCoreVersion>
+    <TgsCoreVersion>4.4.1</TgsCoreVersion>
     <TgsConfigVersion>2.0.0</TgsConfigVersion>
     <TgsApiVersion>7.0.1</TgsApiVersion>
     <TgsClientVersion>8.0.0</TgsClientVersion>

--- a/src/Tgstation.Server.Host/Components/Deployment/DmbFactory.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/DmbFactory.cs
@@ -248,6 +248,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 
 				if (!dmbExistsAtRoot)
 				{
+					logger.LogTrace("Didn't find .dmb at game directory root, checking A/B dirs...");
 					var primaryCheckTask = ioManager.FileExists(
 						ioManager.ConcatPath(
 							newProvider.Directory,

--- a/src/Tgstation.Server.Host/Components/InstanceManager.cs
+++ b/src/Tgstation.Server.Host/Components/InstanceManager.cs
@@ -290,9 +290,9 @@ namespace Tgstation.Server.Host.Components
 					.AsQueryable()
 					.Where(x => x.Online.Value)
 					.Include(x => x.RepositorySettings)
+					.Include(x => x.DreamDaemonSettings)
 					.Include(x => x.ChatSettings)
 					.ThenInclude(x => x.Channels)
-					.Include(x => x.DreamDaemonSettings)
 					.ToAsyncEnumerable();
 				var tasks = new List<Task>();
 				await factoryStartup.ConfigureAwait(false);

--- a/src/Tgstation.Server.Host/Components/Session/SessionPersistor.cs
+++ b/src/Tgstation.Server.Host/Components/Session/SessionPersistor.cs
@@ -153,9 +153,16 @@ namespace Tgstation.Server.Host.Components.Session
 				return null;
 			}
 
+			var dmb = await dmbFactory.FromCompileJob(result.CompileJob, cancellationToken).ConfigureAwait(false);
+			if (dmb == null)
+			{
+				logger.LogError("Unable to reattach! Could not load .dmb!");
+				return null;
+			}
+
 			var info = new ReattachInformation(
 				result,
-				await dmbFactory.FromCompileJob(result.CompileJob, cancellationToken).ConfigureAwait(false),
+				dmb,
 				topicTimeout.Value);
 
 			logger.LogDebug("Reattach information loaded: {0}", info);

--- a/src/Tgstation.Server.Host/Components/Watchdog/PosixWatchdogFactory.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/PosixWatchdogFactory.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using System;
 using Tgstation.Server.Api.Models.Internal;
 using Tgstation.Server.Host.Components.Chat;
 using Tgstation.Server.Host.Components.Deployment;
@@ -73,6 +74,6 @@ namespace Tgstation.Server.Host.Components.Watchdog
 				LoggerFactory.CreateLogger<PosixWatchdog>(),
 				settings,
 				instance,
-				settings.AutoStart.Value);
+				settings.AutoStart ?? throw new ArgumentNullException(nameof(settings)));
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Watchdog/WatchdogFactory.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/WatchdogFactory.cs
@@ -97,6 +97,6 @@ namespace Tgstation.Server.Host.Components.Watchdog
 				LoggerFactory.CreateLogger<BasicWatchdog>(),
 				settings,
 				instance,
-				settings.AutoStart.Value);
+				settings.AutoStart ?? throw new ArgumentNullException(nameof(settings)));
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Watchdog/WindowsWatchdogFactory.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/WindowsWatchdogFactory.cs
@@ -80,6 +80,6 @@ namespace Tgstation.Server.Host.Components.Watchdog
 				LoggerFactory.CreateLogger<WindowsWatchdog>(),
 				settings,
 				instance,
-				settings.AutoStart.Value);
+				settings.AutoStart ?? throw new ArgumentNullException(nameof(settings)));
 	}
 }

--- a/src/Tgstation.Server.Host/Controllers/InstanceController.cs
+++ b/src/Tgstation.Server.Host/Controllers/InstanceController.cs
@@ -604,6 +604,9 @@ namespace Tgstation.Server.Host.Controllers
 			if (instance == null)
 				return Gone();
 
+			if (ValidateInstanceOnlineStatus(instance))
+				await DatabaseContext.Save(cancellationToken).ConfigureAwait(false);
+
 			if (cantList && !instance.InstanceUsers.Any(instanceUser => instanceUser.UserId == AuthenticationContext.User.Id &&
 				(instanceUser.ByondRights != ByondRights.None ||
 				instanceUser.ChatBotRights != ChatBotRights.None ||

--- a/src/Tgstation.Server.Host/Server.cs
+++ b/src/Tgstation.Server.Host/Server.cs
@@ -286,7 +286,7 @@ namespace Tgstation.Server.Host
 				}
 
 				RestartRequested = true;
-				propagatedException = exception;
+				propagatedException ??= exception;
 			}
 
 			if (exception == null)


### PR DESCRIPTION
:cl:
Fixed BYOND topic timeouts potentially being constantly set to 0 from bad configs.
Fixed an issue where exceptions that crash the server would fail to be re-thrown at the top level.
Fixed a potential NullReferenceException when on-lining instances.
Instance on-lining errors at server startup will no longer prevent the server from starting.
Fixed a rare issue where reattaching would fail instance startup due to an ArgumentNullException.
/:cl:

:cl: HTTP API
Instance queries will now always reflect online state as it is in the service.
/:cl:
