### PR TITLE
Add a null check for the OAuth config section

### DIFF
--- a/src/Tgstation.Server.Host/Security/OAuth/OAuthProviders.cs
+++ b/src/Tgstation.Server.Host/Security/OAuth/OAuthProviders.cs
@@ -42,6 +42,10 @@ namespace Tgstation.Server.Host.Security.OAuth
 			var securityConfiguration = securityConfigurationOptions?.Value ?? throw new ArgumentNullException(nameof(securityConfigurationOptions));
 
 			var validatorsBuilder = new List<IOAuthValidator>();
+			validators = validatorsBuilder;
+
+			if (securityConfiguration.OAuth == null)
+				return;
 
 			if (securityConfiguration.OAuth.TryGetValue(OAuthProvider.GitHub, out var gitHubConfig))
 				validatorsBuilder.Add(
@@ -73,8 +77,6 @@ namespace Tgstation.Server.Host.Security.OAuth
 						assemblyInformationProvider,
 						loggerFactory.CreateLogger<KeycloakOAuthValidator>(),
 						keyCloakConfig));
-
-			validators = validatorsBuilder;
 		}
 
 		/// <inheritdoc />

--- a/tests/Tgstation.Server.Tests/TestingServer.cs
+++ b/tests/Tgstation.Server.Tests/TestingServer.cs
@@ -106,6 +106,8 @@ namespace Tgstation.Server.Tests
 					args.Add($"Security:OAuth:{I}:RedirectUrl=https://fakest.com");
 					args.Add($"Security:OAuth:{I}:ServerUrl=https://fakestest.com");
 				}
+			else
+				args.Add($"Security:OAuth=null");
 
 			// SPECIFICALLY DELETE THE DEV APPSETTINGS, WE DON'T WANT IT IN THE WAY
 			File.Delete("appsettings.Development.json");


### PR DESCRIPTION
:cl:
Fixed a startup exception that could happen if the `Security:OAuth` configuration section was set to `null`.
/:cl: