### PR TITLE
v4.4.4

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- This is the authorative version list -->
     <!-- Integration tests will ensure they match across the board -->
-    <TgsCoreVersion>4.4.3</TgsCoreVersion>
+    <TgsCoreVersion>4.4.4</TgsCoreVersion>
     <TgsConfigVersion>2.0.0</TgsConfigVersion>
     <TgsApiVersion>7.2.0</TgsApiVersion>
     <TgsClientVersion>8.2.0</TgsClientVersion>

--- a/build/Version.props
+++ b/build/Version.props
@@ -4,8 +4,8 @@
     <!-- Integration tests will ensure they match across the board -->
     <TgsCoreVersion>4.4.3</TgsCoreVersion>
     <TgsConfigVersion>2.0.0</TgsConfigVersion>
-    <TgsApiVersion>7.1.0</TgsApiVersion>
-    <TgsClientVersion>8.1.0</TgsClientVersion>
+    <TgsApiVersion>7.2.0</TgsApiVersion>
+    <TgsClientVersion>8.2.0</TgsClientVersion>
     <TgsDmapiVersion>5.2.3</TgsDmapiVersion>
     <TgsControlPanelVersion>0.4.0</TgsControlPanelVersion>
     <TgsHostWatchdogVersion>1.1.0</TgsHostWatchdogVersion>

--- a/src/Tgstation.Server.Api/Models/ErrorCode.cs
+++ b/src/Tgstation.Server.Api/Models/ErrorCode.cs
@@ -563,6 +563,12 @@ namespace Tgstation.Server.Api.Models
 		/// An attempt to connect a chat bot failed.
 		/// </summary>
 		[Description("Failed to connect chat bot!")]
-		ChatCannotConnectProvider
+		ChatCannotConnectProvider,
+
+		/// <summary>
+		/// Attempt to add DreamDaemon to the list of firewall exempt processes failed.
+		/// </summary>
+		[Description("Failed to allow DreamDaemon through the Windows firewall!")]
+		ByondDreamDaemonFirewallFail,
 	}
 }

--- a/src/Tgstation.Server.Host/Controllers/ConfigurationController.cs
+++ b/src/Tgstation.Server.Host/Controllers/ConfigurationController.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
@@ -290,6 +290,9 @@ namespace Tgstation.Server.Host.Controllers
 		{
 			if (directory == null)
 				throw new ArgumentNullException(nameof(directory));
+
+			if (directory.Path == null)
+				return BadRequest(new ErrorMessage(ErrorCode.ModelValidationFailure));
 
 			if (ForbidDueToModeConflicts(directory.Path, out var systemIdentity))
 				return Forbid();


### PR DESCRIPTION
:cl:
On Windows, DreamDaemon will be allowed through the firewall automatically. This will only happen for BYOND versions installed after this patch.
Fixed a 500 response that should have returned ErrorCode 2 in DELETE /Configuration.
/:cl:

:cl: HTTP API
Added ErrorCode 92 for when DreamDaemon cannot be let through the Windows firewall
/:cl:

Fixes #960