### PR TITLE
Add missing 410 response to PATCH /Instance/{id}

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -3,9 +3,9 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>4.7.2</TgsCoreVersion>
+    <TgsCoreVersion>4.7.3</TgsCoreVersion>
     <TgsConfigVersion>2.2.0</TgsConfigVersion>
-    <TgsApiVersion>8.1.2</TgsApiVersion>
+    <TgsApiVersion>8.2.0</TgsApiVersion>
     <TgsClientVersion>9.1.1</TgsClientVersion>
     <TgsDmapiVersion>5.2.10</TgsDmapiVersion>
     <TgsHostWatchdogVersion>1.1.0</TgsHostWatchdogVersion>

--- a/src/Tgstation.Server.Host/Components/Repository/GitHubRemoteFeatures.cs
+++ b/src/Tgstation.Server.Host/Components/Repository/GitHubRemoteFeatures.cs
@@ -51,6 +51,8 @@ namespace Tgstation.Server.Host.Components.Repository
 
 			RemoteRepositoryOwner = remoteUrl.Segments[1].TrimEnd('/');
 			RemoteRepositoryName = remoteUrl.Segments[2].TrimEnd('/');
+			if (RemoteRepositoryName.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+				RemoteRepositoryName = RemoteRepositoryName[0..^4];
 		}
 
 		/// <inheritdoc />

--- a/src/Tgstation.Server.Host/Components/Repository/GitLabRemoteFeatures.cs
+++ b/src/Tgstation.Server.Host/Components/Repository/GitLabRemoteFeatures.cs
@@ -45,6 +45,8 @@ namespace Tgstation.Server.Host.Components.Repository
 		{
 			RemoteRepositoryOwner = remoteUrl.Segments[1].TrimEnd('/');
 			RemoteRepositoryName = remoteUrl.Segments[2].TrimEnd('/');
+			if (RemoteRepositoryName.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+				RemoteRepositoryName = RemoteRepositoryName.Substring(0, RemoteRepositoryName.Length - 4);
 		}
 
 		/// <inheritdoc />

--- a/src/Tgstation.Server.Host/Controllers/HomeController.cs
+++ b/src/Tgstation.Server.Host/Controllers/HomeController.cs
@@ -158,13 +158,22 @@ namespace Tgstation.Server.Host.Controllers
 		[HttpGet]
 		[AllowAnonymous]
 		[ProducesResponseType(typeof(ServerInformation), 200)]
-		#pragma warning disable CA1506
+#pragma warning disable CA1506
 		public async Task<IActionResult> Home(CancellationToken cancellationToken)
 		{
+			if (controlPanelConfiguration.Enable)
+				Response.Headers.Add(
+					HeaderNames.Vary,
+					new StringValues(
+						new[]{
+							HeaderNames.UserAgent,
+							ApiHeaders.ApiVersionHeader
+						}));
+
 			// we only allow authorization header issues
 			if (ApiHeaders == null)
 			{
-				// if we are using a browser and the control panel, soft redirect to the app page
+				// if we are using a browser and the control panel, redirect to the app page
 				if (controlPanelConfiguration.Enable && browserResolver.Browser.Type != BrowserType.Generic)
 				{
 					Logger.LogDebug("Unauthorized browser request (User-Agent: \"{0}\"), redirecting to control panel...", browserResolver.UserAgent);

--- a/src/Tgstation.Server.Host/Controllers/HomeController.cs
+++ b/src/Tgstation.Server.Host/Controllers/HomeController.cs
@@ -161,15 +161,16 @@ namespace Tgstation.Server.Host.Controllers
 		#pragma warning disable CA1506
 		public async Task<IActionResult> Home(CancellationToken cancellationToken)
 		{
-			// if we are using a browser and the control panel, soft redirect to the app page
-			if (controlPanelConfiguration.Enable && browserResolver.Browser.Type != BrowserType.Generic)
-			{
-				Logger.LogDebug("Unauthorized browser request (User-Agent: \"{0}\"), redirecting to control panel...", browserResolver.UserAgent);
-				return Redirect(Core.Application.ControlPanelRoute);
-			}
-
 			// we only allow authorization header issues
 			if (ApiHeaders == null)
+			{
+				// if we are using a browser and the control panel, soft redirect to the app page
+				if (controlPanelConfiguration.Enable && browserResolver.Browser.Type != BrowserType.Generic)
+				{
+					Logger.LogDebug("Unauthorized browser request (User-Agent: \"{0}\"), redirecting to control panel...", browserResolver.UserAgent);
+					return Redirect(Core.Application.ControlPanelRoute);
+				}
+
 				try
 				{
 					var headers = new ApiHeaders(Request.GetTypedHeaders(), true);
@@ -182,6 +183,7 @@ namespace Tgstation.Server.Host.Controllers
 				{
 					return HeadersIssue(true);
 				}
+			}
 
 			return Json(new ServerInformation
 			{

--- a/src/Tgstation.Server.Host/Controllers/InstanceController.cs
+++ b/src/Tgstation.Server.Host/Controllers/InstanceController.cs
@@ -730,19 +730,30 @@ namespace Tgstation.Server.Host.Controllers
 		[HttpPatch("{id}")]
 		[TgsAuthorize(InstanceManagerRights.GrantPermissions)]
 		[ProducesResponseType(204)]
+		[ProducesResponseType(typeof(ErrorMessage), 410)]
 		public async Task<IActionResult> GrantPermissions(long id, CancellationToken cancellationToken)
 		{
-			// ensure the current user has write privilege on the instance
-			var usersInstancePermissionSet = await DatabaseContext
+			IQueryable<Models.Instance> BaseQuery() => DatabaseContext
 				.Instances
 				.AsQueryable()
-				.Where(x => x.Id == id && x.SwarmIdentifer == swarmConfiguration.Identifier)
+				.Where(x => x.Id == id && x.SwarmIdentifer == swarmConfiguration.Identifier);
+
+			// ensure the current user has write privilege on the instance
+			var usersInstancePermissionSet = await BaseQuery()
 				.SelectMany(x => x.InstancePermissionSets)
 				.Where(x => x.PermissionSetId == AuthenticationContext.PermissionSet.Id.Value)
 				.FirstOrDefaultAsync(cancellationToken)
 				.ConfigureAwait(false);
 			if (usersInstancePermissionSet == default)
 			{
+				// does the instance actually exist?
+				var instanceExists = await BaseQuery()
+					.AnyAsync(cancellationToken)
+					.ConfigureAwait(false);
+
+				if (!instanceExists)
+					return Gone();
+
 				var instanceAdminUser = InstanceAdminPermissionSet(null);
 				instanceAdminUser.InstanceId = id;
 				DatabaseContext.InstancePermissionSets.Add(instanceAdminUser);

--- a/tests/Tgstation.Server.Tests/InstanceManagerTest.cs
+++ b/tests/Tgstation.Server.Tests/InstanceManagerTest.cs
@@ -89,6 +89,11 @@ namespace Tgstation.Server.Tests
 				Path = testNonEmpty
 			}, cancellationToken), ErrorCode.InstanceAtExistingPath).ConfigureAwait(false);
 
+			await ApiAssert.ThrowsException<ConflictException>(() => instanceManagerClient.GrantPermissions(new Api.Models.Instance
+			{
+				Id = 3482974,
+			}, cancellationToken), ErrorCode.ResourceNotPresent).ConfigureAwait(false);
+
 			// test can't create instance outside of whitelist
 			await ApiAssert.ThrowsException<ApiConflictException>(() => instanceManagerClient.CreateOrAttach(new Api.Models.Instance
 			{


### PR DESCRIPTION
:cl: HTTP API
Added a missing 410 response to PATCH `/Instance` when the instance did not exist.
GET `/` no longer redirects to the webpanel if API headers are present.
GET `/` now returns a `Vary` header when the webpanel is enabled.
Fixed `remoteRepositoryName` field not trimming the `.git` extension.
/:cl:
