### PR TITLE
v4.5.3

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- This is the authorative version list -->
     <!-- Integration tests will ensure they match across the board -->
-    <TgsCoreVersion>4.5.2</TgsCoreVersion>
+    <TgsCoreVersion>4.5.3</TgsCoreVersion>
     <TgsConfigVersion>2.1.0</TgsConfigVersion>
     <TgsApiVersion>7.3.2</TgsApiVersion>
     <TgsClientVersion>8.3.2</TgsClientVersion>

--- a/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
@@ -337,22 +337,26 @@ namespace Tgstation.Server.Host.Components.Deployment
 				return;
 			}
 
-			if (dmeModifications.HeadIncludeLine != null)
-				logger.LogDebug("Head .dme include line: {0}", dmeModifications.HeadIncludeLine);
-			if (dmeModifications.TailIncludeLine != null)
-				logger.LogDebug("Tail .dme include line: {0}", dmeModifications.TailIncludeLine);
-
-			var dmeLines = new List<string>(dme.Split(new[] { Environment.NewLine }, StringSplitOptions.None));
+			var dmeLines = new List<string>(dme.Split('\n', StringSplitOptions.None));
 			for (var I = 0; I < dmeLines.Count; ++I)
 			{
 				var line = dmeLines[I];
 				if (line.Contains("BEGIN_INCLUDE", StringComparison.Ordinal) && dmeModifications.HeadIncludeLine != null)
 				{
-					dmeLines.Insert(I + 1, dmeModifications.HeadIncludeLine);
+					var headIncludeLineNumber = I + 1;
+					logger.LogDebug(
+						"Inserting HeadInclude.dm at line {0}: {1}",
+						headIncludeLineNumber,
+						dmeModifications.HeadIncludeLine);
+					dmeLines.Insert(headIncludeLineNumber, dmeModifications.HeadIncludeLine);
 					++I;
 				}
 				else if (line.Contains("END_INCLUDE", StringComparison.Ordinal) && dmeModifications.TailIncludeLine != null)
 				{
+					logger.LogDebug(
+						"Inserting TailInclude.dm at line {0}: {1}",
+						I,
+						dmeModifications.TailIncludeLine);
 					dmeLines.Insert(I, dmeModifications.TailIncludeLine);
 					break;
 				}


### PR DESCRIPTION
:cl:
Fixed HeadInclude.dm and TailInclude.dm always being put at the start of the .dme if non-Windows line endings were used.
/:cl: