### PR TITLE
Fix that annoying Docker startup bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,22 +51,24 @@ tgstation-server supports running in a docker container and is the recommended d
 To create a container run
 ```sh
 docker run \
-	-ti \ #start interactive for manual configuration
-	--restart=always \ #if you want maximum uptime
-	--network="host" \ #if your sql server is on the same machine
-	--name="tgs" \ #or whatever else you wanna call it
-	--cap-add=sys_nice \ #allows tgs to schedule DreamDaemon as a higher priority process
-	--init \ #reaps potential zombie processes
-	-p <tgs port>:80 \
-	-p 0.0.0.0:<public game port>:<public game port> \
-	-v /path/to/your/configfile/directory:/config_data \ #only if you want to use manual configuration
-	-v /path/to/store/instances:/tgs4_instances \
-	-v /path/to/your/log/folder:/tgs_logs \
-	tgstation/server:<release version> #replace this with <your tag name> if you built the image locally
+	-ti \ # Start with interactive terminal the first time to run the setup wizard
+	--restart=always \ # Recommended for maximum uptime
+	--network="host" \ # Not recommended, eases networking setup if your sql server is on the same machine
+	--name="tgs" \ # Name for the container
+	--cap-add=sys_nice \ # Recommended, allows tgs to schedule DreamDaemon as a higher priority process
+	--init \ #Highly recommended, reaps potential zombie processes
+	-p <tgs port>:<port configured with setup wizard> \ # Port bridge for accessing TGS
+	-p 0.0.0.0:<public game port>:<public game port> \ # Port bridge for accessing DreamDaemon
+	-v /path/to/your/configfile/directory:/config_data \ # Recommended, create a volume mapping for server configuration
+	-v /path/to/store/instances:/tgs4_instances \ # Recommended, create a volume mapping for server instances
+	-v /path/to/your/log/folder:/tgs_logs \ # Recommended, create a volume mapping for server logs
+	tgstation/server[:<release version>]
 ```
 with any additional options you desire (i.e. You'll have to expose more game ports in order to host more than one instance).
 
-- Important note about port exposure: The internal port used by DreamDaemon _**MUST**_ match the port you want users to connect on. If it doesn't, you'll still be able to have them connect HOWEVER links from the BYOND hub will point at what DreamDaemon thinks the port is.
+When launching the container for the first time, you'll be prompted with the setup wizard.
+
+Important note about port exposure: The internal port used by DreamDaemon _**MUST**_ match the port you want users to connect on. If it doesn't, you'll still be able to have them connect HOWEVER links from the BYOND hub will point at what DreamDaemon thinks the port is (the internal port).
 
 Note although `/app/lib` is specified as a volume mount point in the `Dockerfile`, unless you REALLY know what you're doing. Do not mount any volumes over this for fear of breaking your container.
 

--- a/build/Version.props
+++ b/build/Version.props
@@ -9,5 +9,6 @@
     <TgsDmapiVersion>5.2.7</TgsDmapiVersion>
     <TgsControlPanelVersion>0.4.0</TgsControlPanelVersion>
     <TgsHostWatchdogVersion>1.1.0</TgsHostWatchdogVersion>
+    <TgsContainerScriptVersion>1.1.0</TgsContainerScriptVersion>
   </PropertyGroup>
 </Project>

--- a/src/Tgstation.Server.Host/apspsettings.Development.json
+++ b/src/Tgstation.Server.Host/apspsettings.Development.json
@@ -1,0 +1,34 @@
+{
+  "Database": {
+    "DatabaseType": "SqlServer",
+    "ResetAdminPassword": false,
+    "ConnectionString": "Data Source=(local);Initial Catalog=TGS_Debug2341;Integrated Security=True;Application Name=tgstation-server",
+    "DropDatabase": false,
+    "DesignTime": false,
+    "ServerVersion": null
+  },
+  "General": {
+    "ConfigVersion": "2.0.0",
+    "ApiPort": 5000,
+    "GitHubAccessToken": null,
+    "SetupWizardMode": "Never",
+    "ByondTopicTimeout": 5000,
+    "RestartTimeout": 60000,
+    "UseBasicWatchdog": false,
+    "MinimumPasswordLength": 15,
+    "InstanceLimit": 10,
+    "UserLimit": 100,
+    "ValidInstancePaths": null
+  },
+  "FileLogging": {
+    "Directory": null,
+    "Disable": false,
+    "LogLevel": "Trace",
+    "MicrosoftLogLevel": "Warning"
+  },
+  "ControlPanel": {
+    "Enable": true,
+    "AllowAnyOrigin": true,
+    "AllowedOrigins": null
+  }
+}

--- a/tests/Tgstation.Server.Tests/VersionsTest.cs
+++ b/tests/Tgstation.Server.Tests/VersionsTest.cs
@@ -1,14 +1,14 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json.Linq;
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Xml.Linq;
 using Tgstation.Server.Api;
 using Tgstation.Server.Client;
 using Tgstation.Server.Host;
 using Tgstation.Server.Host.Components.Interop;
-using Tgstation.Server.Host.Components.Watchdog;
 using Tgstation.Server.Host.Configuration;
 
 namespace Tgstation.Server.Tests
@@ -126,6 +126,18 @@ namespace Tgstation.Server.Tests
 			Assert.AreEqual(expected.Minor, actual.Minor);
 			Assert.AreEqual(expected.Build, actual.Build);
 			Assert.AreEqual(-1, actual.Revision);
+		}
+
+		[TestMethod]
+		public async Task TestContainerScriptVersion()
+		{
+			var versionString = versionsPropertyGroup.Element(xmlNamespace + "TgsContainerScriptVersion").Value;
+			Assert.IsNotNull(versionString);
+			Assert.IsTrue(Version.TryParse(versionString, out var expected));
+			var scriptLines = await File.ReadAllLinesAsync("../../../../../build/tgs.docker.sh");
+
+			var line = scriptLines.FirstOrDefault(x => x.Trim().Contains($"SCRIPT_VERSION=\"{expected.Semver()}\""));
+			Assert.IsNotNull(line);
 		}
 	}
 }


### PR DESCRIPTION
- Add container script to master version list
- Setup wizard now waits for a guaranteed config reload

:cl:
The setup wizard now waits until the confugration reloads before exiting. This caused issues where the first run of the server could possibly default to using incorrect database configurations.
/:cl:

Fixes #1138 