### PR TITLE
v4.9.2

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>4.9.1</TgsCoreVersion>
+    <TgsCoreVersion>4.9.2</TgsCoreVersion>
     <TgsConfigVersion>3.0.0</TgsConfigVersion>
     <TgsApiVersion>8.3.0</TgsApiVersion>
     <TgsClientVersion>9.2.0</TgsClientVersion>

--- a/src/Tgstation.Server.Api/Models/Internal/SwarmServer.cs
+++ b/src/Tgstation.Server.Api/Models/Internal/SwarmServer.cs
@@ -12,7 +12,7 @@ namespace Tgstation.Server.Api.Models.Internal
 		/// The public address of the server.
 		/// </summary>
 		[Required]
-		public Uri? Address { get; set; }
+		public virtual Uri? Address { get; set; }
 
 		/// <summary>
 		/// The server's identifier.

--- a/src/Tgstation.Server.Host/Components/Repository/Repository.cs
+++ b/src/Tgstation.Server.Host/Components/Repository/Repository.cs
@@ -117,6 +117,16 @@ namespace Tgstation.Server.Host.Components.Repository
 		static CheckoutProgressHandler CheckoutProgressHandler(Action<int> progressReporter) => (a, completedSteps, totalSteps) => progressReporter((int)(((float)completedSteps) / totalSteps * 100));
 
 		/// <summary>
+		/// Rethrow the authentication failure message as a <see cref="JobException"/> if it is one.
+		/// </summary>
+		/// <param name="exception">The current <see cref="LibGit2SharpException"/>.</param>
+		static void CheckBadCredentialsException(LibGit2SharpException exception)
+		{
+			if (exception.Message == "too many redirects or authentication replays")
+				throw new JobException("Bad git credentials exchange!", exception);
+		}
+
+		/// <summary>
 		/// Construct a <see cref="Repository"/>
 		/// </summary>
 		/// <param name="libGitRepo">The value of <see cref="libGitRepo"/></param>
@@ -324,6 +334,10 @@ namespace Tgstation.Server.Host.Components.Repository
 							logMessage);
 					}
 					catch (UserCancelledException) { }
+					catch (LibGit2SharpException ex)
+					{
+						CheckBadCredentialsException(ex);
+					}
 
 					cancellationToken.ThrowIfCancellationRequested();
 
@@ -432,23 +446,34 @@ namespace Tgstation.Server.Host.Components.Repository
 				var remote = libGitRepo.Network.Remotes.First();
 				try
 				{
-					Commands.Fetch((LibGit2Sharp.Repository)libGitRepo, remote.Name, remote.FetchRefSpecs.Select(x => x.Specification), new FetchOptions
-					{
-						Prune = true,
-						OnProgress = (a) => !cancellationToken.IsCancellationRequested,
-						OnTransferProgress = (a) =>
+					commands.Fetch(
+						libGitRepo,
+						remote
+							.FetchRefSpecs
+							.Select(x => x.Specification),
+						remote,
+						new FetchOptions
 						{
-							var percentage = 100 * (((float)a.IndexedObjects + a.ReceivedObjects) / (a.TotalObjects * 2));
-							progressReporter((int)percentage);
-							return !cancellationToken.IsCancellationRequested;
+							Prune = true,
+							OnProgress = (a) => !cancellationToken.IsCancellationRequested,
+							OnTransferProgress = (a) =>
+							{
+								var percentage = 100 * (((float)a.IndexedObjects + a.ReceivedObjects) / (a.TotalObjects * 2));
+								progressReporter((int)percentage);
+								return !cancellationToken.IsCancellationRequested;
+							},
+							OnUpdateTips = (a, b, c) => !cancellationToken.IsCancellationRequested,
+							CredentialsProvider = credentialsProvider.GenerateCredentialsHandler(username, password)
 						},
-						OnUpdateTips = (a, b, c) => !cancellationToken.IsCancellationRequested,
-						CredentialsProvider = credentialsProvider.GenerateCredentialsHandler(username, password)
-					}, "Fetch origin commits");
+						"Fetch origin commits");
 				}
 				catch (UserCancelledException)
 				{
 					cancellationToken.ThrowIfCancellationRequested();
+				}
+				catch (LibGit2SharpException ex)
+				{
+					CheckBadCredentialsException(ex);
 				}
 			}, cancellationToken, DefaultIOManager.BlockingTaskCreationOptions, TaskScheduler.Current).ConfigureAwait(false);
 		}
@@ -480,7 +505,7 @@ namespace Tgstation.Server.Host.Components.Repository
 				{
 					cancellationToken.ThrowIfCancellationRequested();
 				}
-				catch(LibGit2SharpException e)
+				catch (LibGit2SharpException e)
 				{
 					logger.LogWarning(e, "Unable to push to temporary branch!");
 				}

--- a/src/Tgstation.Server.Host/Configuration/SwarmConfiguration.cs
+++ b/src/Tgstation.Server.Host/Configuration/SwarmConfiguration.cs
@@ -1,5 +1,6 @@
 using System;
 using Tgstation.Server.Api.Models.Internal;
+using YamlDotNet.Serialization;
 
 namespace Tgstation.Server.Host.Configuration
 {
@@ -13,9 +14,18 @@ namespace Tgstation.Server.Host.Configuration
 		/// </summary>
 		public const string Section = "Swarm";
 
+		/// <inheritdoc />
+		[YamlMember(SerializeAs = typeof(string))]
+		public override Uri Address
+		{
+			get => base.Address;
+			set => base.Address = value;
+		}
+
 		/// <summary>
 		/// The <see cref="SwarmServer.Address"/> of the swarm controller. If <see langword="null"/>, the current server is considered the controller.
 		/// </summary>
+		[YamlMember(SerializeAs = typeof(string))]
 		public Uri ControllerAddress { get; set; }
 
 		/// <summary>

--- a/src/Tgstation.Server.Host/Extensions/Converters/VersionConverter.cs
+++ b/src/Tgstation.Server.Host/Extensions/Converters/VersionConverter.cs
@@ -8,7 +8,7 @@ using YamlDotNet.Serialization;
 namespace Tgstation.Server.Host.Extensions.Converters
 {
 	/// <summary>
-	/// <see cref="JsonConverter"/> and <see cref="IYamlTypeConverter"/> for serializing <see cref="global::System.Version"/>s for BYOND.
+	/// <see cref="JsonConverter"/> and <see cref="IYamlTypeConverter"/> for serializing <see cref="global::System.Version"/>s in semver format.
 	/// </summary>
 	sealed class VersionConverter : JsonConverter, IYamlTypeConverter
 	{
@@ -82,19 +82,7 @@ namespace Tgstation.Server.Host.Extensions.Converters
 		public bool Accepts(Type type) => CheckSupportsType(type, false);
 
 		/// <inheritdoc />
-		public object ReadYaml(IParser parser, Type type)
-		{
-			if (parser == null)
-				throw new ArgumentNullException(nameof(parser));
-
-			CheckSupportsType(type, true);
-
-			var scalar = parser.Consume<Scalar>();
-			if (scalar == null)
-				return null;
-
-			return global::System.Version.Parse(scalar.Value);
-		}
+		public object ReadYaml(IParser parser, Type type) => throw new NotSupportedException("Deserialization not supported!"); // The default implementation is fine at handling this
 
 		/// <inheritdoc />
 		public void WriteYaml(IEmitter emitter, object value, Type type)
@@ -104,11 +92,14 @@ namespace Tgstation.Server.Host.Extensions.Converters
 
 			CheckSupportsType(type, true);
 
+			if (value == null)
+				throw new NotSupportedException("Null values not supported!");
+
 			var version = (global::System.Version)value;
 			emitter.Emit(
 				new Scalar(
 					version
-						?.Semver()
+						.Semver()
 						.ToString()));
 		}
 	}

--- a/tests/Tgstation.Server.Host.Tests/Extensions/Converters/TestVersionConverter.cs
+++ b/tests/Tgstation.Server.Host.Tests/Extensions/Converters/TestVersionConverter.cs
@@ -37,16 +37,5 @@ namespace Tgstation.Server.Host.Extensions.Converters.Tests
 
 			Assert.AreEqual(testYaml, serializedString.Trim());
 		}
-
-		[TestMethod]
-		public void TestYamlDeserialization()
-		{
-			var deserialized = new DeserializerBuilder()
-				.WithTypeConverter(new VersionConverter())
-				.Build()
-				.Deserialize<TestObject>(testYaml);
-
-			Assert.AreEqual(testVersion, deserialized.Version);
-		}
 	}
 }

--- a/tests/Tgstation.Server.Host.Tests/Setup/TestSetupWizard.cs
+++ b/tests/Tgstation.Server.Host.Tests/Setup/TestSetupWizard.cs
@@ -47,7 +47,7 @@ namespace Tgstation.Server.Host.Setup.Tests
 			mockConfiguration.Setup(x => x.GetReloadToken()).Returns(Mock.Of<IChangeToken>());
 			Assert.ThrowsException<ArgumentNullException>(() => new SetupWizard(mockIOManager.Object, mockConsole.Object, mockHostingEnvironment.Object, mockAssemblyInfoProvider.Object, mockDBConnectionFactory.Object, mockPlatformIdentifier.Object, mockAsyncDelayer.Object, mockLifetime.Object, mockConfiguration.Object, null));
 		}
-		
+
 		[TestMethod]
 		public async Task TestWithUserStupiditiy()
 		{
@@ -106,7 +106,7 @@ namespace Tgstation.Server.Host.Setup.Tests
 				.Callback(() => configReloadCallback(configReloadCallbackState))
 				.Returns(Task.CompletedTask)
 				.Verifiable();
-			
+
 			var mockSuccessCommand = new Mock<DbCommand>();
 			mockSuccessCommand.Setup(x => x.ExecuteNonQueryAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult(0)).Verifiable();
 			mockSuccessCommand.Setup(x => x.ExecuteScalarAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult<object>("1.2.3")).Verifiable();
@@ -279,11 +279,16 @@ namespace Tgstation.Server.Host.Setup.Tests
 			//second run
 			mockIOManager.Setup(x => x.ReadAllBytes(It.IsNotNull<string>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(Encoding.UTF8.GetBytes(String.Empty))).Verifiable();
 			await wizard.StartAsync(default).ConfigureAwait(false);
-		
+
 			//third run
 			testGeneralConfig.SetupWizardMode = SetupWizardMode.Autodetect;
 			mockIOManager
 				.Setup(x => x.WriteAllBytes(It.IsNotNull<string>(), It.IsNotNull<byte[]>(), It.IsAny<CancellationToken>()))
+				.Callback((string path, byte[] bytes, CancellationToken ct) =>
+				{
+					// for debugging
+					var str = Encoding.UTF8.GetString(bytes);
+				})
 				.Throws(new Exception())
 				.Verifiable();
 			var firstRun = true;


### PR DESCRIPTION
:cl:
Fixed swarm settings saved by the setup wizard being invalid.
Bad credentials should now throw cleaner errors for git remote operations.
/:cl: