### PR TITLE
Adds better port allocation

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -4,8 +4,8 @@
     <!-- Integration tests will ensure they match across the board -->
     <TgsCoreVersion>4.5.4</TgsCoreVersion>
     <TgsConfigVersion>2.1.0</TgsConfigVersion>
-    <TgsApiVersion>7.3.2</TgsApiVersion>
-    <TgsClientVersion>8.3.2</TgsClientVersion>
+    <TgsApiVersion>7.4.0</TgsApiVersion>
+    <TgsClientVersion>8.4.0</TgsClientVersion>
     <TgsDmapiVersion>5.2.6</TgsDmapiVersion>
     <TgsControlPanelVersion>0.4.0</TgsControlPanelVersion>
     <TgsHostWatchdogVersion>1.1.0</TgsHostWatchdogVersion>

--- a/src/Tgstation.Server.Api/Models/ErrorCode.cs
+++ b/src/Tgstation.Server.Api/Models/ErrorCode.cs
@@ -570,5 +570,17 @@ namespace Tgstation.Server.Api.Models
 		/// </summary>
 		[Description("Failed to allow DreamDaemon through the Windows firewall!")]
 		ByondDreamDaemonFirewallFail,
+
+		/// <summary>
+		/// Attempted to create an instance but no free ports could be found.
+		/// </summary>
+		[Description("TGS was unable to find a free port to allocate for the operation!")]
+		NoPortsAvailable,
+
+		/// <summary>
+		/// Attempted to set a port which is either in use by another part of TGS or otherwise not available for binding.
+		/// </summary>
+		[Description("The requested port is either already in use by TGS or could not be allocated!")]
+		PortNotAvailable,
 	}
 }

--- a/src/Tgstation.Server.Host/Core/Application.cs
+++ b/src/Tgstation.Server.Host/Core/Application.cs
@@ -294,6 +294,7 @@ namespace Tgstation.Server.Host.Core
 			services.AddSingleton<IProcessExecutor, ProcessExecutor>();
 			services.AddSingleton<IServerPortProvider, ServerPortProivder>();
 			services.AddSingleton<ITopicClientFactory, TopicClientFactory>();
+			services.AddScoped<IPortAllocator, PortAllocator>();
 
 			// configure component services
 			services.AddSingleton<ILibGit2RepositoryFactory, LibGit2RepositoryFactory>();

--- a/src/Tgstation.Server.Host/Core/IPortAllocator.cs
+++ b/src/Tgstation.Server.Host/Core/IPortAllocator.cs
@@ -1,0 +1,20 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Tgstation.Server.Host.Core
+{
+	/// <summary>
+	/// Gets unassigned ports for use by TGS.
+	/// </summary>
+	public interface IPortAllocator
+	{
+		/// <summary>
+		/// Gets a port not currently in use by TGS.
+		/// </summary>
+		/// <param name="basePort">The port to check first. Will not allocate a port lower than this.</param>
+		/// <param name="checkOne">If only <paramref name="basePort"/> should be checked and no others.</param>
+		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
+		/// <returns>A <see cref="Task{TResult}"/> resulting in the first available port on success, <see langword="null"/> on failure.</returns>
+		Task<ushort?> GetAvailablePort(ushort basePort, bool checkOne, CancellationToken cancellationToken);
+	}
+}

--- a/src/Tgstation.Server.Host/Core/PortAllocator.cs
+++ b/src/Tgstation.Server.Host/Core/PortAllocator.cs
@@ -1,0 +1,90 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Tgstation.Server.Host.Database;
+using Tgstation.Server.Host.Extensions;
+
+namespace Tgstation.Server.Host.Core
+{
+	/// <inheritdoc />
+	sealed class PortAllocator : IPortAllocator
+	{
+		/// <summary>
+		/// The <see cref="IServerPortProvider"/> for the <see cref="PortAllocator"/>.
+		/// </summary>
+		readonly IServerPortProvider serverPortProvider;
+
+		/// <summary>
+		/// The <see cref="IDatabaseContext"/> for the <see cref="PortAllocator"/>.
+		/// </summary>
+		readonly IDatabaseContext databaseContext;
+
+		/// <summary>
+		/// The <see cref="ILogger"/> for the <see cref="PortAllocator"/>.
+		/// </summary>
+		readonly ILogger<PortAllocator> logger;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="PortAllocator"/> <see langword="class"/>.
+		/// </summary>
+		/// <param name="serverPortProvider">The value of <see cref="serverPortProvider"/>.</param>
+		/// <param name="databaseContext">The value of <see cref="databaseContext"/>.</param>
+		/// <param name="logger">The value of <see cref="logger"/>.</param>
+		public PortAllocator(IServerPortProvider serverPortProvider, IDatabaseContext databaseContext, ILogger<PortAllocator> logger)
+		{
+			this.serverPortProvider = serverPortProvider ?? throw new ArgumentNullException(nameof(serverPortProvider));
+			this.databaseContext = databaseContext ?? throw new ArgumentNullException(nameof(databaseContext));
+			this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+		}
+
+		/// <inheritdoc />
+		public async Task<ushort?> GetAvailablePort(ushort basePort, bool checkOne, CancellationToken cancellationToken)
+		{
+			logger.LogTrace("Port allocation >= {0} requested...", basePort);
+
+			var ddPorts = await databaseContext
+				.DreamDaemonSettings
+				.AsQueryable()
+				.Select(x => x.Port)
+				.ToListAsync(cancellationToken)
+				.ConfigureAwait(false);
+
+			var dmPorts = await databaseContext
+				.DreamMakerSettings
+				.AsQueryable()
+				.Select(x => x.ApiValidationPort)
+				.ToListAsync(cancellationToken)
+				.ConfigureAwait(false);
+
+			for (var I = basePort; I < UInt16.MaxValue; ++I)
+			{
+				if (checkOne && I != basePort)
+					break;
+
+				if (I == serverPortProvider.HttpApiPort
+					|| ddPorts.Contains(I)
+					|| dmPorts.Contains(I))
+					continue;
+
+				try
+				{
+					logger.LogTrace("Bind test: {0}", I);
+					SocketExtensions.BindTest(I, false);
+				}
+				catch (Exception ex)
+				{
+					logger.LogDebug(ex, "Not using port {0}", I);
+				}
+
+				logger.LogInformation("Allocated port {0}", I);
+				return I;
+			}
+
+			logger.LogWarning("Unable to allocate port >= {0}!", basePort);
+			return null;
+		}
+	}
+}


### PR DESCRIPTION
:cl: HTTP API
Instances will now allocate and pre-check the DreamDaemon and DMAPI validation ports can be used before they are created. Added error code 93 for when none are available.
You can no longer modify DreamDaemon or DMAPI validation ports so that they would conflict with other ports in use by TGS or the system. Added error code 94 for when a conflict occurs.
/:cl:

Closes #1126