### PR TITLE
Fixes set-env depreciation 

### DIFF
--- a/.github/workflows/ci-suite.yml
+++ b/.github/workflows/ci-suite.yml
@@ -5,6 +5,7 @@ on:
     branches:
     - dev
     - master
+    - fix/setenv-deprec
   pull_request:
     branches:
     - dev

--- a/.github/workflows/ci-suite.yml
+++ b/.github/workflows/ci-suite.yml
@@ -593,7 +593,7 @@ jobs:
         run: |
           [XML]$versionXML = Get-Content build/Version.props
           $apiVersion = $versionXML.Project.PropertyGroup.TgsApiVersion
-          Write-Host "TGS_API_VERSION=$apiVersion" >> $GITHUB_ENV
+          Write-Host "TGS_API_VERSION=$apiVersion" >> $env:GITHUB_ENV
 
       - name: Retrieve OpenAPI Spec
         uses: actions/download-artifact@v2
@@ -637,7 +637,7 @@ jobs:
         run: |
           [XML]$versionXML = Get-Content build/Version.props
           $dmVersion = $versionXML.Project.PropertyGroup.TgsDmapiVersion
-          Write-Host "TGS_DM_VERSION=$dmVersion" >> $GITHUB_ENV
+          Write-Host "TGS_DM_VERSION=$dmVersion" >> $env:GITHUB_ENV
 
       - name: Zip DMAPI
         shell: powershell
@@ -704,7 +704,7 @@ jobs:
         run: |
           [XML]$versionXML = Get-Content build/Version.props
           $tgsVersion = $versionXML.Project.PropertyGroup.TgsCoreVersion
-          Write-Host "TGS_VERSION=$tgsVersion" >> $GITHUB_ENV
+          Write-Host "TGS_VERSION=$tgsVersion" >> $env:GITHUB_ENV
 
       - name: Retrieve Server Service
         uses: actions/download-artifact@v2

--- a/.github/workflows/ci-suite.yml
+++ b/.github/workflows/ci-suite.yml
@@ -5,7 +5,6 @@ on:
     branches:
     - dev
     - master
-    - fix/setenv-deprec
   pull_request:
     branches:
     - dev

--- a/.github/workflows/ci-suite.yml
+++ b/.github/workflows/ci-suite.yml
@@ -186,25 +186,25 @@ jobs:
     steps:
     - name: Set General__UseBasicWatchdog
       if: ${{ matrix.watchdog-type == 'Basic' }}
-      run: echo "::set-env name=General__UseBasicWatchdog::true"
+      run: echo "General__UseBasicWatchdog=true" >> $GITHUB_ENV
 
     - name: Set TGS4_TEST_CONNECTION_STRING
-      run: echo "::set-env name=TGS4_TEST_CONNECTION_STRING::Server=(localdb)\MSSQLLocalDB;Integrated Security=true;Initial Catalog=TGS_${{ matrix.watchdog-type }}_${{ matrix.configuration }};Application Name=tgstation-server"
+      run: echo "TGS4_TEST_CONNECTION_STRING=Server=(localdb)\MSSQLLocalDB;Integrated Security=true;Initial Catalog=TGS_${{ matrix.watchdog-type }}_${{ matrix.configuration }};Application Name=tgstation-server" >> $GITHUB_ENV
 
     - name: Checkout
       uses: actions/checkout@v1
 
     - name: Set TGS4_TEST_PULL_REQUEST_NUMBER
       if: ${{ github.event_name == 'pull_request' }}
-      run: echo "::set-env name=TGS4_TEST_PULL_REQUEST_NUMBER::${{ github.event.number }}"
+      run: echo "TGS4_TEST_PULL_REQUEST_NUMBER=${{ github.event.number }}" >> $GITHUB_ENV
 
     - name: Set TGS4_GITHUB_REF for PR
       if: ${{ github.event_name == 'pull_request' }}
-      run: echo "::set-env name=TGS4_GITHUB_REF::${{ github.event.base_ref }}"
+      run: echo "TGS4_GITHUB_REF=${{ github.event.base_ref }}" >> $GITHUB_ENV
 
     - name: Set TGS4_GITHUB_REF for push
       if: ${{ github.event_name == 'push' }}
-      run: echo "::set-env name=TGS4_GITHUB_REF::${{ github.event.ref }}"
+      run: echo "TGS4_GITHUB_REF=${{ github.event.ref }}" >> $GITHUB_ENV
 
     - name: Run Integration Test
       run: |
@@ -307,46 +307,46 @@ jobs:
     - name: Set Sqlite Connection Info
       if: ${{ matrix.database-type == 'Sqlite' }}
       run: |
-        echo "::set-env name=TGS4_TEST_DATABASE_TYPE::Sqlite"
-        echo "::set-env name=TGS4_TEST_CONNECTION_STRING::Data Source=TGS_${{ matrix.watchdog-type }}_${{ matrix.configuration }}.sqlite3;Mode=ReadWriteCreate"
+        echo "TGS4_TEST_DATABASE_TYPE=Sqlite" >> $GITHUB_ENV
+        echo "TGS4_TEST_CONNECTION_STRING=Data Source=TGS_${{ matrix.watchdog-type }}_${{ matrix.configuration }}.sqlite3;Mode=ReadWriteCreate" >> $GITHUB_ENV
 
     - name: Set PostgresSql Connection Info
       if: ${{ matrix.database-type == 'PostgresSql' }}
       run: |
-        echo "::set-env name=TGS4_TEST_DATABASE_TYPE::PostgresSql"
-        echo "::set-env name=TGS4_TEST_CONNECTION_STRING::Application Name=tgstation-server;Host=127.0.0.1;Username=postgres;Password=postgres;Database=TGS__${{ matrix.watchdog-type }}_${{ matrix.configuration }}"
+        echo "TGS4_TEST_DATABASE_TYPE=PostgresSql" >> $GITHUB_ENV
+        echo "TGS4_TEST_CONNECTION_STRING=Application Name=tgstation-server;Host=127.0.0.1;Username=postgres;Password=postgres;Database=TGS__${{ matrix.watchdog-type }}_${{ matrix.configuration }}" >> $GITHUB_ENV
 
     - name: Set MariaDB Connection Info
       if: ${{ matrix.database-type == 'MariaDB' }}
       run: |
-        echo "::set-env name=TGS4_TEST_DATABASE_TYPE::MariaDB"
-        echo "::set-env name=TGS4_TEST_CONNECTION_STRING::Server=127.0.0.1;uid=root;pwd=mariadb;database=tgs__${{ matrix.watchdog-type }}_${{ matrix.configuration }}"
+        echo "TGS4_TEST_DATABASE_TYPE=MariaDB" >> $GITHUB_ENV
+        echo "TGS4_TEST_CONNECTION_STRING=Server=127.0.0.1;uid=root;pwd=mariadb;database=tgs__${{ matrix.watchdog-type }}_${{ matrix.configuration }}" >> $GITHUB_ENV
 
     - name: Set MySQL Connection Info
       if: ${{ matrix.database-type == 'MySql' }}
       run: |
-        echo "::set-env name=TGS4_TEST_DATABASE_TYPE::MySql"
-        echo "::set-env name=TGS4_TEST_CONNECTION_STRING::Server=127.0.0.1;Port=3307;uid=root;pwd=mysql;database=tgs__${{ matrix.watchdog-type }}_${{ matrix.configuration }}"
-        echo "::set-env name=Database__ServerVersion::5.7.31"
+        echo "TGS4_TEST_DATABASE_TYPE=MySql" >> $GITHUB_ENV
+        echo "TGS4_TEST_CONNECTION_STRING=Server=127.0.0.1;Port=3307;uid=root;pwd=mysql;database=tgs__${{ matrix.watchdog-type }}_${{ matrix.configuration }}" >> $GITHUB_ENV
+        echo "Database__ServerVersion=5.7.31" >> $GITHUB_ENV
 
     - name: Set General__UseBasicWatchdog
       if: ${{ matrix.watchdog-type == 'Basic' }}
-      run: echo "::set-env name=General__UseBasicWatchdog::true"
+      run: echo "General__UseBasicWatchdog=true" >> $GITHUB_ENV
 
     - name: Checkout
       uses: actions/checkout@v1
 
     - name: Set TGS4_TEST_PULL_REQUEST_NUMBER
       if: ${{ github.event_name == 'pull_request' }}
-      run: echo "::set-env name=TGS4_TEST_PULL_REQUEST_NUMBER::${{ github.event.number }}"
+      run: echo "TGS4_TEST_PULL_REQUEST_NUMBER=${{ github.event.number }}" >> $GITHUB_ENV
 
     - name: Set TGS4_GITHUB_REF for PR
       if: ${{ github.event_name == 'pull_request' }}
-      run: echo "::set-env name=TGS4_GITHUB_REF::${{ github.event.base_ref }}"
+      run: echo "TGS4_GITHUB_REF=${{ github.event.base_ref }}" >> $GITHUB_ENV
 
     - name: Set TGS4_GITHUB_REF for push
       if: ${{ github.event_name == 'push' }}
-      run: echo "::set-env name=TGS4_GITHUB_REF::${{ github.event.ref }}"
+      run: echo "TGS4_GITHUB_REF=${{ github.event.ref }}" >> $GITHUB_ENV
 
     - name: Run Integration Test
       run: |
@@ -593,7 +593,7 @@ jobs:
         run: |
           [XML]$versionXML = Get-Content build/Version.props
           $apiVersion = $versionXML.Project.PropertyGroup.TgsApiVersion
-          Write-Host "::set-env name=TGS_API_VERSION::$apiVersion"
+          Write-Host "TGS_API_VERSION=$apiVersion" >> $GITHUB_ENV
 
       - name: Retrieve OpenAPI Spec
         uses: actions/download-artifact@v2
@@ -637,7 +637,7 @@ jobs:
         run: |
           [XML]$versionXML = Get-Content build/Version.props
           $dmVersion = $versionXML.Project.PropertyGroup.TgsDmapiVersion
-          Write-Host "::set-env name=TGS_DM_VERSION::$dmVersion"
+          Write-Host "TGS_DM_VERSION=$dmVersion" >> $GITHUB_ENV
 
       - name: Zip DMAPI
         shell: powershell
@@ -704,7 +704,7 @@ jobs:
         run: |
           [XML]$versionXML = Get-Content build/Version.props
           $tgsVersion = $versionXML.Project.PropertyGroup.TgsCoreVersion
-          Write-Host "::set-env name=TGS_VERSION::$tgsVersion"
+          Write-Host "TGS_VERSION=$tgsVersion" >> $GITHUB_ENV
 
       - name: Retrieve Server Service
         uses: actions/download-artifact@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,42 @@
+name: "Code Scanning"
+
+on:
+  push:
+    branches: [dev, master]
+  pull_request:
+    branches: [dev, master]
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['csharp']
+
+    steps:
+    - name: Install Node 12.X
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 2
+
+    - run: git checkout HEAD^2
+      if: ${{ github.event_name == 'pull_request' }}
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
[Why]: # (If this does not close or work on an existing GitHub issue, please add a short description [two lines down] of why you think these changes would benefit the server. If you can't justify it in words, it might not be worth adding.)

[GitHub bad.](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) Depreciation bad. CI breaking in the future bad. 

This fix. Gooncoder happy.