### PR TITLE
Fix the possibility of watchdog starting twice.

### DIFF
--- a/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
@@ -360,6 +360,8 @@ namespace Tgstation.Server.Host.Components.Watchdog
 			CancellationToken cancellationToken)
 		{
 			Logger.LogTrace("Begin LaunchImplNoLock");
+			if (startMonitor && Status != WatchdogStatus.Offline)
+				throw new JobException(ErrorCode.WatchdogRunning);
 
 			if (reattachInfo == null && !DmbFactory.DmbAvailable)
 				throw new JobException(ErrorCode.WatchdogCompileJobCorrupted);


### PR DESCRIPTION
This can happen if the initial Status check in Launch passes and blocks on the lock before Status is set to Restoring. It needs to be checked again.

:cl:
Fixed a rare race condition allowing for the internal watchdog startup to run twice and crash the monitor.
/:cl: