### PR TITLE
v4.5.4

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- This is the authorative version list -->
     <!-- Integration tests will ensure they match across the board -->
-    <TgsCoreVersion>4.5.3</TgsCoreVersion>
+    <TgsCoreVersion>4.5.4</TgsCoreVersion>
     <TgsConfigVersion>2.1.0</TgsConfigVersion>
     <TgsApiVersion>7.3.2</TgsApiVersion>
     <TgsClientVersion>8.3.2</TgsClientVersion>

--- a/src/Tgstation.Server.Host/Components/Watchdog/BasicWatchdog.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/BasicWatchdog.cs
@@ -192,6 +192,8 @@ namespace Tgstation.Server.Host.Components.Watchdog
 					Logger.LogTrace("Initializing controller with CompileJob {0}...", dmbToUse.CompileJob.Id);
 					await BeforeApplyDmb(dmbToUse.CompileJob, cancellationToken).ConfigureAwait(false);
 					dmbToUse = await PrepServerForLaunch(dmbToUse, cancellationToken).ConfigureAwait(false);
+
+					await chatTask.ConfigureAwait(false);
 					serverLaunchTask = SessionControllerFactory.LaunchNew(
 						dmbToUse,
 						null,
@@ -200,7 +202,10 @@ namespace Tgstation.Server.Host.Components.Watchdog
 						cancellationToken);
 				}
 				else
+				{
+					await chatTask.ConfigureAwait(false);
 					serverLaunchTask = SessionControllerFactory.Reattach(reattachInfo, cancellationToken);
+				}
 
 				// retrieve the session controller
 				Server = await serverLaunchTask.ConfigureAwait(false);
@@ -209,7 +214,6 @@ namespace Tgstation.Server.Host.Components.Watchdog
 				if (Server == null)
 				{
 					await ReattachFailure(
-						chatTask,
 						cancellationToken)
 						.ConfigureAwait(false);
 					return;

--- a/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
@@ -474,10 +474,9 @@ namespace Tgstation.Server.Host.Components.Watchdog
 		/// <summary>
 		/// Call from <see cref="InitControllers(Task, ReattachInformation, CancellationToken)"/> when a reattach operation fails to attempt a fresh start.
 		/// </summary>
-		/// <param name="chatTask">A, possibly active, <see cref="Task"/> for an outgoing chat message.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task"/> representing the running operation.</returns>
-		protected async Task ReattachFailure(Task chatTask, CancellationToken cancellationToken)
+		protected async Task ReattachFailure(CancellationToken cancellationToken)
 		{
 			// we lost the server, just restart entirely
 			// DCT: Operation must always run
@@ -485,13 +484,8 @@ namespace Tgstation.Server.Host.Components.Watchdog
 			const string FailReattachMessage = "Unable to properly reattach to server! Restarting watchdog...";
 			Logger.LogWarning(FailReattachMessage);
 
-			async Task ChainChatTask()
-			{
-				await chatTask.ConfigureAwait(false);
-				await Chat.SendWatchdogMessage(FailReattachMessage, cancellationToken).ConfigureAwait(false);
-			}
-
-			await InitControllers(ChainChatTask(), null, cancellationToken).ConfigureAwait(false);
+			var chatTask = Chat.SendWatchdogMessage(FailReattachMessage, cancellationToken);
+			await InitControllers(chatTask, null, cancellationToken).ConfigureAwait(false);
 		}
 
 		/// <summary>


### PR DESCRIPTION
:cl:
The `WatchdogLaunch` event script will now complete before DreamDaemon starts.
/:cl:

Closes #1124 