### PR TITLE
Add missing console logging to service configuring

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -8,7 +8,7 @@
     <TgsApiVersion>8.3.0</TgsApiVersion>
     <TgsClientVersion>9.1.2</TgsClientVersion>
     <TgsDmapiVersion>5.3.0</TgsDmapiVersion>
-    <TgsHostWatchdogVersion>1.1.0</TgsHostWatchdogVersion>
+    <TgsHostWatchdogVersion>1.1.1</TgsHostWatchdogVersion>
     <TgsContainerScriptVersion>1.2.0</TgsContainerScriptVersion>
   </PropertyGroup>
 </Project>

--- a/src/Tgstation.Server.Host.Service/Program.cs
+++ b/src/Tgstation.Server.Host.Service/Program.cs
@@ -1,4 +1,4 @@
-﻿using McMaster.Extensions.CommandLineUtils;
+using McMaster.Extensions.CommandLineUtils;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Specialized;
@@ -20,12 +20,10 @@ namespace Tgstation.Server.Host.Service
 	/// </summary>
 	sealed class Program
 	{
-#pragma warning disable SA1401 // Fields should be private
 		/// <summary>
 		/// The <see cref="IWatchdogFactory"/> for the <see cref="Program"/>
 		/// </summary>
 		internal static IWatchdogFactory WatchdogFactory = new WatchdogFactory();
-#pragma warning restore SA1401 // Fields should be private
 
 		/// <summary>
 		/// The --uninstall or -u option
@@ -151,6 +149,10 @@ namespace Tgstation.Server.Host.Service
 
 				if (Configure)
 				{
+#pragma warning disable CS0618 // Type or member is obsolete
+					loggerFactory.AddConsole();
+#pragma warning restore CS0618 // Type or member is obsolete
+
 					// DCT: None available
 					await WatchdogFactory.CreateWatchdog(loggerFactory).RunAsync(true, Array.Empty<string>(), default).ConfigureAwait(false);
 				}

--- a/src/Tgstation.Server.Host.Service/Tgstation.Server.Host.Service.csproj
+++ b/src/Tgstation.Server.Host.Service/Tgstation.Server.Host.Service.csproj
@@ -30,6 +30,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.EventLog" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tgstation.Server.Host/Program.cs
+++ b/src/Tgstation.Server.Host/Program.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Tgstation.Server.Host.Core;
+using Tgstation.Server.Host.Properties;
 using Tgstation.Server.Host.System;
 
 namespace Tgstation.Server.Host
@@ -17,7 +18,7 @@ namespace Tgstation.Server.Host
 		/// <summary>
 		/// The expected host watchdog <see cref="Version"/>.
 		/// </summary>
-		internal static readonly Version HostWatchdogVersion = new Version(1, 1, 0);
+		internal static Version HostWatchdogVersion => Version.Parse(MasterVersionsAttribute.Instance.RawHostWatchdogVersion);
 
 		/// <summary>
 		/// The <see cref="IServerFactory"/> to use.

--- a/src/Tgstation.Server.Host/Properties/MasterVersionsAttribute.cs
+++ b/src/Tgstation.Server.Host/Properties/MasterVersionsAttribute.cs
@@ -32,19 +32,27 @@ namespace Tgstation.Server.Host.Properties
 		public string RawControlPanelVersion { get; }
 
 		/// <summary>
+		/// The <see cref="Version"/> <see cref="string"/> of the control panel version built.
+		/// </summary>
+		public string RawHostWatchdogVersion { get; }
+
+		/// <summary>
 		/// Initializes a new instance of the <see cref="MasterVersionsAttribute"/> <see langword="class"/>.
 		/// </summary>
 		/// <param name="rawConfigurationVersion">The value of <see cref="RawConfigurationVersion"/>.</param>
 		/// <param name="rawDMApiVersion">The value of <see cref="RawDMApiVersion"/>.</param>
 		/// <param name="rawControlPanelVersion">The value of <see cref="RawControlPanelVersion"/>.</param>
+		/// <param name="rawHostWatchdogVersion">The value of <see cref="RawHostWatchdogVersion"/>.</param>
 		public MasterVersionsAttribute(
 			string rawConfigurationVersion,
 			string rawDMApiVersion,
-			string rawControlPanelVersion)
+			string rawControlPanelVersion,
+			string rawHostWatchdogVersion)
 		{
 			RawConfigurationVersion = rawConfigurationVersion ?? throw new ArgumentNullException(nameof(rawConfigurationVersion));
 			RawDMApiVersion = rawDMApiVersion ?? throw new ArgumentNullException(nameof(rawDMApiVersion));
 			RawControlPanelVersion = rawControlPanelVersion ?? throw new ArgumentNullException(nameof(rawControlPanelVersion));
+			RawHostWatchdogVersion = rawHostWatchdogVersion ?? throw new ArgumentNullException(nameof(rawHostWatchdogVersion));
 		}
 	}
 }

--- a/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
+++ b/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
@@ -51,6 +51,7 @@
         <_Parameter1>$(TgsConfigVersion)</_Parameter1>
         <_Parameter2>$(TgsDmapiVersion)</_Parameter2>
         <_Parameter3>$(TgsControlPanelVersion)</_Parameter3>
+        <_Parameter4>$(TgsHostWatchdogVersion)</_Parameter4>
       </AssemblyAttributes>
     </ItemGroup>
 


### PR DESCRIPTION
- Let people know they're missing the .NET runtime

:cl:
The service first time experience now logs if you're missing the required dotnet runtime.
/:cl: