### PR TITLE
Fix watchdog shutdown script invocation

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>4.9.2</TgsCoreVersion>
+    <TgsCoreVersion>4.9.3</TgsCoreVersion>
     <TgsConfigVersion>3.0.0</TgsConfigVersion>
     <TgsApiVersion>8.3.0</TgsApiVersion>
     <TgsClientVersion>9.2.0</TgsClientVersion>

--- a/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
@@ -267,7 +267,12 @@ namespace Tgstation.Server.Host.Components.Watchdog
 				return;
 			if (!graceful)
 			{
-				var eventTask = EventConsumer.HandleEvent(releaseServers ? EventType.WatchdogDetach : EventType.WatchdogShutdown, null, cancellationToken);
+				var eventTask = EventConsumer.HandleEvent(
+					releaseServers
+						? EventType.WatchdogDetach
+						: EventType.WatchdogShutdown,
+					Enumerable.Empty<string>(),
+					cancellationToken);
 
 				var chatTask = announce ? Chat.QueueWatchdogMessage("Shutting down...", cancellationToken) : Task.CompletedTask;
 


### PR DESCRIPTION
:cl:
Fixed an error when stopping the watchdog with event scripts for `WatchdogDetach` or `WatchdogShutdown` present.
/:cl: