### PR TITLE
Api fixups

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -5,8 +5,8 @@
   <PropertyGroup>
     <TgsCoreVersion>4.7.0</TgsCoreVersion>
     <TgsConfigVersion>2.2.0</TgsConfigVersion>
-    <TgsApiVersion>8.0.0</TgsApiVersion>
-    <TgsClientVersion>9.0.0</TgsClientVersion>
+    <TgsApiVersion>8.1.0</TgsApiVersion>
+    <TgsClientVersion>9.1.0</TgsClientVersion>
     <TgsDmapiVersion>5.2.10</TgsDmapiVersion>
     <TgsHostWatchdogVersion>1.1.0</TgsHostWatchdogVersion>
     <TgsContainerScriptVersion>1.2.0</TgsContainerScriptVersion>

--- a/src/Tgstation.Server.Api/Models/ErrorCode.cs
+++ b/src/Tgstation.Server.Api/Models/ErrorCode.cs
@@ -608,5 +608,17 @@ namespace Tgstation.Server.Api.Models
 		/// </summary>
 		[Description("Cannot delete the user group as it is not empty!")]
 		UserGroupNotEmpty,
+
+		/// <summary>
+		/// Attempted to create an <see cref="User"/> but the configured limit has been reached.
+		/// </summary>
+		[Description("The user cannot be created because the configured limit has been reached!")]
+		UserLimitReached,
+
+		/// <summary>
+		/// Attempted to create an <see cref="UserGroup"/> but the configured limit has been reached.
+		/// </summary>
+		[Description("The user group cannot be created because the configured limit has been reached!")]
+		UserGroupLimitReached,
 	}
 }

--- a/src/Tgstation.Server.Api/Models/Internal/ServerInformation.cs
+++ b/src/Tgstation.Server.Api/Models/Internal/ServerInformation.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace Tgstation.Server.Api.Models.Internal
 {
@@ -21,6 +21,11 @@ namespace Tgstation.Server.Api.Models.Internal
 		/// The maximum number of <see cref="Models.User"/>s allowed.
 		/// </summary>
 		public uint UserLimit { get; set; }
+
+		/// <summary>
+		/// The maximum number of <see cref="Models.UserGroup"/>s allowed.
+		/// </summary>
+		public uint UserGroupLimit { get; set; }
 
 		/// <summary>
 		/// Limits the locations instances may be created or attached from.

--- a/src/Tgstation.Server.Host/Configuration/GeneralConfiguration.cs
+++ b/src/Tgstation.Server.Host/Configuration/GeneralConfiguration.cs
@@ -44,6 +44,11 @@ namespace Tgstation.Server.Host.Configuration
 		const uint DefaultUserLimit = 100;
 
 		/// <summary>
+		/// The default value for <see cref="ServerInformation.UserGroupLimit"/>.
+		/// </summary>
+		const uint DefaultUserGroupLimit = 25;
+
+		/// <summary>
 		/// The default value for <see cref="ByondTopicTimeout"/>
 		/// </summary>
 		const uint DefaultByondTopicTimeout = 5000;
@@ -102,6 +107,7 @@ namespace Tgstation.Server.Host.Configuration
 			MinimumPasswordLength = DefaultMinimumPasswordLength;
 			InstanceLimit = DefaultInstanceLimit;
 			UserLimit = DefaultUserLimit;
+			UserGroupLimit = DefaultUserGroupLimit;
 		}
 
 		/// <summary>

--- a/src/Tgstation.Server.Host/Controllers/HomeController.cs
+++ b/src/Tgstation.Server.Host/Controllers/HomeController.cs
@@ -191,6 +191,7 @@ namespace Tgstation.Server.Host.Controllers
 				MinimumPasswordLength = generalConfiguration.MinimumPasswordLength,
 				InstanceLimit = generalConfiguration.InstanceLimit,
 				UserLimit = generalConfiguration.UserLimit,
+				UserGroupLimit = generalConfiguration.UserGroupLimit,
 				ValidInstancePaths = generalConfiguration.ValidInstancePaths,
 				WindowsHost = platformIdentifier.IsWindows,
 				SwarmServers = swarmService.GetSwarmServers(),

--- a/src/Tgstation.Server.Host/Controllers/UserController.cs
+++ b/src/Tgstation.Server.Host/Controllers/UserController.cs
@@ -113,6 +113,7 @@ namespace Tgstation.Server.Host.Controllers
 		[HttpPut]
 		[TgsAuthorize(AdministrationRights.WriteUsers)]
 		[ProducesResponseType(typeof(Api.Models.User), 201)]
+#pragma warning disable CA1502, CA1506
 		public async Task<IActionResult> Create([FromBody] UserUpdate model, CancellationToken cancellationToken)
 		{
 			if (model == null)
@@ -181,6 +182,7 @@ namespace Tgstation.Server.Host.Controllers
 
 			return Created(dbUser.ToApi(true));
 		}
+#pragma warning restore CA1502, CA1506
 
 		/// <summary>
 		/// Update a <see cref="Api.Models.User"/>.

--- a/src/Tgstation.Server.Host/Controllers/UserController.cs
+++ b/src/Tgstation.Server.Host/Controllers/UserController.cs
@@ -182,10 +182,12 @@ namespace Tgstation.Server.Host.Controllers
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> of the operation.</returns>
 		/// <response code="200"><see cref="Api.Models.User"/> updated successfully.</response>
 		/// <response code="404">Requested <see cref="Api.Models.Internal.User.Id"/> does not exist.</response>
+		/// <response code="410">Requested <see cref="Api.Models.User.Group"/> does not exist.</response>
 		[HttpPost]
 		[TgsAuthorize(AdministrationRights.WriteUsers | AdministrationRights.EditOwnPassword | AdministrationRights.EditOwnOAuthConnections)]
 		[ProducesResponseType(typeof(Api.Models.User), 200)]
 		[ProducesResponseType(typeof(ErrorMessage), 404)]
+		[ProducesResponseType(typeof(ErrorMessage), 410)]
 #pragma warning disable CA1502 // TODO: Decomplexify
 #pragma warning disable CA1506
 		public async Task<IActionResult> Update([FromBody] UserUpdate model, CancellationToken cancellationToken)

--- a/src/Tgstation.Server.Host/Controllers/UserController.cs
+++ b/src/Tgstation.Server.Host/Controllers/UserController.cs
@@ -139,6 +139,14 @@ namespace Tgstation.Server.Host.Controllers
 			if (fail != null)
 				return fail;
 
+			var totalUsers = await DatabaseContext
+				.Users
+				.AsQueryable()
+				.CountAsync(cancellationToken)
+				.ConfigureAwait(false);
+			if (totalUsers >= generalConfiguration.UserLimit)
+				return Conflict(new ErrorMessage(ErrorCode.UserLimitReached));
+
 			var dbUser = await CreateNewUserFromModel(model, cancellationToken).ConfigureAwait(false);
 			if (dbUser == null)
 				return Gone();

--- a/src/Tgstation.Server.Host/appsettings.json
+++ b/src/Tgstation.Server.Host/appsettings.json
@@ -8,6 +8,7 @@
     "ApiPort": 5000,
     "UseBasicWatchdog": false,
     "UserLimit": 100,
+    "UserGroupLimit": 25,
     "InstanceLimit": 10,
     "ValidInstancePaths": null,
     "HostApiDocumentation": false

--- a/tests/Tgstation.Server.Tests/RootTest.cs
+++ b/tests/Tgstation.Server.Tests/RootTest.cs
@@ -162,6 +162,7 @@ namespace Tgstation.Server.Tests
 			Assert.AreEqual(10U, serverInfo.MinimumPasswordLength);
 			Assert.AreEqual(11U, serverInfo.InstanceLimit);
 			Assert.AreEqual(150U, serverInfo.UserLimit);
+			Assert.AreEqual(47U, serverInfo.UserGroupLimit);
 			Assert.AreEqual(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), serverInfo.WindowsHost);
 
 			//check that modifying the token even slightly fucks up the auth

--- a/tests/Tgstation.Server.Tests/TestingServer.cs
+++ b/tests/Tgstation.Server.Tests/TestingServer.cs
@@ -80,6 +80,7 @@ namespace Tgstation.Server.Tests
 				String.Format(CultureInfo.InvariantCulture, "General:MinimumPasswordLength={0}", 10),
 				String.Format(CultureInfo.InvariantCulture, "General:InstanceLimit={0}", 11),
 				String.Format(CultureInfo.InvariantCulture, "General:UserLimit={0}", 150),
+				String.Format(CultureInfo.InvariantCulture, "General:UserGroupLimit={0}", 47),
 				String.Format(CultureInfo.InvariantCulture, "General:HostApiDocumentation={0}", DumpOpenApiSpecpath),
 				String.Format(CultureInfo.InvariantCulture, "FileLogging:Directory={0}", Path.Combine(Directory, "Logs")),
 				String.Format(CultureInfo.InvariantCulture, "FileLogging:LogLevel={0}", "Trace"),


### PR DESCRIPTION
:cl: **Configuration**
Added `General:UserGroupLimit` for limiting the total number of user groups that can be created.
/:cl:

:cl:
Fixed the user limit not actually applying.
/:cl:

:cl: HTTP API
Added `userGroupLimit` to ServerInformation model.
Added error code 100 for when the user limit is hit.
Added error code 101 for when the user group limit is hit.
/:cl:

Fixes #1177 
Closes #1176 