### PR TITLE
Adds Pagination and UserGroups to HTTP API

### DIFF
--- a/build/OpenApiValidationSettings.json
+++ b/build/OpenApiValidationSettings.json
@@ -4,7 +4,7 @@
       "no_operation_id": "error",
       "operation_id_case_convention": "off",
       "no_summary": "error",
-      "no_array_responses": "off",
+      "no_array_responses": "error",
       "parameter_order": "error",
       "undefined_tag": "off",
       "unused_tag": "error",

--- a/src/Tgstation.Server.Api/Models/ErrorCode.cs
+++ b/src/Tgstation.Server.Api/Models/ErrorCode.cs
@@ -250,18 +250,16 @@ namespace Tgstation.Server.Api.Models
 		RepoWhitespaceCommitterEmail,
 
 		/// <summary>
-		/// Deprecated.
+		/// A paginated request asked for too large a page.
 		/// </summary>
-		[Description("Deprecated error code.")]
-		[Obsolete("With API v7 ", true)]
-		DreamDaemonDuplicatePorts,
+		[Description("Requested pageSize is too large!")]
+		ApiPageTooLarge,
 
 		/// <summary>
-		/// Deprecated.
+		/// A paginated request asked for page 0.
 		/// </summary>
-		[Description("Deprecated error code.")]
-		[Obsolete("With DMAPI-5.0.0, ultrasafe security is now supported.", true)]
-		InvalidSecurityLevel,
+		[Description("Cannot request page or pageSize <= 0.")]
+		ApiInvalidPageOrPageSize,
 
 		/// <summary>
 		/// A requested <see cref="ChatChannel"/>'s data does not match with its <see cref="Internal.ChatBot.Provider"/>.

--- a/src/Tgstation.Server.Api/Models/Paginated.cs
+++ b/src/Tgstation.Server.Api/Models/Paginated.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace Tgstation.Server.Api.Models
+{
+	/// <summary>
+	/// Represents a paginated set of models.
+	/// </summary>
+	/// <typeparam name="TModel">The <see cref="System.Type"/> of the returned model.</typeparam>
+	public sealed class Paginated<TModel>
+	{
+		/// <summary>
+		/// The <see cref="ICollection{T}"/> of the returned <typeparamref name="TModel"/>s.
+		/// </summary>
+		[Required]
+		public ICollection<TModel>? Content { get; set; }
+
+		/// <summary>
+		/// The total number of pages in the query.
+		/// </summary>
+		public int TotalPages { get; set; }
+
+		/// <summary>
+		/// The current size of pages in the query.
+		/// </summary>
+		public int PageSize { get; set; }
+	}
+}

--- a/src/Tgstation.Server.Client/Components/ChatBotsClient.cs
+++ b/src/Tgstation.Server.Client/Components/ChatBotsClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,13 +8,8 @@ using Tgstation.Server.Api.Models;
 namespace Tgstation.Server.Client.Components
 {
 	/// <inheritdoc />
-	sealed class ChatBotsClient : IChatBotsClient
+	sealed class ChatBotsClient : PaginatedClient, IChatBotsClient
 	{
-		/// <summary>
-		/// The <see cref="IApiClient"/> for the <see cref="ChatBotsClient"/>
-		/// </summary>
-		readonly IApiClient apiClient;
-
 		/// <summary>
 		/// The <see cref="Instance"/> for the <see cref="ChatBotsClient"/>
 		/// </summary>
@@ -23,27 +18,28 @@ namespace Tgstation.Server.Client.Components
 		/// <summary>
 		/// Construct a <see cref="ChatBotsClient"/>
 		/// </summary>
-		/// <param name="apiClient">The value of <see cref="apiClient"/></param>
+		/// <param name="apiClient">The <see cref="IApiClient"/> for the <see cref="PaginatedClient"/>.</param>
 		/// <param name="instance">The value of <see cref="instance"/></param>
 		public ChatBotsClient(IApiClient apiClient, Instance instance)
+			: base(apiClient)
 		{
-			this.apiClient = apiClient ?? throw new ArgumentNullException(nameof(apiClient));
 			this.instance = instance ?? throw new ArgumentNullException(nameof(instance));
 		}
 
 		/// <inheritdoc />
-		public Task<ChatBot> Create(ChatBot settings, CancellationToken cancellationToken) => apiClient.Create<ChatBot, ChatBot>(Routes.Chat, settings ?? throw new ArgumentNullException(nameof(settings)), instance.Id, cancellationToken);
+		public Task<ChatBot> Create(ChatBot settings, CancellationToken cancellationToken) => ApiClient.Create<ChatBot, ChatBot>(Routes.Chat, settings ?? throw new ArgumentNullException(nameof(settings)), instance.Id, cancellationToken);
 
 		/// <inheritdoc />
-		public Task Delete(ChatBot settings, CancellationToken cancellationToken) => apiClient.Delete(Routes.SetID(Routes.Chat, settings?.Id ?? throw new ArgumentNullException(nameof(settings))), instance.Id, cancellationToken);
+		public Task Delete(ChatBot settings, CancellationToken cancellationToken) => ApiClient.Delete(Routes.SetID(Routes.Chat, settings?.Id ?? throw new ArgumentNullException(nameof(settings))), instance.Id, cancellationToken);
 
 		/// <inheritdoc />
-		public Task<IReadOnlyList<ChatBot>> List(CancellationToken cancellationToken) => apiClient.Read<IReadOnlyList<ChatBot>>(Routes.ListRoute(Routes.Chat), instance.Id, cancellationToken);
+		public Task<IReadOnlyList<ChatBot>> List(PaginationSettings? paginationSettings, CancellationToken cancellationToken)
+			=> ReadPaged<ChatBot>(paginationSettings, Routes.ListRoute(Routes.Chat), instance.Id, cancellationToken);
 
 		/// <inheritdoc />
-		public Task<ChatBot> Update(ChatBot settings, CancellationToken cancellationToken) => apiClient.Update<ChatBot, ChatBot>(Routes.Chat, settings ?? throw new ArgumentNullException(nameof(settings)), instance.Id, cancellationToken);
+		public Task<ChatBot> Update(ChatBot settings, CancellationToken cancellationToken) => ApiClient.Update<ChatBot, ChatBot>(Routes.Chat, settings ?? throw new ArgumentNullException(nameof(settings)), instance.Id, cancellationToken);
 
 		/// <inheritdoc />
-		public Task<ChatBot> GetId(ChatBot settings, CancellationToken cancellationToken) => apiClient.Read<ChatBot>(Routes.SetID(Routes.Chat, (settings ?? throw new ArgumentNullException(nameof(settings))).Id), instance.Id, cancellationToken);
+		public Task<ChatBot> GetId(ChatBot settings, CancellationToken cancellationToken) => ApiClient.Read<ChatBot>(Routes.SetID(Routes.Chat, (settings ?? throw new ArgumentNullException(nameof(settings))).Id), instance.Id, cancellationToken);
 	}
 }

