### PR TITLE
v4.8.1

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -7,7 +7,7 @@
     <TgsConfigVersion>2.3.0</TgsConfigVersion>
     <TgsApiVersion>8.3.0</TgsApiVersion>
     <TgsClientVersion>9.1.2</TgsClientVersion>
-    <TgsDmapiVersion>6.0.0</TgsDmapiVersion>
+    <TgsDmapiVersion>6.0.1</TgsDmapiVersion>
     <TgsInteropVersion>5.3.0</TgsInteropVersion>
     <TgsHostWatchdogVersion>1.1.1</TgsHostWatchdogVersion>
     <TgsContainerScriptVersion>1.2.0</TgsContainerScriptVersion>

--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>4.8.0</TgsCoreVersion>
+    <TgsCoreVersion>4.8.1</TgsCoreVersion>
     <TgsConfigVersion>2.3.0</TgsConfigVersion>
     <TgsApiVersion>8.3.0</TgsApiVersion>
     <TgsClientVersion>9.2.0</TgsClientVersion>

--- a/src/DMAPI/tgs.dm
+++ b/src/DMAPI/tgs.dm
@@ -95,7 +95,7 @@
 #define TGS_EVENT_WATCHDOG_SHUTDOWN 15
 /// Before the watchdog detaches for a TGS update/restart. No parameters.
 #define TGS_EVENT_WATCHDOG_DETACH 16
-// We don't actually implement these 3 events as the DMAPI can never receive them.
+// We don't actually implement these 4 events as the DMAPI can never receive them.
 // #define TGS_EVENT_WATCHDOG_LAUNCH 17
 // #define TGS_EVENT_WATCHDOG_CRASH 18
 // #define TGS_EVENT_WORLD_END_PROCESS 19

--- a/src/DMAPI/tgs.dm
+++ b/src/DMAPI/tgs.dm
@@ -1,6 +1,6 @@
 // tgstation-server DMAPI
 
-#define TGS_DMAPI_VERSION "6.0.0"
+#define TGS_DMAPI_VERSION "6.0.1"
 
 // All functions and datums outside this document are subject to change with any version and should not be relied on.
 

--- a/src/DMAPI/tgs/v5/api.dm
+++ b/src/DMAPI/tgs/v5/api.dm
@@ -66,10 +66,13 @@
 			if(revInfo)
 				tm.commit = revisionData[DMAPI5_REVISION_INFORMATION_COMMIT_SHA]
 				tm.origin_commit = revisionData[DMAPI5_REVISION_INFORMATION_ORIGIN_COMMIT_SHA]
+				tm.timestamp = entry[DMAPI5_REVISION_INFORMATION_TIMESTAMP]
 			else
 				TGS_WARNING_LOG("Failed to decode [DMAPI5_TEST_MERGE_REVISION] from test merge #[tm.number]!")
 
-			tm.timestamp = entry[DMAPI5_TEST_MERGE_TIME_MERGED]
+			if(!tm.timestamp)
+				tm.timestamp = entry[DMAPI5_TEST_MERGE_TIME_MERGED]
+
 			tm.title = entry[DMAPI5_TEST_MERGE_TITLE_AT_MERGE]
 			tm.body = entry[DMAPI5_TEST_MERGE_BODY_AT_MERGE]
 			tm.url = entry[DMAPI5_TEST_MERGE_URL]

--- a/src/Tgstation.Server.Host/Core/Application.cs
+++ b/src/Tgstation.Server.Host/Core/Application.cs
@@ -450,7 +450,7 @@ namespace Tgstation.Server.Host.Core
 			}
 			else if (controlPanelConfiguration.AllowedOrigins?.Count > 0)
 			{
-				logger.LogTrace("Access-Control-Allow-Origin: ", String.Join(',', controlPanelConfiguration.AllowedOrigins));
+				logger.LogTrace("Access-Control-Allow-Origin: {0}", String.Join(',', controlPanelConfiguration.AllowedOrigins));
 				corsBuilder = builder => builder.WithOrigins(controlPanelConfiguration.AllowedOrigins.ToArray());
 			}
 

--- a/src/Tgstation.Server.Host/Setup/SetupWizard.cs
+++ b/src/Tgstation.Server.Host/Setup/SetupWizard.cs
@@ -952,6 +952,13 @@ namespace Tgstation.Server.Host.Setup
 				try
 				{
 					var exists = await ioManager.FileExists(userConfigFileName, cancellationToken).ConfigureAwait(false);
+					if (!exists)
+					{
+						var legacyJsonFileName = $"appsettings.{hostingEnvironment.EnvironmentName}.json";
+						exists = await ioManager.FileExists(legacyJsonFileName, cancellationToken).ConfigureAwait(false);
+						if (exists)
+							userConfigFileName = legacyJsonFileName;
+					}
 
 					bool shouldRunBasedOnAutodetect;
 					if (exists)


### PR DESCRIPTION
:cl:
Fixed servers <= 4.7.X updating with `General:SetupWizardMode` set to `Autodetect` having their setup wizards run again.
Fixed swarmed servers colliding ports across nodes.
/:cl:

:cl: DMAPI
Fixed incorrect documentation.
Prefer the interop 5.3 method of retrieving test merge `timestamp`s instead of the legacy `timeMerged`.
/:cl: