### PR TITLE
Small patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ TGS 4 can self update without stopping your DreamDaemon servers. Any V4 release 
 
 Here are tools for interacting with the TGS 4 web API
 
-- [tgstation-server-control-panel]: Official client and included with the server. A react web app for using tgstation-server.
+- [tgstation-server-control-panel]: Official client and included with the server (WIP). A react web app for using tgstation-server.
 - [Tgstation.Server.ControlPanel](https://github.com/tgstation/Tgstation.Server.ControlPanel): Official client. A cross platform GUI for using tgstation-server
 - [Tgstation.Server.Client](https://www.nuget.org/packages/Tgstation.Server.Client): A nuget .NET Standard 2.0 TAP based library for communicating with tgstation-server
 - [Tgstation.Server.Api](https://www.nuget.org/packages/Tgstation.Server.Api): A nuget .NET Standard 2.0 library containing API definitions for tgstation-server

--- a/build/Version.props
+++ b/build/Version.props
@@ -6,7 +6,7 @@
     <TgsConfigVersion>2.1.0</TgsConfigVersion>
     <TgsApiVersion>7.3.1</TgsApiVersion>
     <TgsClientVersion>8.3.1</TgsClientVersion>
-    <TgsDmapiVersion>5.2.4</TgsDmapiVersion>
+    <TgsDmapiVersion>5.2.5</TgsDmapiVersion>
     <TgsControlPanelVersion>0.4.0</TgsControlPanelVersion>
     <TgsHostWatchdogVersion>1.1.0</TgsHostWatchdogVersion>
   </PropertyGroup>

--- a/build/Version.props
+++ b/build/Version.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- This is the authorative version list -->
     <!-- Integration tests will ensure they match across the board -->
-    <TgsCoreVersion>4.5.0</TgsCoreVersion>
+    <TgsCoreVersion>4.5.1</TgsCoreVersion>
     <TgsConfigVersion>2.1.0</TgsConfigVersion>
     <TgsApiVersion>7.3.0</TgsApiVersion>
     <TgsClientVersion>8.3.0</TgsClientVersion>

--- a/build/Version.props
+++ b/build/Version.props
@@ -4,8 +4,8 @@
     <!-- Integration tests will ensure they match across the board -->
     <TgsCoreVersion>4.5.1</TgsCoreVersion>
     <TgsConfigVersion>2.1.0</TgsConfigVersion>
-    <TgsApiVersion>7.3.0</TgsApiVersion>
-    <TgsClientVersion>8.3.0</TgsClientVersion>
+    <TgsApiVersion>7.3.1</TgsApiVersion>
+    <TgsClientVersion>8.3.1</TgsClientVersion>
     <TgsDmapiVersion>5.2.4</TgsDmapiVersion>
     <TgsControlPanelVersion>0.4.0</TgsControlPanelVersion>
     <TgsHostWatchdogVersion>1.1.0</TgsHostWatchdogVersion>

--- a/src/DMAPI/tgs.dm
+++ b/src/DMAPI/tgs.dm
@@ -1,6 +1,6 @@
 // tgstation-server DMAPI
 
-#define TGS_DMAPI_VERSION "5.2.4"
+#define TGS_DMAPI_VERSION "5.2.5"
 
 // All functions and datums outside this document are subject to change with any version and should not be relied on.
 

--- a/src/DMAPI/tgs/v3210/api.dm
+++ b/src/DMAPI/tgs/v3210/api.dm
@@ -39,7 +39,7 @@
 	var/warned_custom_commands = FALSE
 
 /datum/tgs_api/v3210/ApiVersion()
-	return new /datum/tgs_version("3.2.1.0")
+	return new /datum/tgs_version("3.2.1.1")
 
 /datum/tgs_api/v3210/proc/trim_left(text)
 	for (var/i = 1 to length(text))

--- a/src/DMAPI/tgs/v3210/commands.dm
+++ b/src/DMAPI/tgs/v3210/commands.dm
@@ -42,5 +42,11 @@
 	var/datum/tgs_chat_command/stc = new command_type
 	var/datum/tgs_chat_user/user = new
 	user.friendly_name = sender
+
+	// Discord hack, fix the mention if it's only numbers (fuck you IRC trolls)
+	var/regex/discord_id_regex = regex(@"[0-9]+")
+	if(discord_id_regex.Find(sender))
+		sender = "<@[sender]>"
+
 	user.mention = sender
 	return stc.Run(user, params) || TRUE

--- a/src/DMAPI/tgs/v5/api.dm
+++ b/src/DMAPI/tgs/v5/api.dm
@@ -18,7 +18,7 @@
 	var/initialized = FALSE
 
 /datum/tgs_api/v5/ApiVersion()
-	return new /datum/tgs_version("5.2.4")
+	return new /datum/tgs_version("5.2.5")
 
 /datum/tgs_api/v5/OnWorldNew(minimum_required_security_level)
 	server_port = world.params[DMAPI5_PARAM_SERVER_PORT]

--- a/src/Tgstation.Server.Api/Rights/AdministrationRights.cs
+++ b/src/Tgstation.Server.Api/Rights/AdministrationRights.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Tgstation.Server.Api.Rights
 {
@@ -14,27 +14,27 @@ namespace Tgstation.Server.Api.Rights
 		None = 0,
 
 		/// <summary>
-		/// User can edit themself and other <see cref="Models.User"/>s and also create others
+		/// User can edit their and other <see cref="Models.User"/>s and create new ones.
 		/// </summary>
 		WriteUsers = 1,
 
 		/// <summary>
-		/// User can gracefully restart the host
+		/// User can gracefully restart TGS.
 		/// </summary>
 		RestartHost = 2,
 
 		/// <summary>
-		/// User can change <see cref="Models.Administration.NewVersion"/>
+		/// User can upgrade or downgrade TGS through the API.
 		/// </summary>
 		ChangeVersion = 4,
 
 		/// <summary>
-		/// User can change their password
+		/// User can change their password.
 		/// </summary>
 		EditOwnPassword = 8,
 
 		/// <summary>
-		/// User can read info and rights of other users
+		/// User can read info and rights of other users.
 		/// </summary>
 		ReadUsers = 16,
 

--- a/src/Tgstation.Server.Api/Rights/ByondRights.cs
+++ b/src/Tgstation.Server.Api/Rights/ByondRights.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Tgstation.Server.Api.Rights
 {
@@ -9,32 +9,32 @@ namespace Tgstation.Server.Api.Rights
 	public enum ByondRights : ulong
 	{
 		/// <summary>
-		/// User has no rights
+		/// User has no rights.
 		/// </summary>
 		None = 0,
 
 		/// <summary>
-		/// User may check the active installed BYOND version
+		/// User may view the active installed BYOND version.
 		/// </summary>
 		ReadActive = 1,
 
 		/// <summary>
-		/// User may list all installed BYOND versions
+		/// User may list all installed BYOND versions.
 		/// </summary>
 		ListInstalled = 2,
 
 		/// <summary>
-		/// User may change the active BYOND version. Also allows installing official BYOND versions
+		/// User may install official BYOND versions or change the active BYOND version.
 		/// </summary>
 		InstallOfficialOrChangeActiveVersion = 4,
 
 		/// <summary>
-		/// User may cancel version installations
+		/// User may cancel BYOND installation job.
 		/// </summary>
 		CancelInstall = 8,
 
 		/// <summary>
-		/// User may upload custom BYOND versions
+		/// User may upload and activate custom BYOND builds.
 		/// </summary>
 		InstallCustomVersion = 16,
 	}

--- a/src/Tgstation.Server.Api/Rights/ChatBotRights.cs
+++ b/src/Tgstation.Server.Api/Rights/ChatBotRights.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Tgstation.Server.Api.Rights
 {
@@ -9,22 +9,22 @@ namespace Tgstation.Server.Api.Rights
 	public enum ChatBotRights : ulong
 	{
 		/// <summary>
-		/// User has no rights
+		/// User has no rights.
 		/// </summary>
 		None = 0,
 
 		/// <summary>
-		/// User can change <see cref="Models.Internal.ChatBot.Enabled"/>
+		/// User can change <see cref="Models.Internal.ChatBot.Enabled"/>.
 		/// </summary>
 		WriteEnabled = 1,
 
 		/// <summary>
-		/// User can change <see cref="Models.Internal.ChatBot.Provider"/>
+		/// User can change <see cref="Models.Internal.ChatBot.Provider"/>.
 		/// </summary>
 		WriteProvider = 2,
 
 		/// <summary>
-		/// User can change <see cref="Models.ChatBot.Channels"/>
+		/// User can change <see cref="Models.ChatBot.Channels"/>.
 		/// </summary>
 		WriteChannels = 4,
 
@@ -34,37 +34,37 @@ namespace Tgstation.Server.Api.Rights
 		WriteConnectionString = 8,
 
 		/// <summary>
-		/// User can read <see cref="Models.Internal.ChatBot.ConnectionString"/> requires <see cref="Read"/>
+		/// User can read <see cref="Models.Internal.ChatBot.ConnectionString"/> requires the <see cref="Read"/> permission.
 		/// </summary>
 		ReadConnectionString = 16,
 
 		/// <summary>
-		/// User can read all chat settings except <see cref="Models.Internal.ChatBot.ConnectionString"/>
+		/// User can read all <see cref="Models.ChatBot"/> properties except <see cref="Models.Internal.ChatBot.ConnectionString"/>
 		/// </summary>
 		Read = 32,
 
 		/// <summary>
-		/// User can create new <see cref="Models.ChatBot"/>
+		/// User can create new <see cref="Models.ChatBot"/>s.
 		/// </summary>
 		Create = 64,
 
 		/// <summary>
-		/// User can delete <see cref="Models.ChatBot"/>
+		/// User can delete <see cref="Models.ChatBot"/>s.
 		/// </summary>
 		Delete = 128,
 
 		/// <summary>
-		/// User can change <see cref="Models.Internal.ChatBot.Name"/>
+		/// User can change <see cref="Models.Internal.ChatBot.Name"/>.
 		/// </summary>
 		WriteName = 256,
 
 		/// <summary>
-		/// User can change <see cref="Models.Internal.ChatBot.ReconnectionInterval"/>
+		/// User can change <see cref="Models.Internal.ChatBot.ReconnectionInterval"/>.
 		/// </summary>
 		WriteReconnectionInterval = 512,
 
 		/// <summary>
-		/// User can change <see cref="Models.Internal.ChatBot.ChannelLimit"/>
+		/// User can change <see cref="Models.Internal.ChatBot.ChannelLimit"/>.
 		/// </summary>
 		WriteChannelLimit = 1024,
 	}

--- a/src/Tgstation.Server.Api/Rights/ConfigurationRights.cs
+++ b/src/Tgstation.Server.Api/Rights/ConfigurationRights.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Tgstation.Server.Api.Rights
 {
@@ -9,27 +9,27 @@ namespace Tgstation.Server.Api.Rights
 	public enum ConfigurationRights : ulong
 	{
 		/// <summary>
-		/// User has no rights
+		/// User has no rights.
 		/// </summary>
 		None = 0,
 
 		/// <summary>
-		/// User may read files
+		/// User may read files if the <see cref="Models.Instance"/> allows it.
 		/// </summary>
 		Read = 1,
 
 		/// <summary>
-		/// User may write files
+		/// User may write files if the <see cref="Models.Instance"/> allows it.
 		/// </summary>
 		Write = 2,
 
 		/// <summary>
-		/// User may list files
+		/// User may list files if the <see cref="Models.Instance"/> allows it.
 		/// </summary>
 		List = 4,
 
 		/// <summary>
-		/// User may delete empty folders
+		/// User may delete empty folders if the <see cref="Models.Instance"/> allows it.
 		/// </summary>
 		Delete = 8
 	}

--- a/src/Tgstation.Server.Api/Rights/DreamDaemonRights.cs
+++ b/src/Tgstation.Server.Api/Rights/DreamDaemonRights.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Tgstation.Server.Api.Rights
 {
@@ -34,7 +34,7 @@ namespace Tgstation.Server.Api.Rights
 		SetSecurity = 8,
 
 		/// <summary>
-		/// User can read all ports, <see cref="Models.DreamDaemon.SoftRestart"/>, <see cref="Models.DreamDaemon.SoftShutdown"/>, <see cref="Models.DreamDaemon.Status"/>, <see cref="Models.Internal.DreamDaemonLaunchParameters.AllowWebClient"/>, and <see cref="Models.Internal.DreamDaemonSettings.AutoStart"/>
+		/// User can read every propery of <see cref="Models.DreamDaemon"/> except <see cref="Models.DreamDaemon.ActiveCompileJob"/> and <see cref="Models.DreamDaemon.StagedCompileJob"/>.
 		/// </summary>
 		ReadMetadata = 16,
 
@@ -44,27 +44,27 @@ namespace Tgstation.Server.Api.Rights
 		SetWebClient = 32,
 
 		/// <summary>
-		/// User can change <see cref="Models.DreamDaemon.SoftRestart"/>
+		/// User can change <see cref="Models.DreamDaemon.SoftRestart"/>.
 		/// </summary>
 		SoftRestart = 64,
 
 		/// <summary>
-		/// User can change <see cref="Models.DreamDaemon.SoftShutdown"/>
+		/// User can change <see cref="Models.DreamDaemon.SoftShutdown"/>.
 		/// </summary>
 		SoftShutdown = 128,
 
 		/// <summary>
-		/// User can immediately restart <see cref="Models.DreamDaemon"/>
+		/// User can immediately restart the Watchdog.
 		/// </summary>
 		Restart = 256,
 
 		/// <summary>
-		/// User can immediately shutdown <see cref="Models.DreamDaemon"/>
+		/// User can immediately shutdown the Watchdog.
 		/// </summary>
 		Shutdown = 512,
 
 		/// <summary>
-		/// User can start <see cref="Models.DreamDaemon"/>.
+		/// User can start the Watchdog.
 		/// </summary>
 		Start = 1024,
 

--- a/src/Tgstation.Server.Api/Rights/DreamMakerRights.cs
+++ b/src/Tgstation.Server.Api/Rights/DreamMakerRights.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Tgstation.Server.Api.Rights
 {
@@ -9,42 +9,42 @@ namespace Tgstation.Server.Api.Rights
 	public enum DreamMakerRights : ulong
 	{
 		/// <summary>
-		/// User has no rights
+		/// User has no rights.
 		/// </summary>
 		None = 0,
 
 		/// <summary>
-		/// User may read <see cref="Models.DreamMaker"/> status
+		/// User may read all properties of <see cref="Models.DreamMaker"/>.
 		/// </summary>
 		Read = 1,
 
 		/// <summary>
-		/// User may trigger compiles
+		/// User may trigger deployments.
 		/// </summary>
 		Compile = 2,
 
 		/// <summary>
-		/// User may cancel compiles
+		/// User may cancel deployment jobs.
 		/// </summary>
 		CancelCompile = 4,
 
 		/// <summary>
-		/// User may modify <see cref="Models.DreamMaker.ProjectName"/>
+		/// User may modify <see cref="Models.DreamMaker.ProjectName"/>.
 		/// </summary>
 		SetDme = 8,
 
 		/// <summary>
-		/// User may modify <see cref="Models.DreamMaker.ApiValidationPort"/>
+		/// User may modify <see cref="Models.DreamMaker.ApiValidationPort"/>.
 		/// </summary>
 		SetApiValidationPort = 16,
 
 		/// <summary>
-		/// User may list and read all <see cref="Models.CompileJob"/>s
+		/// User may list and read all <see cref="Models.CompileJob"/>s.
 		/// </summary>
 		CompileJobs = 32,
 
 		/// <summary>
-		/// User may modify <see cref="Models.DreamMaker.ApiValidationSecurityLevel"/>
+		/// User may modify <see cref="Models.DreamMaker.ApiValidationSecurityLevel"/>.
 		/// </summary>
 		SetSecurityLevel = 64,
 

--- a/src/Tgstation.Server.Api/Rights/InstanceManagerRights.cs
+++ b/src/Tgstation.Server.Api/Rights/InstanceManagerRights.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Tgstation.Server.Api.Rights
 {
@@ -9,62 +9,62 @@ namespace Tgstation.Server.Api.Rights
 	public enum InstanceManagerRights : ulong
 	{
 		/// <summary>
-		/// User has no rights
+		/// User has no rights.
 		/// </summary>
 		None = 0,
 
 		/// <summary>
-		/// User can view <see cref="Models.Instance"/>s which they have any rights for
+		/// User can view <see cref="Models.Instance"/>s which they have an <see cref="Models.InstanceUser"/> for.
 		/// </summary>
 		Read = 1,
 
 		/// <summary>
-		/// User can create <see cref="Models.Instance"/>s
+		/// User can create <see cref="Models.Instance"/>s.
 		/// </summary>
 		Create = 2,
 
 		/// <summary>
-		/// User can rename <see cref="Models.Instance"/>s they can view
+		/// User can rename <see cref="Models.Instance"/>s they can view.
 		/// </summary>
 		Rename = 4,
 
 		/// <summary>
-		/// User can relocate <see cref="Models.Instance"/>s they can view
+		/// User can relocate <see cref="Models.Instance"/>s they can view.
 		/// </summary>
 		Relocate = 8,
 
 		/// <summary>
-		/// User can online <see cref="Models.Instance"/>s they can view
+		/// User can online <see cref="Models.Instance"/>s they can view.
 		/// </summary>
 		SetOnline = 16,
 
 		/// <summary>
-		/// User can delete <see cref="Models.Instance"/>s they can view
+		/// User can delete <see cref="Models.Instance"/>s they can view.
 		/// </summary>
 		Delete = 32,
 
 		/// <summary>
-		/// User can view all <see cref="Models.Instance"/>s
+		/// User can view all <see cref="Models.Instance"/>s.
 		/// </summary>
 		List = 64,
 
 		/// <summary>
-		/// User can change <see cref="Models.Instance.ConfigurationType"/>
+		/// User can change <see cref="Models.Instance.ConfigurationType"/> on instances they can view.
 		/// </summary>
 		SetConfiguration = 128,
 
 		/// <summary>
-		/// User can change <see cref="Models.Instance.AutoUpdateInterval"/>
+		/// User can change <see cref="Models.Instance.AutoUpdateInterval"/> on instances they can view.
 		/// </summary>
 		SetAutoUpdate = 256,
 
 		/// <summary>
-		/// User can change <see cref="Models.Instance.ChatBotLimit"/>.
+		/// User can change <see cref="Models.Instance.ChatBotLimit"/> on instances they can view.
 		/// </summary>
 		SetChatBotLimit = 512,
 
 		/// <summary>
-		/// User can give themselves full <see cref="Models.InstanceUser"/> rights on instances.
+		/// User can give themselves full <see cref="Models.InstanceUser"/> rights on ALL instances.
 		/// </summary>
 		GrantPermissions = 1024,
 	}

--- a/src/Tgstation.Server.Api/Rights/InstanceUserRights.cs
+++ b/src/Tgstation.Server.Api/Rights/InstanceUserRights.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Tgstation.Server.Api.Rights
 {
@@ -9,22 +9,22 @@ namespace Tgstation.Server.Api.Rights
 	public enum InstanceUserRights : ulong
 	{
 		/// <summary>
-		/// User has no rights
+		/// User has no rights/
 		/// </summary>
 		None = 0,
 
 		/// <summary>
-		/// Allow read access to <see cref="Models.InstanceUser"/> for the <see cref="Models.Instance"/>
+		/// Allow read access to all <see cref="Models.InstanceUser"/>s in the <see cref="Models.Instance"/>.
 		/// </summary>
 		ReadUsers = 1,
 
 		/// <summary>
-		/// Allow write and delete access to <see cref="Models.InstanceUser"/> for the <see cref="Models.Instance"/>
+		/// Allow write and delete access to all <see cref="Models.InstanceUser"/> for the <see cref="Models.Instance"/>.
 		/// </summary>
 		WriteUsers = 2,
 
 		/// <summary>
-		/// Allow adding additional <see cref="Models.InstanceUser"/> to the <see cref="Models.Instance"/>
+		/// Allow adding additional <see cref="Models.InstanceUser"/>s to the <see cref="Models.Instance"/>.
 		/// </summary>
 		CreateUsers = 4
 	}

--- a/src/Tgstation.Server.Api/Rights/RepositoryRights.cs
+++ b/src/Tgstation.Server.Api/Rights/RepositoryRights.cs
@@ -9,37 +9,37 @@ namespace Tgstation.Server.Api.Rights
 	public enum RepositoryRights : ulong
 	{
 		/// <summary>
-		/// User has no rights
+		/// User has no rights.
 		/// </summary>
 		None = 0,
 
 		/// <summary>
-		/// User may cancel update operations.
+		/// User may cancel repository jobs excluding clone operations.
 		/// </summary>
 		CancelPendingChanges = 1,
 
 		/// <summary>
-		/// User may create the <see cref="Models.Repository"/> if it does not exist
+		/// User may clone the <see cref="Models.Repository"/> if it does not exist.
 		/// </summary>
 		SetOrigin = 2,
 
 		/// <summary>
-		/// User may directly set the sha the <see cref="Models.Repository"/>'s HEAD points to
+		/// User may directly checkout a git SHA that the <see cref="Models.Repository"/>'s HEAD will point to.
 		/// </summary>
 		SetSha = 4,
 
 		/// <summary>
-		/// User may fetch and merge GitHub pull requests
+		/// User may fetch and merge GitHub pull requests.
 		/// </summary>
 		MergePullRequest = 8,
 
 		/// <summary>
-		/// User may use the update feature
+		/// User may fetch and hard reset to the origin version of the current branch.
 		/// </summary>
 		UpdateBranch = 16,
 
 		/// <summary>
-		/// User may change <see cref="Models.Internal.RepositorySettings.CommitterName"/> and <see cref="Models.Internal.RepositorySettings.CommitterEmail"/>
+		/// User may change <see cref="Models.Internal.RepositorySettings.CommitterName"/> and <see cref="Models.Internal.RepositorySettings.CommitterEmail"/>.
 		/// </summary>
 		ChangeCommitter = 32,
 
@@ -49,32 +49,32 @@ namespace Tgstation.Server.Api.Rights
 		ChangeTestMergeCommits = 64,
 
 		/// <summary>
-		/// User may read and change <see cref="Models.Internal.RepositorySettings.AccessUser"/> and <see cref="Models.Internal.RepositorySettings.AccessToken"/>
+		/// User may read and change <see cref="Models.Internal.RepositorySettings.AccessUser"/> and <see cref="Models.Internal.RepositorySettings.AccessToken"/>.
 		/// </summary>
 		ChangeCredentials = 128,
 
 		/// <summary>
-		/// User may set <see cref="Models.Repository.Reference"/> to another git reference (not a SHA)
+		/// User may set <see cref="Models.Repository.Reference"/> to another git branch or tag (not a SHA).
 		/// </summary>
 		SetReference = 256,
 
 		/// <summary>
-		/// User may read all fields in the <see cref="Models.Repository"/> with the exception of <see cref="Models.Internal.RepositorySettings.AccessToken"/>
+		/// User may read all fields in the <see cref="Models.Repository"/> with the exception of <see cref="Models.Internal.RepositorySettings.AccessToken"/>.
 		/// </summary>
 		Read = 512,
 
 		/// <summary>
-		/// User may change <see cref="Models.Internal.RepositorySettings.AutoUpdatesKeepTestMerges"/> and  <see cref="Models.Internal.RepositorySettings.AutoUpdatesSynchronize"/>
+		/// User may change <see cref="Models.Internal.RepositorySettings.AutoUpdatesKeepTestMerges"/> and <see cref="Models.Internal.RepositorySettings.AutoUpdatesSynchronize"/>.
 		/// </summary>
 		ChangeAutoUpdateSettings = 1024,
 
 		/// <summary>
-		/// User may delete the <see cref="Models.Repository"/>
+		/// User may delete the <see cref="Models.Repository"/> and allow it to be cloned again.
 		/// </summary>
 		Delete = 2048,
 
 		/// <summary>
-		/// User may cancel clone operations
+		/// User may cancel clone jobs.
 		/// </summary>
 		CancelClone = 4096
 	}

--- a/src/Tgstation.Server.Host/Components/Interop/DMApiConstants.cs
+++ b/src/Tgstation.Server.Host/Components/Interop/DMApiConstants.cs
@@ -33,7 +33,7 @@ namespace Tgstation.Server.Host.Components.Interop
 		/// <summary>
 		/// The DMAPI <see cref="Version"/> being used.
 		/// </summary>
-		public static readonly Version Version = new Version(5, 2, 4);
+		public static readonly Version Version = new Version(5, 2, 5);
 
 		/// <summary>
 		/// <see cref="JsonSerializerSettings"/> for use when communicating with the DMAPI.

--- a/src/Tgstation.Server.Host/Controllers/DreamDaemonController.cs
+++ b/src/Tgstation.Server.Host/Controllers/DreamDaemonController.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using System;
@@ -275,7 +275,7 @@ namespace Tgstation.Server.Host.Controllers
 #pragma warning restore CA1502
 
 		/// <summary>
-		/// Creates a <see cref="Api.Models.Job"/> to restart the Watchdog. It will start if it wasn't already running.
+		/// Creates a <see cref="Api.Models.Job"/> to restart the Watchdog. It will not start if it wasn't already running.
 		/// </summary>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> of the request</returns>

--- a/src/Tgstation.Server.Host/Database/DatabaseSeeder.cs
+++ b/src/Tgstation.Server.Host/Database/DatabaseSeeder.cs
@@ -218,7 +218,7 @@ namespace Tgstation.Server.Host.Database
 		}
 
 		/// <summary>
-		/// Changes the admin password in <see cref="IDatabaseContext"/> back to it's default and enables the account
+		/// Changes the admin password in <see cref="IDatabaseContext"/> back to it's default, enables the account, and gives it <see cref="AdministrationRights.WriteUsers"/> access.
 		/// </summary>
 		/// <param name="databaseContext">The <see cref="IDatabaseContext"/> to reset the admin password for</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
@@ -229,6 +229,7 @@ namespace Tgstation.Server.Host.Database
 			if (admin != null)
 			{
 				admin.Enabled = true;
+				admin.AdministrationRights |= AdministrationRights.WriteUsers;
 				cryptographySuite.SetUserPassword(admin, Api.Models.User.DefaultAdminPassword, false);
 			}
 

--- a/src/Tgstation.Server.Host/Models/RepositorySettings.cs
+++ b/src/Tgstation.Server.Host/Models/RepositorySettings.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 using Tgstation.Server.Api.Models;
 
 namespace Tgstation.Server.Host.Models
@@ -36,7 +36,8 @@ namespace Tgstation.Server.Host.Models
 			CommitterName = CommitterName,
 			PushTestMergeCommits = PushTestMergeCommits,
 			ShowTestMergeCommitters = ShowTestMergeCommitters,
-			PostTestMergeComment = PostTestMergeComment
+			PostTestMergeComment = PostTestMergeComment,
+			CreateGitHubDeployments = CreateGitHubDeployments,
 
 			// revision information and the rest retrieved by controller
 		};


### PR DESCRIPTION
:cl:
Fixed repository's `createGitHubDeployments` property not being returned in responses.
/:cl:

:cl: DMAPI
Fixed a V3 issue when populating /datum/tgs_chat_user/var/mention
/:cl:

:cl: HTTP API
Updated documentation of various permissions.
Fixed wording about what PATCH /DreamDaemon does.
/:cl: