### PR TITLE
Adds additional null checking around test merging

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>4.6.0</TgsCoreVersion>
+    <TgsCoreVersion>4.6.1</TgsCoreVersion>
     <TgsConfigVersion>2.1.1</TgsConfigVersion>
     <TgsApiVersion>7.4.0</TgsApiVersion>
     <TgsClientVersion>8.4.0</TgsClientVersion>

--- a/src/Tgstation.Server.Host/Controllers/RepositoryController.cs
+++ b/src/Tgstation.Server.Host/Controllers/RepositoryController.cs
@@ -744,6 +744,9 @@ namespace Tgstation.Server.Host.Controllers
 											revInfoWereLookingFor = dbPull
 												.Where(testRevInfo =>
 												{
+													if (testRevInfo.PrimaryTestMerge == null)
+														return false;
+
 													var testMergeMatch = model.NewTestMerges.Any(testTestMerge =>
 													{
 														var numberMatch = testRevInfo.PrimaryTestMerge.Number == testTestMerge.Number;


### PR DESCRIPTION
Likely fixes #1127

:cl:
Fixed a NullReferenceException while test merging multiple PRs.
/:cl:

Merge with `[TGSDeploy]`