### PR TITLE
Adds more events

### DIFF
--- a/src/DMAPI/tgs.dm
+++ b/src/DMAPI/tgs.dm
@@ -95,10 +95,12 @@
 #define TGS_EVENT_WATCHDOG_SHUTDOWN 15
 /// Before the watchdog detaches for a TGS update/restart. No parameters.
 #define TGS_EVENT_WATCHDOG_DETACH 16
-// We don't actually implement this value as the DMAPI can never receive it
+// We don't actually implement these 3 events as the DMAPI can never receive them.
 // #define TGS_EVENT_WATCHDOG_LAUNCH 17
-// Same here. We don't actually implement this value as the DMAPI can never receive it
 // #define TGS_EVENT_WORLD_END_PROCESS 18
+// #define TGS_EVENT_WORLD_DEL 19
+/// Watchdog event when TgsInitializationComplete() is called. No parameters.
+ #define TGS_EVENT_WORLD_PRIME 20
 
 // OTHER ENUMS
 
@@ -132,7 +134,6 @@
  *
  * This may use [/world/var/sleep_offline] to make this happen so ensure no changes are made to it while this call is running.
  * Afterwards, consider explicitly setting it to what you want to avoid this BYOND bug: http://www.byond.com/forum/post/2575184
- * Before this point, note that any static files or directories may be in use by another server. Your code should account for this.
  * This function should not be called before ..() in [/world/proc/New].
  */
 /world/proc/TgsInitializationComplete()

--- a/src/DMAPI/tgs.dm
+++ b/src/DMAPI/tgs.dm
@@ -99,7 +99,7 @@
 // #define TGS_EVENT_WATCHDOG_LAUNCH 17
 // #define TGS_EVENT_WATCHDOG_CRASH 18
 // #define TGS_EVENT_WORLD_END_PROCESS 19
-// #define TGS_EVENT_WORLD_DEL 20
+// #define TGS_EVENT_WORLD_REBOOT 20
 /// Watchdog event when TgsInitializationComplete() is called. No parameters.
  #define TGS_EVENT_WORLD_PRIME 21
 

--- a/src/DMAPI/tgs.dm
+++ b/src/DMAPI/tgs.dm
@@ -97,10 +97,11 @@
 #define TGS_EVENT_WATCHDOG_DETACH 16
 // We don't actually implement these 3 events as the DMAPI can never receive them.
 // #define TGS_EVENT_WATCHDOG_LAUNCH 17
-// #define TGS_EVENT_WORLD_END_PROCESS 18
-// #define TGS_EVENT_WORLD_DEL 19
+// #define TGS_EVENT_WATCHDOG_CRASH 18
+// #define TGS_EVENT_WORLD_END_PROCESS 19
+// #define TGS_EVENT_WORLD_DEL 20
 /// Watchdog event when TgsInitializationComplete() is called. No parameters.
- #define TGS_EVENT_WORLD_PRIME 20
+ #define TGS_EVENT_WORLD_PRIME 21
 
 // OTHER ENUMS
 

--- a/src/Tgstation.Server.Host/Components/Events/EventType.cs
+++ b/src/Tgstation.Server.Host/Components/Events/EventType.cs
@@ -114,9 +114,21 @@ namespace Tgstation.Server.Host.Components.Events
 		WatchdogLaunch,
 
 		/// <summary>
-		/// In between DD restarts if the process has been force-ended by the DMAPI (TgsEndProcess())
+		/// In between watchdog DreamDaemon restarts if the process has been force-ended by the DMAPI (TgsEndProcess()). No parameters.
 		/// </summary>
 		[EventScript("WorldEndProcess")]
 		WorldEndProcess,
+
+		/// <summary>
+		/// After any sort of watchdog DreamDaemon closure or reboot. Reboots only supported with DMAPI. Not synchronous. Called after <see cref="WorldEndProcess"/>. No parameters.
+		/// </summary>
+		[EventScript("WorldDel")]
+		WorldDel,
+
+		/// <summary>
+		/// Watchdog event when TgsInitializationComplete() is called. No parameters.
+		/// </summary>
+		[EventScript("WorldPrime")]
+		WorldPrime,
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Events/EventType.cs
+++ b/src/Tgstation.Server.Host/Components/Events/EventType.cs
@@ -116,7 +116,7 @@ namespace Tgstation.Server.Host.Components.Events
 		/// <summary>
 		/// Watchdog event when DreamDaemon exits unexpectedly. No parameters.
 		/// </summary>
-		[EventScript("WatchdogLaunch")]
+		[EventScript("WatchdogCrash")]
 		WatchdogCrash,
 
 		/// <summary>

--- a/src/Tgstation.Server.Host/Components/Events/EventType.cs
+++ b/src/Tgstation.Server.Host/Components/Events/EventType.cs
@@ -96,7 +96,7 @@ namespace Tgstation.Server.Host.Components.Events
 		DeploymentComplete,
 
 		/// <summary>
-		/// Before the watchdog shutsdown. Not sent for graceful shutdowns. No parameters.
+		/// Before the watchdog shuts down. Not sent for graceful shutdowns. No parameters.
 		/// </summary>
 		[EventScript("WatchdogShutdown")]
 		WatchdogShutdown,
@@ -128,8 +128,8 @@ namespace Tgstation.Server.Host.Components.Events
 		/// <summary>
 		/// Watchdog event when TgsReboot() is called. Not synchronous. Called after <see cref="WorldEndProcess"/>. No parameters.
 		/// </summary>
-		[EventScript("WorldDel")]
-		WorldDel,
+		[EventScript("WorldReboot")]
+		WorldReboot,
 
 		/// <summary>
 		/// Watchdog event when TgsInitializationsComplete() is called. No parameters.

--- a/src/Tgstation.Server.Host/Components/Events/EventType.cs
+++ b/src/Tgstation.Server.Host/Components/Events/EventType.cs
@@ -114,6 +114,12 @@ namespace Tgstation.Server.Host.Components.Events
 		WatchdogLaunch,
 
 		/// <summary>
+		/// Watchdog event when DreamDaemon exits unexpectedly. No parameters.
+		/// </summary>
+		[EventScript("WatchdogLaunch")]
+		WatchdogCrash,
+
+		/// <summary>
 		/// In between watchdog DreamDaemon restarts if the process has been force-ended by the DMAPI (TgsEndProcess()). No parameters.
 		/// </summary>
 		[EventScript("WorldEndProcess")]

--- a/src/Tgstation.Server.Host/Components/Events/EventType.cs
+++ b/src/Tgstation.Server.Host/Components/Events/EventType.cs
@@ -120,13 +120,13 @@ namespace Tgstation.Server.Host.Components.Events
 		WorldEndProcess,
 
 		/// <summary>
-		/// After any sort of watchdog DreamDaemon closure or reboot. Reboots only supported with DMAPI. Not synchronous. Called after <see cref="WorldEndProcess"/>. No parameters.
+		/// Watchdog event when TgsReboot() is called. Not synchronous. Called after <see cref="WorldEndProcess"/>. No parameters.
 		/// </summary>
 		[EventScript("WorldDel")]
 		WorldDel,
 
 		/// <summary>
-		/// Watchdog event when TgsInitializationComplete() is called. No parameters.
+		/// Watchdog event when TgsInitializationsComplete() is called. No parameters.
 		/// </summary>
 		[EventScript("WorldPrime")]
 		WorldPrime,

--- a/src/Tgstation.Server.Host/Components/Session/ISessionController.cs
+++ b/src/Tgstation.Server.Host/Components/Session/ISessionController.cs
@@ -49,12 +49,12 @@ namespace Tgstation.Server.Host.Components.Session
 		RebootState RebootState { get; }
 
 		/// <summary>
-		/// A <see cref="Task"/> that completes when the server calls /world/Reboot()
+		/// A <see cref="Task"/> that completes when the server calls /world/TgsReboot().
 		/// </summary>
 		Task OnReboot { get; }
 
 		/// <summary>
-		/// A <see cref="Task"/> that completes when the server calls /world/TgsInitializationsComplete()
+		/// A <see cref="Task"/> that completes when the server calls /world/TgsInitializationComplete()
 		/// </summary>
 		Task OnPrime { get; }
 

--- a/src/Tgstation.Server.Host/Components/Watchdog/BasicWatchdog.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/BasicWatchdog.cs
@@ -130,7 +130,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 					gracefulRebootRequired = false;
 					Server.ResetRebootState();
 
-					await EventConsumer.HandleEvent(EventType.WorldDel, Enumerable.Empty<string>(), cancellationToken).ConfigureAwait(false);
+					await EventConsumer.HandleEvent(EventType.WorldReboot, Enumerable.Empty<string>(), cancellationToken).ConfigureAwait(false);
 
 					switch (rebootState)
 					{

--- a/src/Tgstation.Server.Host/Components/Watchdog/BasicWatchdog.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/BasicWatchdog.cs
@@ -92,10 +92,12 @@ namespace Tgstation.Server.Host.Components.Watchdog
 			switch (reason)
 			{
 				case MonitorActivationReason.ActiveServerCrashed:
-					if (Server.TerminationWasRequested)
-						await EventConsumer.HandleEvent(EventType.WorldEndProcess, Enumerable.Empty<string>(), cancellationToken).ConfigureAwait(false);
+					var eventType = Server.TerminationWasRequested
+						? EventType.WorldEndProcess
+						: EventType.WatchdogCrash;
+					await EventConsumer.HandleEvent(eventType, Enumerable.Empty<string>(), cancellationToken).ConfigureAwait(false);
 
-					string exitWord = Server.TerminationWasRequested ? "exited" : "crashed";
+					var exitWord = Server.TerminationWasRequested ? "exited" : "crashed";
 					if (Server.RebootState == Session.RebootState.Shutdown)
 					{
 						// the time for graceful shutdown is now

--- a/src/Tgstation.Server.Host/Components/Watchdog/BasicWatchdog.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/BasicWatchdog.cs
@@ -95,8 +95,6 @@ namespace Tgstation.Server.Host.Components.Watchdog
 					if (Server.TerminationWasRequested)
 						await EventConsumer.HandleEvent(EventType.WorldEndProcess, Enumerable.Empty<string>(), cancellationToken).ConfigureAwait(false);
 
-					await EventConsumer.HandleEvent(EventType.WorldDel, Enumerable.Empty<string>(), cancellationToken).ConfigureAwait(false);
-
 					string exitWord = Server.TerminationWasRequested ? "exited" : "crashed";
 					if (Server.RebootState == Session.RebootState.Shutdown)
 					{

--- a/src/Tgstation.Server.Host/Components/Watchdog/BasicWatchdog.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/BasicWatchdog.cs
@@ -95,6 +95,8 @@ namespace Tgstation.Server.Host.Components.Watchdog
 					if (Server.TerminationWasRequested)
 						await EventConsumer.HandleEvent(EventType.WorldEndProcess, Enumerable.Empty<string>(), cancellationToken).ConfigureAwait(false);
 
+					await EventConsumer.HandleEvent(EventType.WorldDel, Enumerable.Empty<string>(), cancellationToken).ConfigureAwait(false);
+
 					string exitWord = Server.TerminationWasRequested ? "exited" : "crashed";
 					if (Server.RebootState == Session.RebootState.Shutdown)
 					{
@@ -128,6 +130,8 @@ namespace Tgstation.Server.Host.Components.Watchdog
 					gracefulRebootRequired = false;
 					Server.ResetRebootState();
 
+					await EventConsumer.HandleEvent(EventType.WorldDel, Enumerable.Empty<string>(), cancellationToken).ConfigureAwait(false);
+
 					switch (rebootState)
 					{
 						case Session.RebootState.Normal:
@@ -144,13 +148,15 @@ namespace Tgstation.Server.Host.Components.Watchdog
 						default:
 							throw new InvalidOperationException($"Invalid reboot state: {rebootState}");
 					}
-
 				case MonitorActivationReason.ActiveLaunchParametersUpdated:
 					await Server.SetRebootState(Session.RebootState.Restart, cancellationToken).ConfigureAwait(false);
 					gracefulRebootRequired = true;
 					break;
 				case MonitorActivationReason.NewDmbAvailable:
 					await HandleNewDmbAvailable(cancellationToken).ConfigureAwait(false);
+					break;
+				case MonitorActivationReason.ActiveServerPrimed:
+					await EventConsumer.HandleEvent(EventType.WorldPrime, Enumerable.Empty<string>(), cancellationToken).ConfigureAwait(false);
 					break;
 				case MonitorActivationReason.Heartbeat:
 				default:

--- a/src/Tgstation.Server.Host/Components/Watchdog/MonitorActivationReason.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/MonitorActivationReason.cs
@@ -1,4 +1,4 @@
-﻿namespace Tgstation.Server.Host.Components.Watchdog
+namespace Tgstation.Server.Host.Components.Watchdog
 {
 	/// <summary>
 	/// Reasons for the monitor to wake up
@@ -29,5 +29,10 @@
 		/// A heartbeat is required.
 		/// </summary>
 		Heartbeat,
+
+		/// <summary>
+		/// Server primed.
+		/// </summary>
+		ActiveServerPrimed,
 	}
 }

--- a/tgstation-server.sln
+++ b/tgstation-server.sln
@@ -65,6 +65,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tgs", "tgs", "{F7765A4B-021
 		src\DMAPI\tgs\includes.dm = src\DMAPI\tgs\includes.dm
 		src\DMAPI\tgs\LICENSE = src\DMAPI\tgs\LICENSE
 		src\DMAPI\tgs\README.md = src\DMAPI\tgs\README.md
+		src\DMAPI\tgs.dm = src\DMAPI\tgs.dm
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "core", "core", "{DCCBA9DA-47BA-4C70-823B-E99A3ACA0377}"


### PR DESCRIPTION
:cl:
Added the `WatchdogCrash` event. Triggers when the DreamDaemon process exits for reasons other than a call to `TgsEndProcess()`.
Added the `WorldReboot` event. Triggers on calls to `TgsReboot()`.
Added the `WorldPrime` event. Triggers on calls to `TgsInitializationComplete()`.
Eliminated scenarios where watchdog events would go unhandled due to a previous event still being processed.
/:cl: