### PR TITLE
Bump webpanel to 2.1.3

### DIFF
--- a/build/ControlPanelVersion.props
+++ b/build/ControlPanelVersion.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <!-- This is in it's own file to help incremental building, changing it causes a complete rebuild of the web panel -->
-    <TgsControlPanelVersion>2.1.2</TgsControlPanelVersion>
+    <TgsControlPanelVersion>2.1.3</TgsControlPanelVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
:cl: Web Control Panel
New info page which shows information about the client and the server
Bumped to version 2.1.3
/:cl:

Also contains a small fix to the bootstraper to handle null channel
