### PR TITLE
Fix 500 error when reading old compile jobs

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>4.7.0</TgsCoreVersion>
+    <TgsCoreVersion>4.7.1</TgsCoreVersion>
     <TgsConfigVersion>2.2.0</TgsConfigVersion>
     <TgsApiVersion>8.1.2</TgsApiVersion>
     <TgsClientVersion>9.1.1</TgsClientVersion>

--- a/src/Tgstation.Server.Host/Models/CompileJob.cs
+++ b/src/Tgstation.Server.Host/Models/CompileJob.cs
@@ -90,7 +90,7 @@ namespace Tgstation.Server.Host.Models
 			ByondVersion = Version.Parse(ByondVersion),
 			MinimumSecurityLevel = MinimumSecurityLevel,
 			DMApiVersion = DMApiVersion,
-			RepositoryOrigin = new Uri(RepositoryOrigin),
+			RepositoryOrigin = RepositoryOrigin != null ? new Uri(RepositoryOrigin) : null,
 		};
 	}
 }


### PR DESCRIPTION
:cl: HTTP API
Fixed a 500 error when retrieving pre-4.7 compile jobs.
/:cl: