### PR TITLE
Adds Webpanel Channels

### DIFF
--- a/build/ControlPanelVersion.props
+++ b/build/ControlPanelVersion.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <!-- This is in it's own file to help incremental building, changing it causes a complete rebuild of the web panel -->
-    <TgsControlPanelVersion>2.0.1</TgsControlPanelVersion>
+    <TgsControlPanelVersion>2.1.0</TgsControlPanelVersion>
   </PropertyGroup>
 </Project>

--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>4.8.1</TgsCoreVersion>
+    <TgsCoreVersion>4.9.0</TgsCoreVersion>
     <TgsConfigVersion>3.0.0</TgsConfigVersion>
     <TgsApiVersion>8.3.0</TgsApiVersion>
     <TgsClientVersion>9.2.0</TgsClientVersion>

--- a/build/Version.props
+++ b/build/Version.props
@@ -4,7 +4,7 @@
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
     <TgsCoreVersion>4.8.1</TgsCoreVersion>
-    <TgsConfigVersion>2.3.0</TgsConfigVersion>
+    <TgsConfigVersion>3.0.0</TgsConfigVersion>
     <TgsApiVersion>8.3.0</TgsApiVersion>
     <TgsClientVersion>9.2.0</TgsClientVersion>
     <TgsDmapiVersion>6.0.1</TgsDmapiVersion>

--- a/src/Tgstation.Server.Host/Configuration/ControlPanelConfiguration.cs
+++ b/src/Tgstation.Server.Host/Configuration/ControlPanelConfiguration.cs
@@ -22,6 +22,9 @@ namespace Tgstation.Server.Host.Configuration
 		/// </summary>
 		public bool AllowAnyOrigin { get; set; }
 
+		/// <summary>
+		/// The channel to retrieve the webpanel from. "local" uses the bundled version.
+		/// </summary>
 		public string Channel { get; set; }
 
 		/// <summary>

--- a/src/Tgstation.Server.Host/Configuration/ControlPanelConfiguration.cs
+++ b/src/Tgstation.Server.Host/Configuration/ControlPanelConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace Tgstation.Server.Host.Configuration
 {
@@ -21,6 +21,8 @@ namespace Tgstation.Server.Host.Configuration
 		/// If any origin is allowed for CORS requests. This overrides <see cref="AllowedOrigins"/>
 		/// </summary>
 		public bool AllowAnyOrigin { get; set; }
+
+		public string Channel { get; set; }
 
 		/// <summary>
 		/// Origins allowed for CORS requests

--- a/src/Tgstation.Server.Host/Controllers/ControlPanelController.cs
+++ b/src/Tgstation.Server.Host/Controllers/ControlPanelController.cs
@@ -50,7 +50,7 @@ namespace Tgstation.Server.Host.Controllers
 		{
 			var controlPanelChannel = controlPanelConfiguration.Channel;
 			if (controlPanelChannel == "local")
-				controlPanelChannel = "/";
+				controlPanelChannel = Application.ControlPanelRoute;
 
 			controlPanelChannel = controlPanelChannel
 				.Replace("${Major}", ApiHeaders.Version.Major.ToString(CultureInfo.InvariantCulture), StringComparison.Ordinal)

--- a/src/Tgstation.Server.Host/Controllers/ControlPanelController.cs
+++ b/src/Tgstation.Server.Host/Controllers/ControlPanelController.cs
@@ -41,6 +41,30 @@ namespace Tgstation.Server.Host.Controllers
 		}
 
 		/// <summary>
+		/// Returns the <see cref="ControlPanelConfiguration.Channel"/>.
+		/// </summary>
+		/// <returns>A <see cref="JsonResult"/> with the <see cref="ControlPanelConfiguration.Channel"/>.</returns>
+		[Route("channel.json")]
+		[HttpGet]
+		public JsonResult GetChannelJson()
+		{
+			var controlPanelChannel = controlPanelConfiguration.Channel;
+			if (controlPanelChannel == "local")
+				controlPanelChannel = "/";
+
+			controlPanelChannel = controlPanelChannel
+				.Replace("${Major}", ApiHeaders.Version.Major.ToString(CultureInfo.InvariantCulture), StringComparison.Ordinal)
+				.Replace("${Minor}", ApiHeaders.Version.Minor.ToString(CultureInfo.InvariantCulture), StringComparison.Ordinal)
+				.Replace("${Patch}", ApiHeaders.Version.Build.ToString(CultureInfo.InvariantCulture), StringComparison.Ordinal);
+
+			return Json(new
+			{
+				FormatVersion = 1,
+				Channel = controlPanelChannel,
+			});
+		}
+
+		/// <summary>
 		/// Handle a GET request to the control panel route. Route to static files if they exist, otherwise index.html.
 		/// </summary>
 		/// <param name="appRoute">The value of the route.</param>
@@ -64,30 +88,6 @@ namespace Tgstation.Server.Host.Controllers
 			}
 
 			return File("index.html", MediaTypeNames.Text.Html);
-		}
-
-		/// <summary>
-		/// 
-		/// </summary>
-		/// <returns></returns>
-		[Route("channel.json")]
-		[HttpGet]
-		public JsonResult GetChannelJson()
-		{
-			var controlPanelChannel = controlPanelConfiguration.Channel;
-			if (controlPanelChannel == "local")
-				controlPanelChannel = "/";
-
-			controlPanelChannel = controlPanelChannel
-				.Replace("${Major}", ApiHeaders.Version.Major.ToString(CultureInfo.InvariantCulture), StringComparison.Ordinal)
-				.Replace("${Minor}", ApiHeaders.Version.Minor.ToString(CultureInfo.InvariantCulture), StringComparison.Ordinal)
-				.Replace("${Patch}", ApiHeaders.Version.Build.ToString(CultureInfo.InvariantCulture), StringComparison.Ordinal);
-
-			return Json(new
-			{
-				FormatVersion = 1,
-				Channel = controlPanelChannel,
-			});
 		}
 	}
 }

--- a/src/Tgstation.Server.Host/Controllers/ControlPanelController.cs
+++ b/src/Tgstation.Server.Host/Controllers/ControlPanelController.cs
@@ -1,10 +1,14 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 using System;
+using System.Globalization;
 using System.Net.Mime;
+using Tgstation.Server.Api;
+using Tgstation.Server.Host.Configuration;
 using Tgstation.Server.Host.Core;
 
 namespace Tgstation.Server.Host.Controllers
@@ -21,12 +25,19 @@ namespace Tgstation.Server.Host.Controllers
 		readonly IWebHostEnvironment hostEnvironment;
 
 		/// <summary>
+		/// The <see cref="ControlPanelConfiguration"/> for the <see cref="ControlPanelController"/>.
+		/// </summary>
+		readonly ControlPanelConfiguration controlPanelConfiguration;
+
+		/// <summary>
 		/// Initializes a new instance of the <see cref="ControlPanelController"/> <see langword="class"/>.
 		/// </summary>
 		/// <param name="hostEnvironment">The value of <see cref="hostEnvironment"/>.</param>
-		public ControlPanelController(IWebHostEnvironment hostEnvironment)
+		/// <param name="controlPanelConfigurationOptions">The <see cref="IOptions{TOptions}"/> containing the value of <see cref="controlPanelConfiguration"/>.</param>
+		public ControlPanelController(IWebHostEnvironment hostEnvironment, IOptions<ControlPanelConfiguration> controlPanelConfigurationOptions)
 		{
 			this.hostEnvironment = hostEnvironment ?? throw new ArgumentNullException(nameof(hostEnvironment));
+			controlPanelConfiguration = controlPanelConfigurationOptions?.Value ?? throw new ArgumentNullException(nameof(controlPanelConfigurationOptions));
 		}
 
 		/// <summary>
@@ -53,6 +64,30 @@ namespace Tgstation.Server.Host.Controllers
 			}
 
 			return File("index.html", MediaTypeNames.Text.Html);
+		}
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <returns></returns>
+		[Route("channel.json")]
+		[HttpGet]
+		public JsonResult GetChannelJson()
+		{
+			var controlPanelChannel = controlPanelConfiguration.Channel;
+			if (controlPanelChannel == "local")
+				controlPanelChannel = "/";
+
+			controlPanelChannel = controlPanelChannel
+				.Replace("${Major}", ApiHeaders.Version.Major.ToString(CultureInfo.InvariantCulture), StringComparison.Ordinal)
+				.Replace("${Minor}", ApiHeaders.Version.Minor.ToString(CultureInfo.InvariantCulture), StringComparison.Ordinal)
+				.Replace("${Patch}", ApiHeaders.Version.Build.ToString(CultureInfo.InvariantCulture), StringComparison.Ordinal);
+
+			return Json(new
+			{
+				FormatVersion = 1,
+				Channel = controlPanelChannel,
+			});
 		}
 	}
 }

--- a/src/Tgstation.Server.Host/Properties/MasterVersionsAttribute.cs
+++ b/src/Tgstation.Server.Host/Properties/MasterVersionsAttribute.cs
@@ -37,6 +37,11 @@ namespace Tgstation.Server.Host.Properties
 		public string RawHostWatchdogVersion { get; }
 
 		/// <summary>
+		/// The compile time default
+		/// </summary>
+		public string DefaultControlPanelChannel { get; }
+
+		/// <summary>
 		/// Initializes a new instance of the <see cref="MasterVersionsAttribute"/> <see langword="class"/>.
 		/// </summary>
 		/// <param name="rawConfigurationVersion">The value of <see cref="RawConfigurationVersion"/>.</param>

--- a/src/Tgstation.Server.Host/Swarm/SwarmService.cs
+++ b/src/Tgstation.Server.Host/Swarm/SwarmService.cs
@@ -1088,7 +1088,7 @@ namespace Tgstation.Server.Host.Swarm
 
 					nextForceHealthCheckTask = forceHealthCheckTcs.Task;
 
-					logger.LogDebug("Performing swarm health check...");
+					logger.LogTrace("Performing swarm health check...");
 					try
 					{
 						if (swarmController)

--- a/src/Tgstation.Server.Host/appsettings.yml
+++ b/src/Tgstation.Server.Host/appsettings.yml
@@ -28,6 +28,7 @@ Logging:
       Microsoft: Warning
 ControlPanel:
   Enable: false
+  Channel: https://tgstation.github.io/tgstation-server-webpanel/api/${Major}.${Minor}.${Patch}
   AllowAnyOrigin: false
   AllowedOrigins: []
 Updates:


### PR DESCRIPTION
Closes #1205 

:cl: Configuration
The new configuration version is 3.0.0.
Added `ControlPanel:Channel`. This should be set to a URL to load the web control panel from. The formatters `${Major}`, `${Minor}`, and `${Patch}` are available for the current TGS API version. If set to "local" the previous behavior of loading the bundled control panel will be used. **Upgrading installations will have this set to `null` by default. Consider setting it to the current default upstream: `https://tgstation.github.io/tgstation-server-webpanel/api/${Major}.${Minor}.${Patch}`.**
/:cl:


:cl: Web Control Panel
The control panel can now be updated independently of TGS via remote tracking.
Updated the bundled control panel to 2.1.2.
:cl: