### PR TITLE
v4.4.3

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- This is the authorative version list -->
     <!-- Integration tests will ensure they match across the board -->
-    <TgsCoreVersion>4.4.2</TgsCoreVersion>
+    <TgsCoreVersion>4.4.3</TgsCoreVersion>
     <TgsConfigVersion>2.0.0</TgsConfigVersion>
     <TgsApiVersion>7.1.0</TgsApiVersion>
     <TgsClientVersion>8.1.0</TgsClientVersion>

--- a/src/Tgstation.Server.Host/Components/Chat/ChatManager.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/ChatManager.cs
@@ -632,7 +632,7 @@ namespace Tgstation.Server.Host.Components.Chat
 		}
 
 		/// <inheritdoc />
-		public async Task SendWatchdogMessage(string message, bool adminOnly, CancellationToken cancellationToken)
+		public async Task SendWatchdogMessage(string message, CancellationToken cancellationToken)
 		{
 			List<ulong> wdChannels = null;
 			message = String.Format(CultureInfo.InvariantCulture, "WD: {0}", message);
@@ -644,17 +644,7 @@ namespace Tgstation.Server.Host.Components.Chat
 
 			// so it doesn't change while we're using it
 			lock (mappedChannels)
-			{
-				if (adminOnly)
-				{
-					wdChannels = mappedChannels.Where(x => x.Value.IsAdminChannel).Select(x => x.Key).ToList();
-					if (wdChannels.Count == 0)
-						adminOnly = false;
-				}
-
-				if (!adminOnly)
-					wdChannels = mappedChannels.Where(x => x.Value.IsWatchdogChannel).Select(x => x.Key).ToList();
-			}
+				wdChannels = mappedChannels.Where(x => x.Value.IsWatchdogChannel).Select(x => x.Key).ToList();
 
 			await SendMessage(message, wdChannels, cancellationToken).ConfigureAwait(false);
 		}

--- a/src/Tgstation.Server.Host/Components/Chat/IChatManager.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/IChatManager.cs
@@ -56,10 +56,9 @@ namespace Tgstation.Server.Host.Components.Chat
 		/// Send a chat <paramref name="message"/> to configured watchdog channels
 		/// </summary>
 		/// <param name="message">The message being sent</param>
-		/// <param name="adminOnly">If the message should be sent to admin channels only. If no admin-only channels are configured, it will be sent to the watchdog channels.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="Task"/> representing the running operation</returns>
-		Task SendWatchdogMessage(string message, bool adminOnly, CancellationToken cancellationToken);
+		Task SendWatchdogMessage(string message, CancellationToken cancellationToken);
 
 		/// <summary>
 		/// Send the message for a deployment to configured deployment channels.

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/IProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/IProvider.cs
@@ -27,6 +27,11 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		string BotMention { get; }
 
 		/// <summary>
+		/// A <see cref="Task"/> that completes once the <see cref="IProvider"/> finishes it's first connection attempt regardless of success.
+		/// </summary>
+		Task InitialConnectionJob { get; }
+
+		/// <summary>
 		/// Get a <see cref="Task{TResult}"/> resulting in the next <see cref="Message"/> the <see cref="IProvider"/> recieves or <see langword="null"/> on a disconnect
 		/// </summary>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>

--- a/src/Tgstation.Server.Host/Components/Instance.cs
+++ b/src/Tgstation.Server.Host/Components/Instance.cs
@@ -304,17 +304,27 @@ namespace Tgstation.Server.Host.Components
 											cancellationToken)
 										.ConfigureAwait(false);
 
-										var lastRevInfoWasOriginCommit = currentRevInfo == default || currentRevInfo.CommitSha == currentRevInfo.OriginCommitSha;
-										var stillOnOrigin = result.Value && lastRevInfoWasOriginCommit;
-
-										var currentHead = repo.Head;
-										if (currentHead != startSha)
+										if (updatedTestMerges.Count == 0)
 										{
-											await UpdateRevInfo(currentHead, stillOnOrigin, updatedTestMerges).ConfigureAwait(false);
-											shouldSyncTracked = stillOnOrigin;
+											logger.LogTrace("All test merges have been merged on remote");
+											preserveTestMerges = false;
 										}
 										else
-											shouldSyncTracked = false;
+										{
+											var lastRevInfoWasOriginCommit =
+												currentRevInfo == default
+												|| currentRevInfo.CommitSha == currentRevInfo.OriginCommitSha;
+											var stillOnOrigin = result.Value && lastRevInfoWasOriginCommit;
+
+											var currentHead = repo.Head;
+											if (currentHead != startSha)
+											{
+												await UpdateRevInfo(currentHead, stillOnOrigin, updatedTestMerges).ConfigureAwait(false);
+												shouldSyncTracked = stillOnOrigin;
+											}
+											else
+												shouldSyncTracked = false;
+										}
 									}
 
 									if (!preserveTestMerges)

--- a/src/Tgstation.Server.Host/Components/Instance.cs
+++ b/src/Tgstation.Server.Host/Components/Instance.cs
@@ -16,6 +16,7 @@ using Tgstation.Server.Host.Components.Repository;
 using Tgstation.Server.Host.Components.Watchdog;
 using Tgstation.Server.Host.Configuration;
 using Tgstation.Server.Host.Core;
+using Tgstation.Server.Host.Database;
 using Tgstation.Server.Host.Extensions;
 using Tgstation.Server.Host.Jobs;
 using Tgstation.Server.Host.Models;
@@ -162,13 +163,209 @@ namespace Tgstation.Server.Host.Components
 			}
 		}
 
+		Task RepositoryAutoUpdateJob(
+			IInstanceCore core,
+			IDatabaseContextFactory databaseContextFactory,
+			Job job,
+			Action<int> progressReporter,
+			CancellationToken cancellationToken)
+			=> databaseContextFactory.UseContext(
+				async databaseContext =>
+		{
+			if (core != this)
+				throw new InvalidOperationException(DifferentCoreExceptionMessage);
+
+			// assume 5 steps with synchronize
+			const int ProgressSections = 7;
+			const int ProgressStep = 100 / ProgressSections;
+
+			var repositorySettingsTask = databaseContext
+				.RepositorySettings
+				.AsQueryable()
+				.Where(x => x.InstanceId == metadata.Id)
+				.FirstAsync(cancellationToken);
+
+			const int NumSteps = 3;
+			var doneSteps = 0;
+
+			Action<int> NextProgressReporter()
+			{
+				var tmpDoneSteps = doneSteps;
+				++doneSteps;
+				return progress => progressReporter((progress + (100 * tmpDoneSteps)) / NumSteps);
+			}
+
+			using var repo = await RepositoryManager.LoadRepository(cancellationToken).ConfigureAwait(false);
+			if (repo == null)
+			{
+				logger.LogTrace("Aborting repo update, no repository!");
+				return;
+			}
+
+			var startSha = repo.Head;
+			if (!repo.Tracking)
+			{
+				logger.LogTrace("Aborting repo update, active ref not tracking any remote branch!");
+				return;
+			}
+
+			var repositorySettings = await repositorySettingsTask.ConfigureAwait(false);
+
+			// the main point of auto update is to pull the remote
+			await repo.FetchOrigin(
+				repositorySettings.AccessUser,
+				repositorySettings.AccessToken,
+				NextProgressReporter(),
+				cancellationToken)
+				.ConfigureAwait(false);
+
+			RevisionInformation currentRevInfo = null;
+
+			Task<RevisionInformation> LoadRevInfo() => databaseContext.RevisionInformations
+					.AsQueryable()
+					.Where(x => x.CommitSha == startSha && x.Instance.Id == metadata.Id)
+					.Include(x => x.ActiveTestMerges).ThenInclude(x => x.TestMerge)
+					.FirstOrDefaultAsync(cancellationToken);
+
+			var hasDbChanges = false;
+
+			// take appropriate auto update actions
+			var shouldSyncTracked = false;
+			var currentRevInfoTask = LoadRevInfo();
+
+			var result = await repo.MergeOrigin(
+				repositorySettings.CommitterName,
+				repositorySettings.CommitterEmail,
+				NextProgressReporter(),
+				cancellationToken)
+				.ConfigureAwait(false);
+
+			async Task UpdateRevInfo(string currentHead, bool onOrigin, IEnumerable<RevInfoTestMerge> updatedTestMerges)
+			{
+				if (currentRevInfo == null)
+					currentRevInfo = await LoadRevInfo().ConfigureAwait(false);
+
+				if (currentRevInfo == default)
+				{
+					logger.LogInformation(Repository.Repository.OriginTrackingErrorTemplate, currentHead);
+					onOrigin = true;
+				}
+
+				var attachedInstance = new Models.Instance
+				{
+					Id = metadata.Id
+				};
+				var oldRevInfo = currentRevInfo;
+				currentRevInfo = new RevisionInformation
+				{
+					CommitSha = currentHead,
+					OriginCommitSha = onOrigin
+						? currentHead
+						: await repo.GetOriginSha(cancellationToken).ConfigureAwait(false),
+					Instance = attachedInstance
+				};
+				if (!onOrigin)
+					currentRevInfo.ActiveTestMerges = new List<RevInfoTestMerge>(
+						updatedTestMerges ?? oldRevInfo.ActiveTestMerges);
+
+				databaseContext.Instances.Attach(attachedInstance);
+				databaseContext.RevisionInformations.Add(currentRevInfo);
+				hasDbChanges = true;
+			}
+
+			var preserveTestMerges = repositorySettings.AutoUpdatesKeepTestMerges.Value;
+
+			if (result.HasValue)
+			{
+				currentRevInfo = await currentRevInfoTask.ConfigureAwait(false);
+
+				var updatedTestMerges = await RemoveMergedPullRequests(
+					repo,
+					repositorySettings,
+					currentRevInfo,
+					cancellationToken)
+				.ConfigureAwait(false);
+
+				if (updatedTestMerges.Count == 0)
+				{
+					logger.LogTrace("All test merges have been merged on remote");
+					preserveTestMerges = false;
+				}
+				else
+				{
+					var lastRevInfoWasOriginCommit =
+						currentRevInfo == default
+						|| currentRevInfo.CommitSha == currentRevInfo.OriginCommitSha;
+					var stillOnOrigin = result.Value && lastRevInfoWasOriginCommit;
+
+					var currentHead = repo.Head;
+					if (currentHead != startSha)
+					{
+						await UpdateRevInfo(currentHead, stillOnOrigin, updatedTestMerges).ConfigureAwait(false);
+						shouldSyncTracked = stillOnOrigin;
+					}
+				}
+			}
+			else if (preserveTestMerges)
+				throw new JobException(Api.Models.ErrorCode.InstanceUpdateTestMergeConflict);
+
+			if (!preserveTestMerges)
+			{
+				logger.LogTrace("Resetting to origin...");
+				await repo.ResetToOrigin(NextProgressReporter(), cancellationToken).ConfigureAwait(false);
+
+				var currentHead = repo.Head;
+
+				currentRevInfo = await databaseContext.RevisionInformations
+					.AsQueryable()
+					.Where(x => x.CommitSha == currentHead && x.Instance.Id == metadata.Id)
+					.FirstOrDefaultAsync(cancellationToken)
+					.ConfigureAwait(false);
+
+				if (currentHead != startSha && currentRevInfo == default)
+					await UpdateRevInfo(currentHead, true, null).ConfigureAwait(false);
+
+				shouldSyncTracked = true;
+			}
+
+			// synch if necessary
+			if (repositorySettings.AutoUpdatesSynchronize.Value && startSha != repo.Head)
+			{
+				var pushedOrigin = await repo.Sychronize(
+					repositorySettings.AccessUser,
+					repositorySettings.AccessToken,
+					repositorySettings.CommitterName,
+					repositorySettings.CommitterEmail,
+					NextProgressReporter(),
+					shouldSyncTracked,
+					cancellationToken).ConfigureAwait(false);
+				var currentHead = repo.Head;
+				if (currentHead != currentRevInfo.CommitSha)
+					await UpdateRevInfo(currentHead, pushedOrigin, null).ConfigureAwait(false);
+			}
+
+			if (hasDbChanges)
+				try
+				{
+					await databaseContext.Save(cancellationToken).ConfigureAwait(false);
+				}
+				catch
+				{
+					// DCT: Cancellation token is for job, operation must run regardless
+					await repo.ResetToSha(startSha, progressReporter, default).ConfigureAwait(false);
+					throw;
+				}
+
+			progressReporter(5 * ProgressStep);
+		});
+
 		/// <summary>
 		/// Pull the repository and compile for every set of given <paramref name="minutes"/>
 		/// </summary>
 		/// <param name="minutes">How many minutes the operation should repeat. Does not include running time</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="Task"/> representing the running operation</returns>
-		#pragma warning disable CA1502 // TODO: Decomplexify
+#pragma warning disable CA1502 // TODO: Decomplexify
 		async Task TimerLoop(uint minutes, CancellationToken cancellationToken)
 		{
 			logger.LogDebug("Entering auto-update loop");
@@ -191,236 +388,59 @@ namespace Tgstation.Server.Host.Components
 							CancelRight = (ulong)RepositoryRights.CancelPendingChanges
 						};
 
-						string deploySha = null;
-						await jobManager.RegisterOperation(repositoryUpdateJob, async (core, databaseContextFactory, paramJob, progressReporter, jobCancellationToken) =>
-						{
-							if (core != this)
-								throw new InvalidOperationException(DifferentCoreExceptionMessage);
-
-							// assume 5 steps with synchronize
-							const int ProgressSections = 7;
-							const int ProgressStep = 100 / ProgressSections;
-							string repoHead = null;
-
-							await databaseContextFactory.UseContext(
-								async databaseContext =>
-								{
-									var repositorySettingsTask = databaseContext
-										.RepositorySettings
-										.AsQueryable()
-										.Where(x => x.InstanceId == metadata.Id)
-										.FirstAsync(jobCancellationToken);
-
-									const int NumSteps = 3;
-									var doneSteps = 0;
-
-									Action<int> NextProgressReporter()
-									{
-										var tmpDoneSteps = doneSteps;
-										++doneSteps;
-										return progress => progressReporter((progress + (100 * tmpDoneSteps)) / NumSteps);
-									}
-
-									using var repo = await RepositoryManager.LoadRepository(jobCancellationToken).ConfigureAwait(false);
-									if (repo == null)
-									{
-										logger.LogTrace("Aborting repo update, no repository!");
-										return;
-									}
-
-									var startSha = repo.Head;
-									if (!repo.Tracking)
-									{
-										logger.LogTrace("Aborting repo update, active ref not tracking any remote branch!");
-										deploySha = startSha;
-										return;
-									}
-
-									var repositorySettings = await repositorySettingsTask.ConfigureAwait(false);
-
-									// the main point of auto update is to pull the remote
-									await repo.FetchOrigin(repositorySettings.AccessUser, repositorySettings.AccessToken, NextProgressReporter(), jobCancellationToken).ConfigureAwait(false);
-
-									RevisionInformation currentRevInfo = null;
-									bool hasDbChanges = false;
-
-									Task<RevisionInformation> LoadRevInfo() => databaseContext.RevisionInformations
-											.AsQueryable()
-											.Where(x => x.CommitSha == startSha && x.Instance.Id == metadata.Id)
-											.Include(x => x.ActiveTestMerges).ThenInclude(x => x.TestMerge)
-											.FirstOrDefaultAsync(jobCancellationToken);
-
-									async Task UpdateRevInfo(string currentHead, bool onOrigin, IEnumerable<RevInfoTestMerge> updatedTestMerges)
-									{
-										if (currentRevInfo == null)
-											currentRevInfo = await LoadRevInfo().ConfigureAwait(false);
-
-										if (currentRevInfo == default)
-										{
-											logger.LogInformation(Repository.Repository.OriginTrackingErrorTemplate, currentHead);
-											onOrigin = true;
-										}
-
-										var attachedInstance = new Models.Instance
-										{
-											Id = metadata.Id
-										};
-										var oldRevInfo = currentRevInfo;
-										currentRevInfo = new RevisionInformation
-										{
-											CommitSha = currentHead,
-											OriginCommitSha = onOrigin ? currentHead : oldRevInfo.OriginCommitSha,
-											Instance = attachedInstance
-										};
-										if (!onOrigin)
-											currentRevInfo.ActiveTestMerges = new List<RevInfoTestMerge>(
-												updatedTestMerges ?? oldRevInfo.ActiveTestMerges);
-
-										databaseContext.Instances.Attach(attachedInstance);
-										databaseContext.RevisionInformations.Add(currentRevInfo);
-										hasDbChanges = true;
-									}
-
-									// take appropriate auto update actions
-									bool shouldSyncTracked = false;
-									bool preserveTestMerges = repositorySettings.AutoUpdatesKeepTestMerges.Value;
-									if (preserveTestMerges)
-									{
-										logger.LogTrace("Preserving test merges...");
-
-										var currentRevInfoTask = LoadRevInfo();
-
-										var result = await repo.MergeOrigin(repositorySettings.CommitterName, repositorySettings.CommitterEmail, NextProgressReporter(), jobCancellationToken).ConfigureAwait(false);
-
-										if (!result.HasValue)
-											throw new JobException(Api.Models.ErrorCode.InstanceUpdateTestMergeConflict);
-
-										currentRevInfo = await currentRevInfoTask.ConfigureAwait(false);
-
-										var updatedTestMerges = await RemoveMergedPullRequests(
-											repo,
-											repositorySettings,
-											currentRevInfo,
-											cancellationToken)
-										.ConfigureAwait(false);
-
-										if (updatedTestMerges.Count == 0)
-										{
-											logger.LogTrace("All test merges have been merged on remote");
-											preserveTestMerges = false;
-										}
-										else
-										{
-											var lastRevInfoWasOriginCommit =
-												currentRevInfo == default
-												|| currentRevInfo.CommitSha == currentRevInfo.OriginCommitSha;
-											var stillOnOrigin = result.Value && lastRevInfoWasOriginCommit;
-
-											var currentHead = repo.Head;
-											if (currentHead != startSha)
-											{
-												await UpdateRevInfo(currentHead, stillOnOrigin, updatedTestMerges).ConfigureAwait(false);
-												shouldSyncTracked = stillOnOrigin;
-											}
-											else
-												shouldSyncTracked = false;
-										}
-									}
-
-									if (!preserveTestMerges)
-									{
-										logger.LogTrace("Resetting to origin...");
-										await repo.ResetToOrigin(NextProgressReporter(), jobCancellationToken).ConfigureAwait(false);
-
-										var currentHead = repo.Head;
-
-										currentRevInfo = await databaseContext.RevisionInformations
-											.AsQueryable()
-											.Where(x => x.CommitSha == currentHead && x.Instance.Id == metadata.Id)
-											.FirstOrDefaultAsync(jobCancellationToken)
-											.ConfigureAwait(false);
-
-										if (currentHead != startSha && currentRevInfo == default)
-											await UpdateRevInfo(currentHead, true, null).ConfigureAwait(false);
-
-										shouldSyncTracked = true;
-									}
-
-									// synch if necessary
-									if (repositorySettings.AutoUpdatesSynchronize.Value && startSha != repo.Head)
-									{
-										var pushedOrigin = await repo.Sychronize(repositorySettings.AccessUser, repositorySettings.AccessToken, repositorySettings.CommitterName, repositorySettings.CommitterEmail, NextProgressReporter(), shouldSyncTracked, jobCancellationToken).ConfigureAwait(false);
-										var currentHead = repo.Head;
-										if (currentHead != currentRevInfo.CommitSha)
-											await UpdateRevInfo(currentHead, pushedOrigin, null).ConfigureAwait(false);
-									}
-
-									repoHead = repo.Head;
-
-									if (hasDbChanges)
-										try
-										{
-											await databaseContext.Save(jobCancellationToken).ConfigureAwait(false);
-										}
-										catch
-										{
-											// DCT: Cancellation token is for job, operation must run regardless
-											await repo.ResetToSha(startSha, progressReporter, default).ConfigureAwait(false);
-											throw;
-										}
-								})
+						await jobManager.RegisterOperation(
+							repositoryUpdateJob,
+							RepositoryAutoUpdateJob,
+							cancellationToken)
 							.ConfigureAwait(false);
-
-							progressReporter(5 * ProgressStep);
-							deploySha = repoHead;
-						}, cancellationToken).ConfigureAwait(false);
 
 						// DCT: First token will cancel the job, second is for cancelling the cancellation, unwanted
 						await jobManager.WaitForJobCompletion(repositoryUpdateJob, null, cancellationToken, default).ConfigureAwait(false);
 
-						if (deploySha == null)
+						Job compileProcessJob;
+						using (var repo = await RepositoryManager.LoadRepository(cancellationToken).ConfigureAwait(false))
 						{
-							logger.LogTrace("Aborting auto update, repository error!");
-							continue;
-						}
-
-						if(deploySha == LatestCompileJob()?.RevisionInformation.CommitSha)
-						{
-							logger.LogTrace("Aborting auto update, same revision as latest CompileJob");
-							continue;
-						}
-
-						// finally set up the job
-						var compileProcessJob = new Job
-						{
-							Instance = repositoryUpdateJob.Instance,
-							Description = "Scheduled code deployment",
-							CancelRightsType = RightsType.DreamMaker,
-							CancelRight = (ulong)DreamMakerRights.CancelCompile
-						};
-
-						await jobManager.RegisterOperation(
-							compileProcessJob,
-							(core, databaseContextFactory, job, progressReporter, jobCancellationToken) =>
+							var deploySha = repo.Head;
+							if (deploySha == null)
 							{
-								if (core != this)
-									throw new InvalidOperationException(DifferentCoreExceptionMessage);
-								return DreamMaker.DeploymentProcess(
-									job,
-									databaseContextFactory,
-									progressReporter,
-									jobCancellationToken);
-							},
-							cancellationToken).ConfigureAwait(false);
+								logger.LogTrace("Aborting auto update, repository error!");
+								continue;
+							}
+
+							if (deploySha == LatestCompileJob()?.RevisionInformation.CommitSha)
+							{
+								logger.LogTrace("Aborting auto update, same revision as latest CompileJob");
+								continue;
+							}
+
+							// finally set up the job
+							compileProcessJob = new Job
+							{
+								Instance = repositoryUpdateJob.Instance,
+								Description = "Scheduled code deployment",
+								CancelRightsType = RightsType.DreamMaker,
+								CancelRight = (ulong)DreamMakerRights.CancelCompile
+							};
+
+							await jobManager.RegisterOperation(
+								compileProcessJob,
+								(core, databaseContextFactory, job, progressReporter, jobCancellationToken) =>
+								{
+									if (core != this)
+										throw new InvalidOperationException(DifferentCoreExceptionMessage);
+									return DreamMaker.DeploymentProcess(
+										job,
+										databaseContextFactory,
+										progressReporter,
+										jobCancellationToken);
+								},
+								cancellationToken)
+								.ConfigureAwait(false);
+						}
 
 						await jobManager.WaitForJobCompletion(compileProcessJob, null, default, cancellationToken).ConfigureAwait(false);
 					}
-					catch (OperationCanceledException)
-					{
-						logger.LogDebug("Cancelled auto update job!");
-						throw;
-					}
-					catch (Exception e)
+					catch (Exception e) when (!(e is OperationCanceledException))
 					{
 						logger.LogWarning(e, "Error in auto update loop!");
 						continue;
@@ -428,6 +448,7 @@ namespace Tgstation.Server.Host.Components
 				}
 				catch (OperationCanceledException)
 				{
+					logger.LogDebug("Cancelled auto update loop!");
 					break;
 				}
 
@@ -478,6 +499,7 @@ namespace Tgstation.Server.Host.Components
 
 			var newList = revisionInformation.ActiveTestMerges.ToList();
 
+			PullRequest lastMerged = null;
 			async Task CheckRemovePR(Task<PullRequest> task)
 			{
 				var pr = await task.ConfigureAwait(false);
@@ -486,9 +508,13 @@ namespace Tgstation.Server.Host.Components
 
 				// We don't just assume, actually check the repo contains the merge commit.
 				if (await repository.ShaIsParent(pr.MergeCommitSha, cancellationToken).ConfigureAwait(false))
+				{
+					if (lastMerged == null || lastMerged.MergedAt < pr.MergedAt)
+						lastMerged = pr;
 					newList.Remove(
 						newList.First(
 							potential => potential.TestMerge.Number == pr.Number));
+				}
 			}
 
 			foreach (var prTask in tasks)

--- a/src/Tgstation.Server.Host/Components/Interop/Topic/EventNotification.cs
+++ b/src/Tgstation.Server.Host/Components/Interop/Topic/EventNotification.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using Tgstation.Server.Host.Components.Events;
 
@@ -12,7 +12,8 @@ namespace Tgstation.Server.Host.Components.Interop.Topic
 		/// <summary>
 		/// The <see cref="EventType"/> triggered.
 		/// </summary>
-		public EventType Type { get; }
+		/// <remarks>Nullable to prevent ignoring when serializing.</remarks>
+		public EventType? Type { get; }
 
 		/// <summary>
 		/// The set of parameters.

--- a/src/Tgstation.Server.Host/Components/Repository/IRepository.cs
+++ b/src/Tgstation.Server.Host/Components/Repository/IRepository.cs
@@ -141,5 +141,12 @@ namespace Tgstation.Server.Host.Components.Repository
 		/// <returns>A <see cref="Task{TResult}"/> resulting in <see langword="true"/> if <paramref name="sha"/> is a parent of <see cref="Head"/>, <see langword="false"/> otherwise.</returns>
 		/// <remarks>This function is NOT reentrant.</remarks>
 		Task<bool> ShaIsParent(string sha, CancellationToken cancellationToken);
+
+		/// <summary>
+		/// Get the tracked reference's current SHA.
+		/// </summary>
+		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
+		/// <returns>A <see cref="Task{TResult}"/> resulting in the tracked origin reference's SHA.</returns>
+		Task<string> GetOriginSha(CancellationToken cancellationToken);
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Session/SessionController.cs
+++ b/src/Tgstation.Server.Host/Components/Session/SessionController.cs
@@ -458,7 +458,14 @@ namespace Tgstation.Server.Host.Components.Session
 								};
 						}
 
-						response.RuntimeInformation = reattachInformation.RuntimeInformation;
+						response.RuntimeInformation = new RuntimeInformation(
+							chatTrackingContext,
+							reattachInformation.Dmb,
+							reattachInformation.RuntimeInformation.ServerVersion,
+							reattachInformation.RuntimeInformation.InstanceName,
+							reattachInformation.RuntimeInformation.SecurityLevel,
+							reattachInformation.RuntimeInformation.ServerPort,
+							reattachInformation.RuntimeInformation.ApiValidateOnly);
 
 						// Load custom commands
 						chatTrackingContext.CustomCommands = parameters.CustomCommands;
@@ -671,7 +678,10 @@ namespace Tgstation.Server.Host.Components.Session
 
 		/// <inheritdoc />
 		public Task InstanceRenamed(string newInstanceName, CancellationToken cancellationToken)
-			=> SendCommand(new TopicParameters(newInstanceName), cancellationToken);
+		{
+			reattachInformation.RuntimeInformation.InstanceName = newInstanceName;
+			return SendCommand(new TopicParameters(newInstanceName), cancellationToken);
+		}
 
 		/// <inheritdoc />
 		public Task UpdateChannels(IEnumerable<ChannelRepresentation> newChannels, CancellationToken cancellationToken)

--- a/src/Tgstation.Server.Host/Components/Session/SessionController.cs
+++ b/src/Tgstation.Server.Host/Components/Session/SessionController.cs
@@ -304,7 +304,7 @@ namespace Tgstation.Server.Host.Components.Session
 			var startupTask = !reattached && (apiValidate || DMApiAvailable)
 				? initialBridgeRequestTcs.Task
 				: process.Startup;
-			var toAwait = startupTask;
+			var toAwait = Task.WhenAny(startupTask, process.Lifetime);
 
 			if (startupTimeout.HasValue)
 				toAwait = Task.WhenAny(toAwait, Task.Delay(startTime.AddSeconds(startupTimeout.Value) - startTime));

--- a/src/Tgstation.Server.Host/Components/Session/SessionControllerFactory.cs
+++ b/src/Tgstation.Server.Host/Components/Session/SessionControllerFactory.cs
@@ -1,7 +1,6 @@
 using Microsoft.Extensions.Logging;
 using System;
 using System.Globalization;
-using System.Linq;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading;
@@ -457,31 +456,14 @@ namespace Tgstation.Server.Host.Components.Session
 			IChatTrackingContext chatTrackingContext,
 			DreamDaemonSecurity? securityLevel,
 			bool apiValidateOnly)
-		{
-			var revisionInfo = new Api.Models.Internal.RevisionInformation
-			{
-				CommitSha = dmbProvider.CompileJob.RevisionInformation.CommitSha,
-				OriginCommitSha = dmbProvider.CompileJob.RevisionInformation.OriginCommitSha
-			};
-
-			var testMerges = dmbProvider
-				.CompileJob
-				.RevisionInformation
-				.ActiveTestMerges?
-				.Select(x => x.TestMerge)
-				.Select(x => new TestMergeInformation(x, revisionInfo))
-				?? Enumerable.Empty<TestMergeInformation>();
-
-			return new RuntimeInformation(
-				assemblyInformationProvider,
-				serverPortProvider,
-				testMerges,
-				chatTrackingContext.Channels,
-				instance,
-				revisionInfo,
+			=> new RuntimeInformation(
+				chatTrackingContext,
+				dmbProvider,
+				assemblyInformationProvider.Version,
+				instance.Name,
 				securityLevel,
+				serverPortProvider.HttpApiPort,
 				apiValidateOnly);
-		}
 
 		/// <summary>
 		/// Make sure the BYOND pager is not running.

--- a/src/Tgstation.Server.Host/Components/Watchdog/BasicWatchdog.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/BasicWatchdog.cs
@@ -96,7 +96,6 @@ namespace Tgstation.Server.Host.Components.Watchdog
 								CultureInfo.InvariantCulture,
 								"Server {0}! Shutting down due to graceful termination request...",
 								exitWord),
-							false,
 							cancellationToken)
 							.ConfigureAwait(false);
 						return MonitorAction.Exit;
@@ -107,7 +106,6 @@ namespace Tgstation.Server.Host.Components.Watchdog
 							CultureInfo.InvariantCulture,
 							"Server {0}! Rebooting...",
 							exitWord),
-						false,
 						cancellationToken)
 						.ConfigureAwait(false);
 					return MonitorAction.Restart;
@@ -132,7 +130,6 @@ namespace Tgstation.Server.Host.Components.Watchdog
 							// graceful shutdown time
 							await Chat.SendWatchdogMessage(
 								"Active server rebooted! Shutting down due to graceful termination request...",
-								false,
 								cancellationToken)
 								.ConfigureAwait(false);
 							return MonitorAction.Exit;
@@ -257,7 +254,6 @@ namespace Tgstation.Server.Host.Components.Watchdog
 			if (Server.CompileJob.DMApiVersion == null)
 				return Chat.SendWatchdogMessage(
 					"A new deployment has been made but cannot be applied automatically as the currently running server has no DMAPI. Please manually reboot the server to apply the update.",
-					true,
 					cancellationToken);
 			return Server.SetRebootState(Session.RebootState.Restart, cancellationToken);
 		}

--- a/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
@@ -897,7 +897,8 @@ namespace Tgstation.Server.Host.Components.Watchdog
 				job,
 				async (core, databaseContextFactory, paramJob, progressFunction, ct) =>
 				{
-					// core will certainly be null here since jobs started before the instance is onlined can't provide one
+					if (core.Watchdog != this)
+						throw new InvalidOperationException(Instance.DifferentCoreExceptionMessage);
 					using (await SemaphoreSlimContext.Lock(synchronizationSemaphore, ct).ConfigureAwait(false))
 						await LaunchNoLock(true, true, true, reattachInfo, ct).ConfigureAwait(false);
 				},

--- a/src/Tgstation.Server.Host/Controllers/AdministrationController.cs
+++ b/src/Tgstation.Server.Host/Controllers/AdministrationController.cs
@@ -348,7 +348,10 @@ namespace Tgstation.Server.Host.Controllers
 
 				await Task.WhenAll(tasks).ConfigureAwait(false);
 
-				var result = tasks.Select(x => x.Result).ToList();
+				var result = tasks
+					.Select(x => x.Result)
+					.OrderByDescending(x => x.Name)
+					.ToList();
 
 				return Ok(result);
 			}

--- a/src/Tgstation.Server.Host/Controllers/InstanceRequiredController.cs
+++ b/src/Tgstation.Server.Host/Controllers/InstanceRequiredController.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Serilog.Context;
 using System;
@@ -101,6 +101,7 @@ namespace Tgstation.Server.Host.Controllers
 
 			logger.LogWarning(
 				"Instance {0} is says it's {1} in the database, but it is actually {2} in the service. Updating the database to reflect this...",
+				metadata.Id,
 				online ? OfflineWord : OnlineWord,
 				online ? OnlineWord : OfflineWord);
 

--- a/src/Tgstation.Server.Host/Controllers/RepositoryController.cs
+++ b/src/Tgstation.Server.Host/Controllers/RepositoryController.cs
@@ -601,10 +601,10 @@ namespace Tgstation.Server.Host.Controllers
 							var fastForward = await repo.MergeOrigin(committerName, currentModel.CommitterEmail, NextProgressReporter(), ct).ConfigureAwait(false);
 							if (!fastForward.HasValue)
 								throw new JobException(ErrorCode.RepoMergeConflict);
+							lastRevisionInfo.OriginCommitSha = await repo.GetOriginSha(cancellationToken).ConfigureAwait(false);
 							await UpdateRevInfo().ConfigureAwait(false);
 							if (fastForward.Value)
 							{
-								lastRevisionInfo.OriginCommitSha = repo.Head;
 								await repo.Sychronize(currentModel.AccessUser, currentModel.AccessToken, currentModel.CommitterName, currentModel.CommitterEmail, NextProgressReporter(), true, ct).ConfigureAwait(false);
 								postUpdateSha = repo.Head;
 							}

--- a/src/Tgstation.Server.Host/Core/Application.cs
+++ b/src/Tgstation.Server.Host/Core/Application.cs
@@ -137,7 +137,7 @@ namespace Tgstation.Server.Host.Core
 					var formatter = new MessageTemplateTextFormatter(
 						"{Timestamp:o} "
 						+ ServiceCollectionExtensions.SerilogContextTemplate
-						+ "|IR:{InstanceReference}){): [{Level:u3}] {SourceContext:l}: {Message} ({EventId:x8}){NewLine}{Exception}",
+						+ "|IR:{InstanceReference}): [{Level:u3}] {SourceContext:l}: {Message} ({EventId:x8}){NewLine}{Exception}",
 						null);
 
 					logPath = IOManager.ConcatPath(logPath, "tgs-.log");

--- a/src/Tgstation.Server.Host/Core/Application.cs
+++ b/src/Tgstation.Server.Host/Core/Application.cs
@@ -137,7 +137,7 @@ namespace Tgstation.Server.Host.Core
 					var formatter = new MessageTemplateTextFormatter(
 						"{Timestamp:o} "
 						+ ServiceCollectionExtensions.SerilogContextTemplate
-						+ "|IR:{InstanceReference}): [{Level:u3}] {SourceContext:l}: {Message} ({EventId:x8}){NewLine}{Exception}",
+						+ "): [{Level:u3}] {SourceContext:l}: {Message} ({EventId:x8}){NewLine}{Exception}",
 						null);
 
 					logPath = IOManager.ConcatPath(logPath, "tgs-.log");

--- a/tests/Tgstation.Server.Tests/Instance/WatchdogTest.cs
+++ b/tests/Tgstation.Server.Tests/Instance/WatchdogTest.cs
@@ -518,7 +518,10 @@ namespace Tgstation.Server.Tests.Instance
 
 			await WaitForJob(compileJobJob, 90, false, null, cancellationToken);
 
-			return await instanceClient.DreamDaemon.Read(cancellationToken);
+			var ddInfo = await instanceClient.DreamDaemon.Read(cancellationToken);
+			if (requireApi)
+				Assert.IsNotNull((ddInfo.StagedCompileJob ?? ddInfo.ActiveCompileJob).DMApiVersion);
+			return ddInfo;
 		}
 
 		async Task GracefulWatchdogShutdown(uint timeout, CancellationToken cancellationToken)

--- a/tests/Tgstation.Server.Tests/IntegrationTest.cs
+++ b/tests/Tgstation.Server.Tests/IntegrationTest.cs
@@ -311,7 +311,7 @@ namespace Tgstation.Server.Tests
 					foreach (var job in jobs)
 					{
 						Assert.IsTrue(job.StartedAt.Value >= preStartupTime);
-						await jrt.WaitForJob(job, 40, false, null, cancellationToken);
+						await jrt.WaitForJob(job, 120, false, null, cancellationToken);
 					}
 
 					var dd = await instanceClient.DreamDaemon.Read(cancellationToken);
@@ -354,7 +354,7 @@ namespace Tgstation.Server.Tests
 					foreach (var job in jobs)
 					{
 						Assert.IsTrue(job.StartedAt.Value >= preStartupTime);
-						await jrt.WaitForJob(job, 40, false, null, cancellationToken);
+						await jrt.WaitForJob(job, 120, false, null, cancellationToken);
 					}
 
 					var dd = await instanceClient.DreamDaemon.Read(cancellationToken);

--- a/tests/Tgstation.Server.Tests/TestingServer.cs
+++ b/tests/Tgstation.Server.Tests/TestingServer.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -79,6 +79,7 @@ namespace Tgstation.Server.Tests
 				String.Format(CultureInfo.InvariantCulture, "General:InstanceLimit={0}", 11),
 				String.Format(CultureInfo.InvariantCulture, "General:UserLimit={0}", 150),
 				String.Format(CultureInfo.InvariantCulture, "FileLogging:Directory={0}", Path.Combine(Directory, "Logs")),
+				String.Format(CultureInfo.InvariantCulture, "FileLogging:LogLevel={0}", "Trace"),
 				String.Format(CultureInfo.InvariantCulture, "General:ValidInstancePaths:0={0}", Directory),
 				"General:ByondTopicTimeout=3000"
 			};


### PR DESCRIPTION
:cl:
Fixed requests failing if instance online state did not match with the database.
Fixed sending invalid revision information over the initial bridge.
Fixed a rare watchdog issue that came from incorrectly measuring the time it took for DreamDaemon to become responsive.
If all test merges have been merged on remote at the time of an auto-update, a hard reset will be performed. Previously, a custom merge commit would be created.
Improved tracking of most recent origin commit when performing local merges.
Fixed EventNotification type 0 not being serialized over topic requests.
/:cl:

:cl: HTTP API
Entries returned from GET /Administration/Logs are now returned from newest to oldest.
/:cl:

Fixes #1094
Fixes #1090 