--- a/src/Tgstation.Server.Client/Components/ConfigurationClient.cs
+++ b/src/Tgstation.Server.Client/Components/ConfigurationClient.cs
@@ -9,13 +9,8 @@ using Tgstation.Server.Api.Models;
 namespace Tgstation.Server.Client.Components
 {
 	/// <inheritdoc />
-	sealed class ConfigurationClient : IConfigurationClient
+	sealed class ConfigurationClient : PaginatedClient, IConfigurationClient
 	{
-		/// <summary>
-		/// The <see cref="IApiClient"/> for the <see cref="ConfigurationClient"/>
-		/// </summary>
-		readonly IApiClient apiClient;
-
 		/// <summary>
 		/// The <see cref="Instance"/> for the <see cref="ConfigurationClient"/>
 		/// </summary>
@@ -24,34 +19,42 @@ namespace Tgstation.Server.Client.Components
 		/// <summary>
 		/// Construct a <see cref="ConfigurationClient"/>
 		/// </summary>
-		/// <param name="apiClient">The value of <see cref="apiClient"/></param>
+		/// <param name="apiClient">The <see cref="IApiClient"/> for the <see cref="PaginatedClient"/>.</param>
 		/// <param name="instance">The value of <see cref="instance"/></param>
 		public ConfigurationClient(IApiClient apiClient, Instance instance)
+			: base(apiClient)
 		{
-			this.apiClient = apiClient ?? throw new ArgumentNullException(nameof(apiClient));
 			this.instance = instance ?? throw new ArgumentNullException(nameof(instance));
 		}
 
 		/// <inheritdoc />
-		public Task DeleteEmptyDirectory(ConfigurationFile directory, CancellationToken cancellationToken) => apiClient.Delete(Routes.Configuration, directory, instance.Id, cancellationToken);
+		public Task DeleteEmptyDirectory(ConfigurationFile directory, CancellationToken cancellationToken) => ApiClient.Delete(Routes.Configuration, directory, instance.Id, cancellationToken);
 
 		/// <inheritdoc />
-		public Task<ConfigurationFile> CreateDirectory(ConfigurationFile directory, CancellationToken cancellationToken) => apiClient.Create<ConfigurationFile, ConfigurationFile>(Routes.Configuration, directory, instance.Id, cancellationToken);
+		public Task<ConfigurationFile> CreateDirectory(ConfigurationFile directory, CancellationToken cancellationToken) => ApiClient.Create<ConfigurationFile, ConfigurationFile>(Routes.Configuration, directory, instance.Id, cancellationToken);
 
 		/// <inheritdoc />
-		public Task<IReadOnlyList<ConfigurationFile>> List(string directory, CancellationToken cancellationToken) => apiClient.Read<IReadOnlyList<ConfigurationFile>>(Routes.ListRoute(Routes.Configuration) + Routes.SanitizeGetPath(directory), instance.Id, cancellationToken);
+		public Task<IReadOnlyList<ConfigurationFile>> List(
+			PaginationSettings? paginationSettings,
+			string directory,
+			CancellationToken cancellationToken)
+			=> ReadPaged<ConfigurationFile>(
+				paginationSettings,
+				Routes.ListRoute(Routes.Configuration) + Routes.SanitizeGetPath(directory),
+				instance.Id,
+				cancellationToken);
 
 		/// <inheritdoc />
 		public async Task<Tuple<ConfigurationFile, Stream>> Read(ConfigurationFile file, CancellationToken cancellationToken)
 		{
 			if (file == null)
 				throw new ArgumentNullException(nameof(file));
-			var configFile = await apiClient.Read<ConfigurationFile>(
+			var configFile = await ApiClient.Read<ConfigurationFile>(
 				Routes.ConfigurationFile + Routes.SanitizeGetPath(file.Path ?? throw new ArgumentException("file.Path should not be null!", nameof(file))),
 				instance.Id,
 				cancellationToken)
 				.ConfigureAwait(false);
-			var downloadStream = await apiClient.Download(configFile, cancellationToken).ConfigureAwait(false);
+			var downloadStream = await ApiClient.Download(configFile, cancellationToken).ConfigureAwait(false);
 			try
 			{
 				return Tuple.Create(configFile, downloadStream);
@@ -75,7 +78,7 @@ namespace Tgstation.Server.Client.Components
 
 			using (memoryStream)
 			{
-				var configFileTask = apiClient.Update<ConfigurationFile, ConfigurationFile>(
+				var configFileTask = ApiClient.Update<ConfigurationFile, ConfigurationFile>(
 					Routes.Configuration,
 					file ?? throw new ArgumentNullException(nameof(file)),
 					instance.Id,
@@ -88,7 +91,7 @@ namespace Tgstation.Server.Client.Components
 
 				var streamUsed = memoryStream ?? uploadStream;
 				streamUsed?.Seek(initialStreamPosition, SeekOrigin.Begin);
-				await apiClient.Upload(configFile, streamUsed, cancellationToken).ConfigureAwait(false);
+				await ApiClient.Upload(configFile, streamUsed, cancellationToken).ConfigureAwait(false);
 
 				return configFile;
 			}

--- a/src/Tgstation.Server.Client/Components/DreamMakerClient.cs
+++ b/src/Tgstation.Server.Client/Components/DreamMakerClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,13 +8,8 @@ using Tgstation.Server.Api.Models;
 namespace Tgstation.Server.Client.Components
 {
 	/// <inheritdoc />
-	sealed class DreamMakerClient : IDreamMakerClient
+	sealed class DreamMakerClient : PaginatedClient, IDreamMakerClient
 	{
-		/// <summary>
-		/// The <see cref="IApiClient"/> for the <see cref="DreamMakerClient"/>
-		/// </summary>
-		readonly IApiClient apiClient;
-
 		/// <summary>
 		/// The <see cref="Instance"/> for the <see cref="DreamMakerClient"/>
 		/// </summary>
@@ -23,27 +18,28 @@ namespace Tgstation.Server.Client.Components
 		/// <summary>
 		/// Construct a <see cref="DreamMakerClient"/>
 		/// </summary>
-		/// <param name="apiClient">The value of <see cref="apiClient"/></param>
+		/// <param name="apiClient">The <see cref="IApiClient"/> for the <see cref="PaginatedClient"/>.</param>
 		/// <param name="instance">The value of <see cref="Instance"/></param>
 		public DreamMakerClient(IApiClient apiClient, Instance instance)
+			: base(apiClient)
 		{
-			this.apiClient = apiClient ?? throw new ArgumentNullException(nameof(apiClient));
 			this.instance = instance ?? throw new ArgumentNullException(nameof(instance));
 		}
 
 		/// <inheritdoc />
-		public Task<Job> Compile(CancellationToken cancellationToken) => apiClient.Create<Job>(Routes.DreamMaker, instance.Id, cancellationToken);
+		public Task<Job> Compile(CancellationToken cancellationToken) => ApiClient.Create<Job>(Routes.DreamMaker, instance.Id, cancellationToken);
 
 		/// <inheritdoc />
-		public Task<CompileJob> GetCompileJob(EntityId compileJob, CancellationToken cancellationToken) => apiClient.Read<CompileJob>(Routes.SetID(Routes.DreamMaker, compileJob?.Id ?? throw new ArgumentNullException(nameof(compileJob))), instance.Id, cancellationToken);
+		public Task<CompileJob> GetCompileJob(EntityId compileJob, CancellationToken cancellationToken) => ApiClient.Read<CompileJob>(Routes.SetID(Routes.DreamMaker, compileJob?.Id ?? throw new ArgumentNullException(nameof(compileJob))), instance.Id, cancellationToken);
 
 		/// <inheritdoc />
-		public Task<IReadOnlyList<EntityId>> GetJobIds(CancellationToken cancellationToken) => apiClient.Read<IReadOnlyList<EntityId>>(Routes.ListRoute(Routes.DreamMaker), instance.Id, cancellationToken);
+		public Task<IReadOnlyList<EntityId>> ListCompileJobs(PaginationSettings? paginationSettings, CancellationToken cancellationToken)
+			=> ReadPaged<EntityId>(paginationSettings, Routes.ListRoute(Routes.DreamMaker), instance.Id, cancellationToken);
 
 		/// <inheritdoc />
-		public Task<DreamMaker> Read(CancellationToken cancellationToken) => apiClient.Read<DreamMaker>(Routes.DreamMaker, instance.Id, cancellationToken);
+		public Task<DreamMaker> Read(CancellationToken cancellationToken) => ApiClient.Read<DreamMaker>(Routes.DreamMaker, instance.Id, cancellationToken);
 
 		/// <inheritdoc />
-		public Task<DreamMaker> Update(DreamMaker dreamMaker, CancellationToken cancellationToken) => apiClient.Update<DreamMaker, DreamMaker>(Routes.DreamMaker, dreamMaker ?? throw new ArgumentNullException(nameof(dreamMaker)), instance.Id, cancellationToken);
+		public Task<DreamMaker> Update(DreamMaker dreamMaker, CancellationToken cancellationToken) => ApiClient.Update<DreamMaker, DreamMaker>(Routes.DreamMaker, dreamMaker ?? throw new ArgumentNullException(nameof(dreamMaker)), instance.Id, cancellationToken);
 	}
 }

--- a/src/Tgstation.Server.Client/Components/IByondClient.cs
+++ b/src/Tgstation.Server.Client/Components/IByondClient.cs
@@ -21,9 +21,10 @@ namespace Tgstation.Server.Client.Components
 		/// <summary>
 		/// Get all installed <see cref="Byond"/> <see cref="System.Version"/>s
 		/// </summary>
+		/// <param name="paginationSettings">The optional <see cref="PaginationSettings"/> for the operation.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in an <see cref="IReadOnlyList{T}"/> of installed <see cref="Byond"/> <see cref="System.Version"/>s</returns>
-		Task<IReadOnlyList<Byond>> InstalledVersions(CancellationToken cancellationToken);
+		Task<IReadOnlyList<Byond>> InstalledVersions(PaginationSettings? paginationSettings, CancellationToken cancellationToken);
 
 		/// <summary>
 		/// Updates the <see cref="Byond"/> information

--- a/src/Tgstation.Server.Client/Components/IChatBotsClient.cs
+++ b/src/Tgstation.Server.Client/Components/IChatBotsClient.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Tgstation.Server.Api.Models;
@@ -13,9 +13,10 @@ namespace Tgstation.Server.Client.Components
 		/// <summary>
 		/// List the <see cref="ChatBot"/>s
 		/// </summary>
+		/// <param name="paginationSettings">The optional <see cref="PaginationSettings"/> for the operation.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in a <see cref="IReadOnlyList{T}"/> of the <see cref="ChatBot"/> of the server</returns>
-		Task<IReadOnlyList<ChatBot>> List(CancellationToken cancellationToken);
+		Task<IReadOnlyList<ChatBot>> List(PaginationSettings? paginationSettings, CancellationToken cancellationToken);
 
 		/// <summary>
 		/// Create a <see cref="ChatBot"/>

--- a/src/Tgstation.Server.Client/Components/IConfigurationClient.cs
+++ b/src/Tgstation.Server.Client/Components/IConfigurationClient.cs
@@ -15,10 +15,14 @@ namespace Tgstation.Server.Client.Components
 		/// <summary>
 		/// List configuration files
 		/// </summary>
+		/// <param name="paginationSettings">The optional <see cref="PaginationSettings"/> for the operation.</param>
 		/// <param name="directory">The path to the directory to list files in</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="IReadOnlyList{T}"/> of <see cref="ConfigurationFile"/>s in the <paramref name="directory"/></returns>
-		Task<IReadOnlyList<ConfigurationFile>> List(string directory, CancellationToken cancellationToken);
+		Task<IReadOnlyList<ConfigurationFile>> List(
+			PaginationSettings? paginationSettings,
+			string directory,
+			CancellationToken cancellationToken);
 
 		/// <summary>
 		/// Read a <see cref="ConfigurationFile"/> file

--- a/src/Tgstation.Server.Client/Components/IDreamMakerClient.cs
+++ b/src/Tgstation.Server.Client/Components/IDreamMakerClient.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Tgstation.Server.Api.Models;
@@ -33,11 +33,12 @@ namespace Tgstation.Server.Client.Components
 		Task<Job> Compile(CancellationToken cancellationToken);
 
 		/// <summary>
-		/// Gets the <see cref="EntityId"/>s of all <see cref="CompileJob"/>s for the instance
+		/// Gets the <see cref="CompileJob"/>s for the instance
 		/// </summary>
+		/// <param name="paginationSettings">The optional <see cref="PaginationSettings"/> for the operation.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in a <see cref="IReadOnlyList{T}"/> of <see cref="CompileJob"/> <see cref="EntityId"/>s.</returns>
-		Task<IReadOnlyList<EntityId>> GetJobIds(CancellationToken cancellationToken);
+		Task<IReadOnlyList<EntityId>> ListCompileJobs(PaginationSettings? paginationSettings, CancellationToken cancellationToken);
 
 		/// <summary>
 		/// Get a <paramref name="compileJob"/>

--- a/src/Tgstation.Server.Client/Components/IInstanceUserClient.cs
+++ b/src/Tgstation.Server.Client/Components/IInstanceUserClient.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Tgstation.Server.Api.Models;
@@ -28,9 +28,10 @@ namespace Tgstation.Server.Client.Components
 		/// <summary>
 		/// Get the <see cref="InstanceUser"/>s in the <see cref="Instance"/>
 		/// </summary>
+		/// <param name="paginationSettings">The optional <see cref="PaginationSettings"/> for the operation.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in a <see cref="IReadOnlyList{T}"/> of <see cref="InstanceUser"/>s in the instance</returns>
-		Task<IReadOnlyList<InstanceUser>> List(CancellationToken cancellationToken);
+		Task<IReadOnlyList<InstanceUser>> List(PaginationSettings? paginationSettings, CancellationToken cancellationToken);
 
 		/// <summary>
 		/// Update a <paramref name="instanceUser"/>

--- a/src/Tgstation.Server.Client/Components/IJobsClient.cs
+++ b/src/Tgstation.Server.Client/Components/IJobsClient.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Tgstation.Server.Api.Models;
@@ -11,18 +11,20 @@ namespace Tgstation.Server.Client.Components
 	public interface IJobsClient
 	{
 		/// <summary>
-		/// List the <see cref="Job"/> <see cref="EntityId"/>s in the <see cref="Instance"/>
+		/// List the <see cref="Job"/>s in the <see cref="Instance"/>
 		/// </summary>
+		/// <param name="paginationSettings">The optional <see cref="PaginationSettings"/> for the operation.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in a <see cref="IReadOnlyList{T}"/> of the <see cref="Job"/> <see cref="EntityId"/>s in the <see cref="Instance"/></returns>
-		Task<IReadOnlyList<EntityId>> List(CancellationToken cancellationToken);
+		Task<IReadOnlyList<Job>> List(PaginationSettings? paginationSettings, CancellationToken cancellationToken);
 
 		/// <summary>
 		/// List the active <see cref="Job"/>s in the <see cref="Instance"/>
 		/// </summary>
+		/// <param name="paginationSettings">The optional <see cref="PaginationSettings"/> for the operation.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in a <see cref="IReadOnlyList{T}"/> of the active <see cref="Job"/>s in the <see cref="Instance"/></returns>
-		Task<IReadOnlyList<Job>> ListActive(CancellationToken cancellationToken);
+		Task<IReadOnlyList<Job>> ListActive(PaginationSettings? paginationSettings, CancellationToken cancellationToken);
 
 		/// <summary>
 		/// Get a <paramref name="job"/>

--- a/src/Tgstation.Server.Client/Components/InstanceUserClient.cs
+++ b/src/Tgstation.Server.Client/Components/InstanceUserClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,13 +8,8 @@ using Tgstation.Server.Api.Models;
 namespace Tgstation.Server.Client.Components
 {
 	/// <inheritdoc />
-	sealed class InstanceUserClient : IInstanceUserClient
+	sealed class InstanceUserClient : PaginatedClient, IInstanceUserClient
 	{
-		/// <summary>
-		/// The <see cref="IApiClient"/> for the <see cref="InstanceUserClient"/>
-		/// </summary>
-		readonly IApiClient apiClient;
-
 		/// <summary>
 		/// The <see cref="Instance"/> for the <see cref="InstanceUserClient"/>
 		/// </summary>
@@ -23,19 +18,19 @@ namespace Tgstation.Server.Client.Components
 		/// <summary>
 		/// Construct an <see cref="InstanceUserClient"/>
 		/// </summary>
-		/// <param name="apiClient">The value of <see cref="apiClient"/></param>
+		/// <param name="apiClient">The <see cref="IApiClient"/> for the <see cref="PaginatedClient"/>.</param>
 		/// <param name="instance">The value of <see cref="instance"/></param>
 		public InstanceUserClient(IApiClient apiClient, Instance instance)
+			: base(apiClient)
 		{
-			this.apiClient = apiClient ?? throw new ArgumentNullException(nameof(apiClient));
 			this.instance = instance ?? throw new ArgumentNullException(nameof(instance));
 		}
 
 		/// <inheritdoc />
-		public Task<InstanceUser> Create(InstanceUser instanceUser, CancellationToken cancellationToken) => apiClient.Create<InstanceUser, InstanceUser>(Routes.InstanceUser, instanceUser ?? throw new ArgumentNullException(nameof(instanceUser)), instance.Id, cancellationToken);
+		public Task<InstanceUser> Create(InstanceUser instanceUser, CancellationToken cancellationToken) => ApiClient.Create<InstanceUser, InstanceUser>(Routes.InstanceUser, instanceUser ?? throw new ArgumentNullException(nameof(instanceUser)), instance.Id, cancellationToken);
 
 		/// <inheritdoc />
-		public Task Delete(InstanceUser instanceUser, CancellationToken cancellationToken) => apiClient.Delete(
+		public Task Delete(InstanceUser instanceUser, CancellationToken cancellationToken) => ApiClient.Delete(
 			Routes.SetID(
 				Routes.InstanceUser,
 				instanceUser.UserId),
@@ -43,15 +38,16 @@ namespace Tgstation.Server.Client.Components
 			cancellationToken);
 
 		/// <inheritdoc />
-		public Task<InstanceUser> Read(CancellationToken cancellationToken) => apiClient.Read<InstanceUser>(Routes.InstanceUser, instance.Id, cancellationToken);
+		public Task<InstanceUser> Read(CancellationToken cancellationToken) => ApiClient.Read<InstanceUser>(Routes.InstanceUser, instance.Id, cancellationToken);
 
 		/// <inheritdoc />
-		public Task<InstanceUser> Update(InstanceUser instanceUser, CancellationToken cancellationToken) => apiClient.Update<InstanceUser, InstanceUser>(Routes.InstanceUser, instanceUser ?? throw new ArgumentNullException(nameof(instanceUser)), instance.Id, cancellationToken);
+		public Task<InstanceUser> Update(InstanceUser instanceUser, CancellationToken cancellationToken) => ApiClient.Update<InstanceUser, InstanceUser>(Routes.InstanceUser, instanceUser ?? throw new ArgumentNullException(nameof(instanceUser)), instance.Id, cancellationToken);
 
 		/// <inheritdoc />
-		public Task<IReadOnlyList<InstanceUser>> List(CancellationToken cancellationToken) => apiClient.Read<IReadOnlyList<InstanceUser>>(Routes.ListRoute(Routes.InstanceUser), instance.Id, cancellationToken);
+		public Task<IReadOnlyList<InstanceUser>> List(PaginationSettings? paginationSettings, CancellationToken cancellationToken)
+			=> ReadPaged<InstanceUser>(paginationSettings, Routes.ListRoute(Routes.InstanceUser), instance.Id, cancellationToken);
 
 		/// <inheritdoc />
-		public Task<InstanceUser> GetId(InstanceUser instanceUser, CancellationToken cancellationToken) => apiClient.Read<InstanceUser>(Routes.SetID(Routes.InstanceUser, instanceUser?.UserId ?? throw new ArgumentNullException(nameof(instanceUser))), instance.Id, cancellationToken);
+		public Task<InstanceUser> GetId(InstanceUser instanceUser, CancellationToken cancellationToken) => ApiClient.Read<InstanceUser>(Routes.SetID(Routes.InstanceUser, instanceUser?.UserId ?? throw new ArgumentNullException(nameof(instanceUser))), instance.Id, cancellationToken);
 	}
 }

--- a/src/Tgstation.Server.Client/Components/JobsClient.cs
+++ b/src/Tgstation.Server.Client/Components/JobsClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,13 +8,8 @@ using Tgstation.Server.Api.Models;
 namespace Tgstation.Server.Client.Components
 {
 	/// <inheritdoc />
-	sealed class JobsClient : IJobsClient
+	sealed class JobsClient : PaginatedClient, IJobsClient
 	{
-		/// <summary>
-		/// The <see cref="IApiClient"/> for the <see cref="JobsClient"/>
-		/// </summary>
-		readonly IApiClient apiClient;
-
 		/// <summary>
 		/// The <see cref="Instance"/> for the <see cref="JobsClient"/>
 		/// </summary>
@@ -23,24 +18,26 @@ namespace Tgstation.Server.Client.Components
 		/// <summary>
 		/// Construct a <see cref="JobsClient"/>
 		/// </summary>
-		/// <param name="apiClient">The value of <see cref="apiClient"/></param>
+		/// <param name="apiClient">The <see cref="IApiClient"/> for the <see cref="PaginatedClient"/>.</param>
 		/// <param name="instance">The value of <see cref="Instance"/></param>
 		public JobsClient(IApiClient apiClient, Instance instance)
+			: base(apiClient)
 		{
-			this.apiClient = apiClient ?? throw new ArgumentNullException(nameof(apiClient));
 			this.instance = instance ?? throw new ArgumentNullException(nameof(instance));
 		}
 
 		/// <inheritdoc />
-		public Task Cancel(Job job, CancellationToken cancellationToken) => apiClient.Delete(Routes.SetID(Routes.Jobs, job?.Id ?? throw new ArgumentNullException(nameof(job))), instance.Id, cancellationToken);
+		public Task Cancel(Job job, CancellationToken cancellationToken) => ApiClient.Delete(Routes.SetID(Routes.Jobs, job?.Id ?? throw new ArgumentNullException(nameof(job))), instance.Id, cancellationToken);
 
 		/// <inheritdoc />
-		public Task<IReadOnlyList<EntityId>> List(CancellationToken cancellationToken) => apiClient.Read<IReadOnlyList<EntityId>>(Routes.ListRoute(Routes.Jobs), instance.Id, cancellationToken);
+		public Task<IReadOnlyList<Job>> List(PaginationSettings? paginationSettings, CancellationToken cancellationToken)
+			=> ReadPaged<Job>(paginationSettings, Routes.ListRoute(Routes.Jobs), instance.Id, cancellationToken);
 
 		/// <inheritdoc />
-		public Task<IReadOnlyList<Job>> ListActive(CancellationToken cancellationToken) => apiClient.Read<IReadOnlyList<Job>>(Routes.Jobs, instance.Id, cancellationToken);
+		public Task<IReadOnlyList<Job>> ListActive(PaginationSettings? paginationSettings, CancellationToken cancellationToken)
+			=> ReadPaged<Job>(paginationSettings, Routes.Jobs, instance.Id, cancellationToken);
 
 		/// <inheritdoc />
-		public Task<Job> GetId(EntityId job, CancellationToken cancellationToken) => apiClient.Read<Job>(Routes.SetID(Routes.Jobs, job?.Id ?? throw new ArgumentNullException(nameof(job))), instance.Id, cancellationToken);
+		public Task<Job> GetId(EntityId job, CancellationToken cancellationToken) => ApiClient.Read<Job>(Routes.SetID(Routes.Jobs, job?.Id ?? throw new ArgumentNullException(nameof(job))), instance.Id, cancellationToken);
 	}
 }

--- a/src/Tgstation.Server.Client/IAdministrationClient.cs
+++ b/src/Tgstation.Server.Client/IAdministrationClient.cs
@@ -37,9 +37,10 @@ namespace Tgstation.Server.Client
 		/// <summary>
 		/// Lists the log files available for download.
 		/// </summary>
+		/// <param name="paginationSettings">The optional <see cref="PaginationSettings"/> for the operation.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in an <see cref="IReadOnlyList{T}"/> of <see cref="LogFile"/> metadata.</returns>
-		Task<IReadOnlyList<LogFile>> ListLogs(CancellationToken cancellationToken);
+		Task<IReadOnlyList<LogFile>> ListLogs(PaginationSettings? paginationSettings, CancellationToken cancellationToken);
 
 		/// <summary>
 		/// Download a given <paramref name="logFile"/>.

--- a/src/Tgstation.Server.Client/IInstanceManagerClient.cs
+++ b/src/Tgstation.Server.Client/IInstanceManagerClient.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Tgstation.Server.Api.Models;
@@ -14,9 +14,10 @@ namespace Tgstation.Server.Client
 		/// <summary>
 		/// Get all <see cref="IInstanceClient"/>s for <see cref="Instance"/>s the user can view
 		/// </summary>
+		/// <param name="paginationSettings">The optional <see cref="PaginationSettings"/> for the operation.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in a <see cref="IReadOnlyList{T}"/> of all <see cref="Instance"/>s the user can view</returns>
-		Task<IReadOnlyList<Instance>> List(CancellationToken cancellationToken);
+		Task<IReadOnlyList<Instance>> List(PaginationSettings? paginationSettings, CancellationToken cancellationToken);
 
 		/// <summary>
 		/// Create or attach an <paramref name="instance"/>

--- a/src/Tgstation.Server.Client/IUsersClient.cs
+++ b/src/Tgstation.Server.Client/IUsersClient.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Tgstation.Server.Api.Models;
@@ -28,9 +28,10 @@ namespace Tgstation.Server.Client
 		/// <summary>
 		/// List all <see cref="User"/>s
 		/// </summary>
+		/// <param name="paginationSettings">The optional <see cref="PaginationSettings"/> for the operation.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in a <see cref="IReadOnlyList{T}"/> of all <see cref="User"/>s</returns>
-		Task<IReadOnlyList<User>> List(CancellationToken cancellationToken);
+		Task<IReadOnlyList<User>> List(PaginationSettings? paginationSettings, CancellationToken cancellationToken);
 
 		/// <summary>
 		/// Create a new <paramref name="user"/>

--- a/src/Tgstation.Server.Client/InstanceManagerClient.cs
+++ b/src/Tgstation.Server.Client/InstanceManagerClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -9,41 +9,36 @@ using Tgstation.Server.Client.Components;
 namespace Tgstation.Server.Client
 {
 	/// <inheritdoc />
-	sealed class InstanceManagerClient : IInstanceManagerClient
+	sealed class InstanceManagerClient : PaginatedClient, IInstanceManagerClient
 	{
-		/// <summary>
-		/// The <see cref="IApiClient"/> for the <see cref="InstanceManagerClient"/>
-		/// </summary>
-		readonly IApiClient apiClient;
-
 		/// <summary>
 		/// Construct an <see cref="InstanceManagerClient"/>
 		/// </summary>
-		/// <param name="apiClient">The value of <see cref="apiClient"/></param>
+		/// <param name="apiClient">The <see cref="IApiClient"/> for the <see cref="PaginatedClient"/>.</param>
 		public InstanceManagerClient(IApiClient apiClient)
-		{
-			this.apiClient = apiClient ?? throw new ArgumentNullException(nameof(apiClient));
-		}
+			: base(apiClient)
+		{ }
 
 		/// <inheritdoc />
-		public Task<Instance> CreateOrAttach(Instance instance, CancellationToken cancellationToken) => apiClient.Create<Instance, Instance>(Routes.InstanceManager, instance ?? throw new ArgumentNullException(nameof(instance)), cancellationToken);
+		public Task<Instance> CreateOrAttach(Instance instance, CancellationToken cancellationToken) => ApiClient.Create<Instance, Instance>(Routes.InstanceManager, instance ?? throw new ArgumentNullException(nameof(instance)), cancellationToken);
 
 		/// <inheritdoc />
-		public Task Detach(Instance instance, CancellationToken cancellationToken) => apiClient.Delete(Routes.SetID(Routes.InstanceManager, instance?.Id ?? throw new ArgumentNullException(nameof(instance))), cancellationToken);
+		public Task Detach(Instance instance, CancellationToken cancellationToken) => ApiClient.Delete(Routes.SetID(Routes.InstanceManager, instance?.Id ?? throw new ArgumentNullException(nameof(instance))), cancellationToken);
 
 		/// <inheritdoc />
-		public Task<IReadOnlyList<Instance>> List(CancellationToken cancellationToken) => apiClient.Read<IReadOnlyList<Instance>>(Routes.ListRoute(Routes.InstanceManager), cancellationToken);
+		public Task<IReadOnlyList<Instance>> List(PaginationSettings? paginationSettings, CancellationToken cancellationToken)
+			=> ReadPaged<Instance>(paginationSettings, Routes.ListRoute(Routes.InstanceManager), null, cancellationToken);
 
 		/// <inheritdoc />
-		public Task<Instance> Update(Instance instance, CancellationToken cancellationToken) => apiClient.Update<Instance, Instance>(Routes.InstanceManager, instance ?? throw new ArgumentNullException(nameof(instance)), cancellationToken);
+		public Task<Instance> Update(Instance instance, CancellationToken cancellationToken) => ApiClient.Update<Instance, Instance>(Routes.InstanceManager, instance ?? throw new ArgumentNullException(nameof(instance)), cancellationToken);
 
 		/// <inheritdoc />
-		public Task<Instance> GetId(Instance instance, CancellationToken cancellationToken) => apiClient.Read<Instance>(Routes.SetID(Routes.InstanceManager, instance?.Id ?? throw new ArgumentNullException(nameof(instance))), cancellationToken);
+		public Task<Instance> GetId(Instance instance, CancellationToken cancellationToken) => ApiClient.Read<Instance>(Routes.SetID(Routes.InstanceManager, instance?.Id ?? throw new ArgumentNullException(nameof(instance))), cancellationToken);
 
 		/// <inheritdoc />
-		public Task GrantPermissions(Instance instance, CancellationToken cancellationToken) => apiClient.Patch(Routes.SetID(Routes.InstanceManager, instance?.Id ?? throw new ArgumentNullException(nameof(instance))), cancellationToken);
+		public Task GrantPermissions(Instance instance, CancellationToken cancellationToken) => ApiClient.Patch(Routes.SetID(Routes.InstanceManager, instance?.Id ?? throw new ArgumentNullException(nameof(instance))), cancellationToken);
 
 		/// <inheritdoc />
-		public IInstanceClient CreateClient(Instance instance) => new InstanceClient(apiClient, instance);
+		public IInstanceClient CreateClient(Instance instance) => new InstanceClient(ApiClient, instance);
 	}
 }

--- a/src/Tgstation.Server.Client/PaginatedClient.cs
+++ b/src/Tgstation.Server.Client/PaginatedClient.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Tgstation.Server.Api.Models;
+
+namespace Tgstation.Server.Client
+{
+	/// <summary>
+	/// Client that deals with getting paginated results.
+	/// </summary>
+	abstract class PaginatedClient
+	{
+		/// <summary>
+		/// The <see cref="IApiClient"/> for the <see cref="PaginatedClient"/>
+		/// </summary>
+		protected IApiClient ApiClient { get; }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="PaginatedClient"/> <see langword="class"/>.
+		/// </summary>
+		/// <param name="apiClient">The value of <see cref="ApiClient"/>.</param>
+		public PaginatedClient(IApiClient apiClient)
+		{
+			ApiClient = apiClient ?? throw new ArgumentNullException(nameof(apiClient));
+		}
+
+		/// <summary>
+		/// Reads a given <paramref name="route"/> with paged results.
+		/// </summary>
+		/// <typeparam name="TModel">The <see cref="Type"/> of result model.</typeparam>
+		/// <param name="paginationSettings">The <see cref="PaginationSettings"/> if any.</param>
+		/// <param name="route">The route.</param>
+		/// <param name="instanceId">The optional <see cref="Instance"/> <see cref="EntityId.Id"/>.</param>
+		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
+		/// <returns>A <see cref="Task{TResult}"/> resulting in an <see cref="IReadOnlyList{T}"/> of the paginated <typeparamref name="TModel"/>s.</returns>
+		protected async Task<IReadOnlyList<TModel>> ReadPaged<TModel>(
+			PaginationSettings? paginationSettings,
+			string route,
+			long? instanceId,
+			CancellationToken cancellationToken)
+		{
+			if (route == null)
+				throw new ArgumentNullException(nameof(route));
+
+			var routeFormatter = $"{route}?page={{0}}";
+			var currentPage = 1;
+			if (paginationSettings != null)
+			{
+				if (paginationSettings.RetrieveCount == 0)
+					return new List<TModel>(); // that was easy
+				else if (paginationSettings.RetrieveCount < 0)
+					throw new ArgumentOutOfRangeException("RetrieveCount cannot be less than 0!", nameof(paginationSettings));
+
+				int? pageSize = null;
+				if (paginationSettings.PageSize.HasValue)
+				{
+					// pagesize validates itself on first request
+					pageSize = paginationSettings.PageSize.Value;
+					routeFormatter += $"&pageSize={pageSize}";
+				}
+
+				if (paginationSettings.Offset.HasValue)
+				{
+					if(paginationSettings.Offset.Value < 0)
+						throw new ArgumentOutOfRangeException("Offset cannot be less than 0!", nameof(paginationSettings));
+
+					pageSize ??= paginationSettings.Offset.Value;
+					currentPage = (paginationSettings.Offset.Value / pageSize.Value) + 1;
+				}
+			}
+
+			Task<Paginated<TModel>> GetPage() => instanceId.HasValue
+				? ApiClient.Read<Paginated<TModel>>(
+					String.Format(routeFormatter, currentPage),
+					instanceId.Value,
+					cancellationToken)
+				: ApiClient.Read<Paginated<TModel>>(
+					String.Format(routeFormatter, currentPage),
+					cancellationToken);
+
+			var firstPage = await GetPage().ConfigureAwait(false);
+
+			var totalAvailable = firstPage.TotalPages * firstPage.PageSize;
+			var maximumItems = paginationSettings?.RetrieveCount.HasValue == true
+				? Math.Min(paginationSettings.RetrieveCount!.Value, totalAvailable)
+				: totalAvailable;
+
+			var results = new List<TModel>(maximumItems);
+			var currentResults = firstPage;
+			do
+			{
+				// check if first page
+				if(currentPage > 1)
+					currentResults = await GetPage().ConfigureAwait(false);
+
+				if (currentResults.Content == null)
+					throw new ApiConflictException("Paginated results missing content!");
+
+				IEnumerable<TModel> rangeToAdd = currentResults.Content;
+				if (paginationSettings?.Offset.HasValue == true)
+				{
+					rangeToAdd = rangeToAdd
+						.Skip(paginationSettings.Offset!.Value % currentResults.PageSize);
+				}
+
+				var itemsAvailableInPage = rangeToAdd.Count();
+				var itemsStillRequired = maximumItems - results.Count;
+				if (itemsAvailableInPage > itemsStillRequired)
+					rangeToAdd = rangeToAdd
+						.Take(itemsStillRequired);
+
+				results.AddRange(rangeToAdd);
+				++currentPage;
+			}
+			while (results.Count < maximumItems && currentPage <= currentResults.TotalPages);
+
+			return results;
+		}
+	}
+}

--- a/src/Tgstation.Server.Client/PaginationSettings.cs
+++ b/src/Tgstation.Server.Client/PaginationSettings.cs
@@ -1,0 +1,24 @@
+namespace Tgstation.Server.Client
+{
+	/// <summary>
+	/// Settings for a paginated request.
+	/// </summary>
+	public sealed class PaginationSettings
+	{
+		/// <summary>
+		/// The size of a page. Defaults to server settings.
+		/// </summary>
+		public int? PageSize { get; set; }
+
+		/// <summary>
+		/// The offset to take from. Default 0.
+		/// </summary>
+		public int? Offset { get; set; }
+
+		/// <summary>
+		/// The maximum amount of items to retrieve. Default everything.
+		/// </summary>
+		/// <remarks>Results will be truncated if overflow occurs due to <see cref="PageSize"/>.</remarks>
+		public int? RetrieveCount { get; set; }
+	}
+}

--- a/src/Tgstation.Server.Client/UsersClient.cs
+++ b/src/Tgstation.Server.Client/UsersClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,35 +8,31 @@ using Tgstation.Server.Api.Models;
 namespace Tgstation.Server.Client
 {
 	/// <inheritdoc />
-	sealed class UsersClient : IUsersClient
+	sealed class UsersClient : PaginatedClient, IUsersClient
 	{
-		/// <summary>
-		/// The <see cref="apiClient"/> for the <see cref="UsersClient"/>
-		/// </summary>
-		readonly IApiClient apiClient;
-
 		/// <summary>
 		/// Construct an <see cref="UsersClient"/>
 		/// </summary>
-		/// <param name="apiClient">The value of <see cref="apiClient"/></param>
+		/// <param name="apiClient">The <see cref="IApiClient"/> for the <see cref="PaginatedClient"/>.</param>
 		public UsersClient(IApiClient apiClient)
+			: base(apiClient)
 		{
-			this.apiClient = apiClient ?? throw new ArgumentNullException(nameof(apiClient));
 		}
 
 		/// <inheritdoc />
-		public Task<User> Create(UserUpdate user, CancellationToken cancellationToken) => apiClient.Create<UserUpdate, User>(Routes.User, user ?? throw new ArgumentNullException(nameof(user)), cancellationToken);
+		public Task<User> Create(UserUpdate user, CancellationToken cancellationToken) => ApiClient.Create<UserUpdate, User>(Routes.User, user ?? throw new ArgumentNullException(nameof(user)), cancellationToken);
 
 		/// <inheritdoc />
-		public Task<User> GetId(Api.Models.Internal.User user, CancellationToken cancellationToken) => apiClient.Read<User>(Routes.SetID(Routes.User, user?.Id ?? throw new ArgumentNullException(nameof(user))), cancellationToken);
+		public Task<User> GetId(Api.Models.Internal.User user, CancellationToken cancellationToken) => ApiClient.Read<User>(Routes.SetID(Routes.User, user?.Id ?? throw new ArgumentNullException(nameof(user))), cancellationToken);
 
 		/// <inheritdoc />
-		public Task<IReadOnlyList<User>> List(CancellationToken cancellationToken) => apiClient.Read<IReadOnlyList<User>>(Routes.ListRoute(Routes.User), cancellationToken);
+		public Task<IReadOnlyList<User>> List(PaginationSettings? paginationSettings, CancellationToken cancellationToken)
+			=> ReadPaged<User>(paginationSettings, Routes.ListRoute(Routes.User), null, cancellationToken);
 
 		/// <inheritdoc />
-		public Task<User> Read(CancellationToken cancellationToken) => apiClient.Read<User>(Routes.User, cancellationToken);
+		public Task<User> Read(CancellationToken cancellationToken) => ApiClient.Read<User>(Routes.User, cancellationToken);
 
 		/// <inheritdoc />
-		public Task<User> Update(UserUpdate user, CancellationToken cancellationToken) => apiClient.Update<UserUpdate, User>(Routes.User, user ?? throw new ArgumentNullException(nameof(user)), cancellationToken);
+		public Task<User> Update(UserUpdate user, CancellationToken cancellationToken) => ApiClient.Update<UserUpdate, User>(Routes.User, user ?? throw new ArgumentNullException(nameof(user)), cancellationToken);
 	}
 }

--- a/src/Tgstation.Server.Host/Controllers/InstanceController.cs
+++ b/src/Tgstation.Server.Host/Controllers/InstanceController.cs
@@ -635,7 +635,7 @@ namespace Tgstation.Server.Host.Controllers
 				instance =>
 				{
 					needsUpdate |= InstanceRequiredController.ValidateInstanceOnlineStatus(instanceManager, Logger, instance);
-					instance.MoveJob = moveJobs.FirstOrDefault(x => x.Instance.Id == instance.Id).ToApi();
+					instance.MoveJob = moveJobs.FirstOrDefault(x => x.Instance.Id == instance.Id)?.ToApi();
 				},
 				page,
 				pageSize,

--- a/src/Tgstation.Server.Host/Controllers/InstanceController.cs
+++ b/src/Tgstation.Server.Host/Controllers/InstanceController.cs
@@ -586,13 +586,18 @@ namespace Tgstation.Server.Host.Controllers
 		/// <summary>
 		/// List <see cref="Api.Models.Instance"/>s.
 		/// </summary>
+		/// <param name="page">The current page.</param>
+		/// <param name="pageSize">The page size.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> of the request.</returns>
 		/// <response code="200">Retrieved <see cref="Api.Models.Instance"/>s successfully.</response>
 		[HttpGet(Routes.List)]
 		[TgsAuthorize(InstanceManagerRights.List | InstanceManagerRights.Read)]
-		[ProducesResponseType(typeof(IEnumerable<Api.Models.Instance>), 200)]
-		public async Task<IActionResult> List(CancellationToken cancellationToken)
+		[ProducesResponseType(typeof(Paginated<Api.Models.Instance>), 200)]
+		public async Task<IActionResult> List(
+			[FromQuery] int? page,
+			[FromQuery] int? pageSize,
+			CancellationToken cancellationToken)
 		{
 			IQueryable<Models.Instance> GetBaseQuery()
 			{
@@ -622,21 +627,25 @@ namespace Tgstation.Server.Host.Controllers
 				.ToListAsync(cancellationToken)
 				.ConfigureAwait(false);
 
-			var instances = await GetBaseQuery()
-				.ToListAsync(cancellationToken)
-				.ConfigureAwait(false);
-
 			var needsUpdate = false;
-			foreach (var instance in instances)
-				needsUpdate |= InstanceRequiredController.ValidateInstanceOnlineStatus(instanceManager, Logger, instance);
+			var result = await Paginated<Models.Instance, Api.Models.Instance>(
+				() => Task.FromResult(
+					new PaginatableResult<Models.Instance>(
+						GetBaseQuery())),
+				instance =>
+				{
+					needsUpdate |= InstanceRequiredController.ValidateInstanceOnlineStatus(instanceManager, Logger, instance);
+					instance.MoveJob = moveJobs.FirstOrDefault(x => x.Instance.Id == instance.Id).ToApi();
+				},
+				page,
+				pageSize,
+				cancellationToken)
+				.ConfigureAwait(false);
 
 			if (needsUpdate)
 				await DatabaseContext.Save(cancellationToken).ConfigureAwait(false);
 
-			var apis = instances.Select(x => x.ToApi());
-			foreach(var I in moveJobs)
-				apis.Where(x => x.Id == I.Instance.Id).First().MoveJob = I.ToApi(); // if this .First() fails i will personally murder kevinz000 because I just know he is somehow responsible
-			return Json(apis);
+			return result;
 		}
 
 		/// <summary>

--- a/src/Tgstation.Server.Host/Controllers/InstanceUserController.cs
+++ b/src/Tgstation.Server.Host/Controllers/InstanceUserController.cs
@@ -1,8 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -147,23 +146,27 @@ namespace Tgstation.Server.Host.Controllers
 		/// <summary>
 		/// Lists <see cref="Api.Models.InstanceUser"/>s for the instance.
 		/// </summary>
+		/// <param name="page">The current page.</param>
+		/// <param name="pageSize">The page size.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> of the request.</returns>
 		/// <response code="200">Retrieved <see cref="Api.Models.InstanceUser"/>s successfully.</response>
 		[HttpGet(Routes.List)]
 		[TgsAuthorize(InstanceUserRights.ReadUsers)]
-		[ProducesResponseType(typeof(IEnumerable<Api.Models.InstanceUser>), 200)]
-		public async Task<IActionResult> List(CancellationToken cancellationToken)
-		{
-			var users = await DatabaseContext
-				.Instances
-				.AsQueryable()
-				.Where(x => x.Id == Instance.Id)
-				.SelectMany(x => x.InstanceUsers)
-				.ToListAsync(cancellationToken)
-				.ConfigureAwait(false);
-			return Json(users.Select(x => x.ToApi()));
-		}
+		[ProducesResponseType(typeof(Paginated<Api.Models.InstanceUser>), 200)]
+		public Task<IActionResult> List([FromQuery] int? page, [FromQuery] int? pageSize, CancellationToken cancellationToken)
+			=> Paginated<Models.InstanceUser, Api.Models.InstanceUser>(
+				() => Task.FromResult(
+					new PaginatableResult<Models.InstanceUser>(
+						DatabaseContext
+							.Instances
+							.AsQueryable()
+							.Where(x => x.Id == Instance.Id)
+							.SelectMany(x => x.InstanceUsers))),
+				null,
+				page,
+				pageSize,
+				cancellationToken);
 
 		/// <summary>
 		/// Gets a specific <see cref="Api.Models.InstanceUser"/>.

--- a/src/Tgstation.Server.Host/Controllers/PaginatableResult.cs
+++ b/src/Tgstation.Server.Host/Controllers/PaginatableResult.cs
@@ -1,0 +1,41 @@
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Linq;
+
+namespace Tgstation.Server.Host.Controllers
+{
+	/// <summary>
+	/// Helper for returning paginated models.
+	/// </summary>
+	/// <typeparam name="TModel">The <see cref="Type"/> of model intended to be returned.</typeparam>
+	public sealed class PaginatableResult<TModel>
+	{
+		/// <summary>
+		/// The <see cref="IQueryable{T}"/> <typeparamref name="TModel"/> results.
+		/// </summary>
+		public IQueryable<TModel> Results { get; }
+
+		/// <summary>
+		/// An <see cref="IActionResult"/> to return immediately.
+		/// </summary>
+		public IActionResult EarlyOut { get; }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="PaginatableResult{TModel}"/> <see langword="class"/>.
+		/// </summary>
+		/// <param name="results">The value of <see cref="Results"/>.</param>
+		public PaginatableResult(IQueryable<TModel> results)
+		{
+			Results = results ?? throw new ArgumentNullException(nameof(results));
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="PaginatableResult{TModel}"/> <see langword="class"/>.
+		/// </summary>
+		/// <param name="earlyOut">The value of <see cref="EarlyOut"/>.</param>
+		public PaginatableResult(IActionResult earlyOut)
+		{
+			EarlyOut = earlyOut ?? throw new ArgumentNullException(nameof(earlyOut));
+		}
+	}
+}

--- a/src/Tgstation.Server.Host/Controllers/UserController.cs
+++ b/src/Tgstation.Server.Host/Controllers/UserController.cs
@@ -298,23 +298,28 @@ namespace Tgstation.Server.Host.Controllers
 		/// <summary>
 		/// List all <see cref="Api.Models.User"/>s in the server.
 		/// </summary>
+		/// <param name="page">The current page.</param>
+		/// <param name="pageSize">The page size.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> of the operation.</returns>
 		/// <response code="200">Retrieved <see cref="Api.Models.User"/>s successfully.</response>
 		[HttpGet(Routes.List)]
 		[TgsAuthorize(AdministrationRights.ReadUsers)]
-		[ProducesResponseType(typeof(IEnumerable<Api.Models.User>), 200)]
-		public async Task<IActionResult> List(CancellationToken cancellationToken)
-		{
-			var users = await DatabaseContext
-				.Users
-				.AsQueryable()
-				.Where(x => x.CanonicalName != Models.User.CanonicalizeName(Models.User.TgsSystemUserName))
-				.Include(x => x.CreatedBy)
-				.Include(x => x.OAuthConnections)
-				.ToListAsync(cancellationToken).ConfigureAwait(false);
-			return Json(users.Select(x => x.ToApi(true)));
-		}
+		[ProducesResponseType(typeof(Paginated<Api.Models.User>), 200)]
+		public Task<IActionResult> List([FromQuery] int? page, [FromQuery] int? pageSize, CancellationToken cancellationToken)
+			=> Paginated<Models.User, Api.Models.User>(
+				() => Task.FromResult(
+					new PaginatableResult<Models.User>(
+						DatabaseContext
+							.Users
+							.AsQueryable()
+							.Where(x => x.CanonicalName != Models.User.CanonicalizeName(Models.User.TgsSystemUserName))
+							.Include(x => x.CreatedBy)
+							.Include(x => x.OAuthConnections))),
+				null,
+				page,
+				pageSize,
+				cancellationToken);
 
 		/// <summary>
 		/// Get a specific <see cref="Api.Models.User"/>.

--- a/src/Tgstation.Server.Host/Core/SwaggerConfiguration.cs
+++ b/src/Tgstation.Server.Host/Core/SwaggerConfiguration.cs
@@ -164,6 +164,9 @@ namespace Tgstation.Server.Host.Core
 				if (type == typeof(Api.Models.Internal.User))
 					return "ShallowUser";
 
+				if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Paginated<>))
+					return $"Paginated{type.GenericTypeArguments.First().Name}";
+
 				return type.Name;
 			});
 
@@ -241,7 +244,7 @@ namespace Tgstation.Server.Host.Core
 				};
 
 				if (typeof(InstanceRequiredController).IsAssignableFrom(context.MethodInfo.DeclaringType))
-					operation.Parameters.Add(new OpenApiParameter
+					operation.Parameters.Insert(0, new OpenApiParameter
 					{
 						Reference = new OpenApiReference
 						{

--- a/src/Tgstation.Server.Host/Models/ChatBot.cs
+++ b/src/Tgstation.Server.Host/Models/ChatBot.cs
@@ -1,11 +1,11 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 
 namespace Tgstation.Server.Host.Models
 {
 	/// <inheritdoc />
-	public sealed class ChatBot : Api.Models.Internal.ChatBot
+	public sealed class ChatBot : Api.Models.Internal.ChatBot, IApiTransformable<Api.Models.ChatBot>
 	{
 		/// <summary>
 		/// Default for <see cref="Api.Models.Internal.ChatBot.ChannelLimit"/>.
@@ -28,10 +28,7 @@ namespace Tgstation.Server.Host.Models
 		/// </summary>
 		public ICollection<ChatChannel> Channels { get; set; }
 
-		/// <summary>
-		/// Convert the <see cref="ChatBot"/> to it's API form
-		/// </summary>
-		/// <returns>A new <see cref="Api.Models.ChatBot"/></returns>
+		/// <inheritdoc />
 		public Api.Models.ChatBot ToApi() => new Api.Models.ChatBot
 		{
 			Channels = Channels.Select(x => x.ToApi()).ToList(),

--- a/src/Tgstation.Server.Host/Models/ChatChannel.cs
+++ b/src/Tgstation.Server.Host/Models/ChatChannel.cs
@@ -1,7 +1,7 @@
-﻿namespace Tgstation.Server.Host.Models
+namespace Tgstation.Server.Host.Models
 {
 	/// <inheritdoc />
-	public sealed class ChatChannel : Api.Models.ChatChannel
+	public sealed class ChatChannel : Api.Models.ChatChannel, IApiTransformable<Api.Models.ChatChannel>
 	{
 		/// <summary>
 		/// The row Id
@@ -18,10 +18,7 @@
 		/// </summary>
 		public ChatBot ChatSettings { get; set; }
 
-		/// <summary>
-		/// Convert the <see cref="ChatChannel"/> to it's API form
-		/// </summary>
-		/// <returns>A new <see cref="Api.Models.ChatChannel"/></returns>
+		/// <inheritdoc />
 		public Api.Models.ChatChannel ToApi() => new Api.Models.ChatChannel
 		{
 			DiscordChannelId = DiscordChannelId,

--- a/src/Tgstation.Server.Host/Models/CompileJob.cs
+++ b/src/Tgstation.Server.Host/Models/CompileJob.cs
@@ -5,7 +5,7 @@ using Tgstation.Server.Api.Models;
 namespace Tgstation.Server.Host.Models
 {
 	/// <inheritdoc />
-	public sealed class CompileJob : Api.Models.Internal.CompileJob
+	public sealed class CompileJob : Api.Models.Internal.CompileJob, IApiTransformable<Api.Models.CompileJob>
 	{
 		/// <summary>
 		/// See <see cref="Api.Models.CompileJob.Job"/>
@@ -78,10 +78,7 @@ namespace Tgstation.Server.Host.Models
 			}
 		}
 
-		/// <summary>
-		/// Convert the <see cref="CompileJob"/> to it's API form
-		/// </summary>
-		/// <returns>A new <see cref="Api.Models.CompileJob"/></returns>
+		/// <inheritdoc />
 		public Api.Models.CompileJob ToApi() => new Api.Models.CompileJob
 		{
 			DirectoryName = DirectoryName,

--- a/src/Tgstation.Server.Host/Models/DreamMakerSettings.cs
+++ b/src/Tgstation.Server.Host/Models/DreamMakerSettings.cs
@@ -1,9 +1,9 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 
 namespace Tgstation.Server.Host.Models
 {
 	/// <inheritdoc />
-	public sealed class DreamMakerSettings : Api.Models.DreamMaker
+	public sealed class DreamMakerSettings : Api.Models.DreamMaker, IApiTransformable<Api.Models.DreamMaker>
 	{
 		/// <summary>
 		/// The row Id
@@ -21,10 +21,7 @@ namespace Tgstation.Server.Host.Models
 		[Required]
 		public Instance Instance { get; set; }
 
-		/// <summary>
-		/// Convert the <see cref="DreamDaemonSettings"/> to it's API form
-		/// </summary>
-		/// <returns>A new <see cref="Api.Models.DreamMaker"/></returns>
+		/// <inheritdoc />
 		public Api.Models.DreamMaker ToApi() => new Api.Models.DreamMaker
 		{
 			ProjectName = ProjectName,

--- a/src/Tgstation.Server.Host/Models/IApiTransformable.cs
+++ b/src/Tgstation.Server.Host/Models/IApiTransformable.cs
@@ -1,0 +1,15 @@
+namespace Tgstation.Server.Host.Models
+{
+	/// <summary>
+	/// Represents a host-side model that may be transformed into a <typeparamref name="TApiModel"/>.
+	/// </summary>
+	/// <typeparam name="TApiModel">The API form of the model.</typeparam>
+	public interface IApiTransformable<TApiModel>
+	{
+		/// <summary>
+		/// Convert the <see cref="IApiTransformable{TApiModel}"/> to it's <typeparamref name="TApiModel"/>.
+		/// </summary>
+		/// <returns>A new <typeparamref name="TApiModel"/> based on the <see cref="IApiTransformable{TApiModel}"/>.</returns>
+		TApiModel ToApi();
+	}
+}

--- a/src/Tgstation.Server.Host/Models/Instance.cs
+++ b/src/Tgstation.Server.Host/Models/Instance.cs
@@ -1,11 +1,11 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace Tgstation.Server.Host.Models
 {
 	/// <summary>
 	/// Represents an <see cref="Api.Models.Instance"/> in the database
 	/// </summary>
-	public sealed class Instance : Api.Models.Instance
+	public sealed class Instance : Api.Models.Instance, IApiTransformable<Api.Models.Instance>
 	{
 		/// <summary>
 		/// Default for <see cref="Api.Models.Instance.ChatBotLimit"/>.
@@ -47,10 +47,7 @@ namespace Tgstation.Server.Host.Models
 		/// </summary>
 		public ICollection<Job> Jobs { get; set; }
 
-		/// <summary>
-		/// Convert the <see cref="Instance"/> to it's API form
-		/// </summary>
-		/// <returns>A new <see cref="Api.Models.Instance"/></returns>
+		/// <inheritdoc />
 		public Api.Models.Instance ToApi() => new Api.Models.Instance
 		{
 			AutoUpdateInterval = AutoUpdateInterval,
@@ -59,7 +56,8 @@ namespace Tgstation.Server.Host.Models
 			Name = Name,
 			Path = Path,
 			Online = Online,
-			ChatBotLimit = ChatBotLimit
+			ChatBotLimit = ChatBotLimit,
+			MoveJob = MoveJob,
 		};
 	}
 }

--- a/src/Tgstation.Server.Host/Models/InstanceUser.cs
+++ b/src/Tgstation.Server.Host/Models/InstanceUser.cs
@@ -1,9 +1,9 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 
 namespace Tgstation.Server.Host.Models
 {
 	/// <inheritdoc />
-	public sealed class InstanceUser : Api.Models.InstanceUser
+	public sealed class InstanceUser : Api.Models.InstanceUser, IApiTransformable<Api.Models.InstanceUser>
 	{
 		/// <summary>
 		/// The row Id
@@ -21,10 +21,7 @@ namespace Tgstation.Server.Host.Models
 		[Required]
 		public Instance Instance { get; set; }
 
-		/// <summary>
-		/// Convert the <see cref="InstanceUser"/> to it's API form
-		/// </summary>
-		/// <returns>A new <see cref="Api.Models.InstanceUser"/></returns>
+		/// <inheritdoc />
 		public Api.Models.InstanceUser ToApi() => new Api.Models.InstanceUser
 		{
 			ByondRights = ByondRights,

--- a/src/Tgstation.Server.Host/Models/Job.cs
+++ b/src/Tgstation.Server.Host/Models/Job.cs
@@ -4,7 +4,7 @@ namespace Tgstation.Server.Host.Models
 {
 	/// <inheritdoc />
 	#pragma warning disable CA1724 // naming conflict with gitlab package
-	public sealed class Job : Api.Models.Internal.Job
+	public sealed class Job : Api.Models.Internal.Job, IApiTransformable<Api.Models.Job>
 	#pragma warning restore CA1724
 	{
 		/// <summary>
@@ -24,10 +24,7 @@ namespace Tgstation.Server.Host.Models
 		[Required]
 		public Instance Instance { get; set; }
 
-		/// <summary>
-		/// Convert the <see cref="Job"/> to it's API form
-		/// </summary>
-		/// <returns>A new <see cref="Api.Models.Job"/></returns>
+		/// <inheritdoc />
 		public Api.Models.Job ToApi() => new Api.Models.Job
 		{
 			Id = Id,

--- a/src/Tgstation.Server.Host/Models/OAuthConnection.cs
+++ b/src/Tgstation.Server.Host/Models/OAuthConnection.cs
@@ -1,7 +1,7 @@
 namespace Tgstation.Server.Host.Models
 {
 	/// <inheritdoc />
-	public sealed class OAuthConnection : Api.Models.OAuthConnection
+	public sealed class OAuthConnection : Api.Models.OAuthConnection, IApiTransformable<Api.Models.OAuthConnection>
 	{
 		/// <summary>
 		/// The row Id.
@@ -13,10 +13,7 @@ namespace Tgstation.Server.Host.Models
 		/// </summary>
 		public User User { get; set; }
 
-		/// <summary>
-		/// Convert the <see cref="OAuthConnection"/> to it's API form.
-		/// </summary>
-		/// <returns>A new <see cref="Api.Models.OAuthConnection"/>.</returns>
+		/// <inheritdoc />
 		public Api.Models.OAuthConnection ToApi() => new Api.Models.OAuthConnection
 		{
 			Provider = Provider,

--- a/src/Tgstation.Server.Host/Models/RepositorySettings.cs
+++ b/src/Tgstation.Server.Host/Models/RepositorySettings.cs
@@ -4,7 +4,7 @@ using Tgstation.Server.Api.Models;
 namespace Tgstation.Server.Host.Models
 {
 	/// <inheritdoc />
-	public sealed class RepositorySettings : Api.Models.Internal.RepositorySettings
+	public sealed class RepositorySettings : Api.Models.Internal.RepositorySettings, IApiTransformable<Repository>
 	{
 		/// <summary>
 		/// The row Id
@@ -22,10 +22,7 @@ namespace Tgstation.Server.Host.Models
 		[Required]
 		public Instance Instance { get; set; }
 
-		/// <summary>
-		/// Convert the <see cref="Repository"/> to it's API form
-		/// </summary>
-		/// <returns>A new <see cref="Repository"/></returns>
+		/// <inheritdoc />
 		public Repository ToApi() => new Repository
 		{
 			// AccessToken = AccessToken, // never show this

--- a/src/Tgstation.Server.Host/Models/RevisionInformation.cs
+++ b/src/Tgstation.Server.Host/Models/RevisionInformation.cs
@@ -1,11 +1,11 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 
 namespace Tgstation.Server.Host.Models
 {
 	/// <inheritdoc />
-	public sealed class RevisionInformation : Api.Models.Internal.RevisionInformation
+	public sealed class RevisionInformation : Api.Models.Internal.RevisionInformation, IApiTransformable<Api.Models.RevisionInformation>
 	{
 		/// <summary>
 		/// The row Id
@@ -38,10 +38,7 @@ namespace Tgstation.Server.Host.Models
 		/// </summary>
 		public ICollection<CompileJob> CompileJobs { get; set; }
 
-		/// <summary>
-		/// Convert the <see cref="RevisionInformation"/> to it's API form
-		/// </summary>
-		/// <returns>A new <see cref="Api.Models.RevisionInformation"/></returns>
+		/// <inheritdoc />
 		public Api.Models.RevisionInformation ToApi() => new Api.Models.RevisionInformation
 		{
 			CommitSha = CommitSha,

--- a/src/Tgstation.Server.Host/Models/TestMerge.cs
+++ b/src/Tgstation.Server.Host/Models/TestMerge.cs
@@ -1,10 +1,10 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
 namespace Tgstation.Server.Host.Models
 {
 	/// <inheritdoc />
-	public sealed class TestMerge : Api.Models.Internal.TestMerge
+	public sealed class TestMerge : Api.Models.Internal.TestMerge, IApiTransformable<Api.Models.TestMerge>
 	{
 		/// <summary>
 		/// See <see cref="Api.Models.TestMerge.MergedBy"/>
@@ -28,10 +28,7 @@ namespace Tgstation.Server.Host.Models
 		/// </summary>
 		public ICollection<RevInfoTestMerge> RevisonInformations { get; set; }
 
-		/// <summary>
-		/// Convert the <see cref="TestMerge"/> to it's API form
-		/// </summary>
-		/// <returns>A new <see cref="Api.Models.TestMerge"/></returns>
+		/// <inheritdoc />
 		public Api.Models.TestMerge ToApi() => new Api.Models.TestMerge
 		{
 			Author = Author,

--- a/src/Tgstation.Server.Host/Models/User.cs
+++ b/src/Tgstation.Server.Host/Models/User.cs
@@ -6,7 +6,7 @@ using System.Linq;
 namespace Tgstation.Server.Host.Models
 {
 	/// <inheritdoc />
-	public sealed class User : Api.Models.Internal.User
+	public sealed class User : Api.Models.Internal.User, IApiTransformable<Api.Models.User>
 	{
 		/// <summary>
 		/// Username used when creating jobs automatically.
@@ -88,5 +88,8 @@ namespace Tgstation.Server.Host.Models
 		/// <param name="showDetails">If rights and system identifier should be shown</param>
 		/// <returns>A new <see cref="Api.Models.User"/></returns>
 		public Api.Models.User ToApi(bool showDetails) => ToApi(true, showDetails);
+
+		/// <inheritdoc />
+		public Api.Models.User ToApi() => ToApi(true);
 	}
 }

--- a/tests/Tgstation.Server.Tests/AdministrationTest.cs
+++ b/tests/Tgstation.Server.Tests/AdministrationTest.cs
@@ -28,7 +28,7 @@ namespace Tgstation.Server.Tests
 
 		async Task TestLogs(CancellationToken cancellationToken)
 		{
-			var logs = await client.ListLogs(cancellationToken);
+			var logs = await client.ListLogs(null, cancellationToken);
 			Assert.AreNotEqual(0, logs.Count);
 			var logFile = logs.First();
 			Assert.IsNotNull(logFile);

--- a/tests/Tgstation.Server.Tests/Instance/ByondTest.cs
+++ b/tests/Tgstation.Server.Tests/Instance/ByondTest.cs
@@ -75,7 +75,7 @@ namespace Tgstation.Server.Tests.Instance
 
 		async Task TestNoVersion(CancellationToken cancellationToken)
 		{
-			var allVersionsTask = byondClient.InstalledVersions(cancellationToken);
+			var allVersionsTask = byondClient.InstalledVersions(null, cancellationToken);
 			var currentShit = await byondClient.ActiveVersion(cancellationToken).ConfigureAwait(false);
 			Assert.IsNotNull(currentShit);
 			Assert.IsNull(currentShit.InstallJob);

--- a/tests/Tgstation.Server.Tests/Instance/ChatTest.cs
+++ b/tests/Tgstation.Server.Tests/Instance/ChatTest.cs
@@ -52,7 +52,7 @@ namespace Tgstation.Server.Tests.Instance
 			Assert.AreEqual(csb.ToString(), firstBot.ConnectionString);
 			Assert.AreNotEqual(0, firstBot.Id);
 
-			var bots = await chatClient.List(cancellationToken);
+			var bots = await chatClient.List(null, cancellationToken);
 			Assert.AreEqual(firstBot.Id, bots.First(x => x.Provider.Value == ChatProvider.Irc).Id);
 
 			var retrievedBot = await chatClient.GetId(firstBot, cancellationToken);
@@ -115,7 +115,7 @@ namespace Tgstation.Server.Tests.Instance
 			Assert.AreEqual(csb.ToString(), firstBot.ConnectionString);
 			Assert.AreNotEqual(0, firstBot.Id);
 
-			var bots = await chatClient.List(cancellationToken);
+			var bots = await chatClient.List(null, cancellationToken);
 			Assert.AreEqual(firstBot.Id, bots.First(x => x.Provider.Value == ChatProvider.Discord).Id);
 
 			var retrievedBot = await chatClient.GetId(firstBot, cancellationToken);
@@ -154,13 +154,13 @@ namespace Tgstation.Server.Tests.Instance
 
 		public async Task RunPostTest(CancellationToken cancellationToken)
 		{
-			var activeBots = await chatClient.List(cancellationToken);
+			var activeBots = await chatClient.List(null, cancellationToken);
 
 			Assert.AreEqual(2, activeBots.Count);
 
 			await Task.WhenAll(activeBots.Select(bot => chatClient.Delete(bot, cancellationToken)));
 
-			var nowBots = await chatClient.List(cancellationToken);
+			var nowBots = await chatClient.List(null, cancellationToken);
 			Assert.AreEqual(0, nowBots.Count);
 		}
 
@@ -173,7 +173,7 @@ namespace Tgstation.Server.Tests.Instance
 				Provider = ChatProvider.Irc
 			}, cancellationToken), ErrorCode.ChatBotMax);
 
-			var bots = await chatClient.List(cancellationToken);
+			var bots = await chatClient.List(null, cancellationToken);
 			var discordBot = bots.First(bot => bot.Provider.Value == ChatProvider.Discord);
 
 			// We limited chat bots and channels to 1 and 2 respectively, try violating them

--- a/tests/Tgstation.Server.Tests/InstanceManagerTest.cs
+++ b/tests/Tgstation.Server.Tests/InstanceManagerTest.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.IO;
 using System.Linq;
@@ -137,7 +137,7 @@ namespace Tgstation.Server.Tests
 
 		public async Task RunPostTest(CancellationToken cancellationToken)
 		{
-			var instances = await instanceManagerClient.List(cancellationToken);
+			var instances = await instanceManagerClient.List(null, cancellationToken);
 			var firstTest = instances.Single(x => x.Name == TestInstanceName);
 			var instanceClient = instanceManagerClient.CreateClient(firstTest);
 

--- a/tests/Tgstation.Server.Tests/IntegrationTest.cs
+++ b/tests/Tgstation.Server.Tests/IntegrationTest.cs
@@ -320,10 +320,10 @@ namespace Tgstation.Server.Tests
 				{
 					var instanceClient = adminClient.Instances.CreateClient(instance);
 
-					var jobs = await instanceClient.Jobs.ListActive(cancellationToken);
+					var jobs = await instanceClient.Jobs.ListActive(null, cancellationToken);
 					if (!jobs.Any())
 					{
-						var entities = await instanceClient.Jobs.List(cancellationToken);
+						var entities = await instanceClient.Jobs.List(null, cancellationToken);
 						var getTasks = entities
 							.Select(e => instanceClient.Jobs.GetId(e, cancellationToken))
 							.ToList();
@@ -363,10 +363,10 @@ namespace Tgstation.Server.Tests
 				{
 					var instanceClient = adminClient.Instances.CreateClient(instance);
 
-					var jobs = await instanceClient.Jobs.ListActive(cancellationToken);
+					var jobs = await instanceClient.Jobs.ListActive(null, cancellationToken);
 					if (!jobs.Any())
 					{
-						var entities = await instanceClient.Jobs.List(cancellationToken);
+						var entities = await instanceClient.Jobs.List(null, cancellationToken);
 						var getTasks = entities
 							.Select(e => instanceClient.Jobs.GetId(e, cancellationToken))
 							.ToList();


### PR DESCRIPTION
Closes #1119

:cl: HTTP API
Endpoints that previously returned top-level array responses are now paginated. Each endpoint now takes optional `page` number (defaulting to 1) and `pageSize` (currently defaulting to 10, but subject to change in the future) query parameters. The returned model is wrapped in a generic Paginated model. Along with the `content` array, it contains the request `pageSize` and `totalPages` for the request.
Previously deprecated ErrorCode 40 is now used when requesting too large a `pageSize`.
Previously deprecated ErrorCode 41 is now used when requesting `page` or `pageSize`s <= 0.
/:cl: