### PR TITLE
Return 400 instead of 401 for Authentication header issues

### DIFF
--- a/src/Tgstation.Server.Host/Controllers/ApiController.cs
+++ b/src/Tgstation.Server.Host/Controllers/ApiController.cs
@@ -182,9 +182,6 @@ namespace Tgstation.Server.Host.Controllers
 			if (headersException.MissingOrMalformedHeaders.HasFlag(HeaderTypes.Accept))
 				return StatusCode(HttpStatusCode.NotAcceptable, errorMessage);
 
-			if (headersException.MissingOrMalformedHeaders == HeaderTypes.Authorization)
-				return Unauthorized(errorMessage);
-
 			return BadRequest(errorMessage);
 		}
 

--- a/tests/Tgstation.Server.Tests/RawRequestTests.cs
+++ b/tests/Tgstation.Server.Tests/RawRequestTests.cs
@@ -136,6 +136,20 @@ namespace Tgstation.Server.Tests
 				Assert.AreEqual(ErrorCode.InstanceHeaderRequired, message.ErrorCode);
 			}
 
+			using (var request = new HttpRequestMessage(HttpMethod.Get, url.ToString()))
+			{
+				request.Headers.Accept.Clear();
+				request.Headers.UserAgent.Add(new ProductInfoHeaderValue("RootTest", "1.0.0"));
+				request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(MediaTypeNames.Application.Json));
+				request.Headers.Add(ApiHeaders.ApiVersionHeader, "Tgstation.Server.Api/" + ApiHeaders.Version);
+				request.Headers.Authorization = new AuthenticationHeaderValue(ApiHeaders.BearerAuthenticationScheme.ToLower(), token);
+				using var response = await httpClient.SendAsync(request, cancellationToken);
+				Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
+				var content = await response.Content.ReadAsStringAsync();
+				var message = JsonConvert.DeserializeObject<ErrorMessage>(content);
+				Assert.AreEqual(ErrorCode.BadHeaders, message.ErrorCode);
+			}
+
 			using (var request = new HttpRequestMessage(HttpMethod.Post, url.ToString()))
 			{
 				request.Headers.Accept.Clear();


### PR DESCRIPTION
:cl: HTTP API
Fixed having a missing/malformed `Authentication` header generating a 401 response instead of a 400.
/:cl: