### PR TITLE
Make webpanel redirection work on presence of `Api` header

### DIFF
--- a/src/Tgstation.Server.Host/Controllers/ControlPanelController.cs
+++ b/src/Tgstation.Server.Host/Controllers/ControlPanelController.cs
@@ -9,17 +9,21 @@ using System.Globalization;
 using System.Net.Mime;
 using Tgstation.Server.Api;
 using Tgstation.Server.Host.Configuration;
-using Tgstation.Server.Host.Core;
 
 namespace Tgstation.Server.Host.Controllers
 {
 	/// <summary>
 	/// Controller for the web control panel.
 	/// </summary>
-	[Route(Application.ControlPanelRoute)]
+	[Route(ControlPanelRoute)]
 	[ApiExplorerSettings(IgnoreApi = true)]
 	public class ControlPanelController : Controller
 	{
+		/// <summary>
+		/// Route to the <see cref="ControlPanelController"/>.
+		/// </summary>
+		public const string ControlPanelRoute = "/app";
+
 		/// <summary>
 		/// The <see cref="IWebHostEnvironment"/> for the <see cref="ControlPanelController"/>.
 		/// </summary>
@@ -51,7 +55,7 @@ namespace Tgstation.Server.Host.Controllers
 		{
 			var controlPanelChannel = controlPanelConfiguration.Channel;
 			if (controlPanelChannel == "local")
-				controlPanelChannel = Application.ControlPanelRoute;
+				controlPanelChannel = ControlPanelRoute;
 
 			controlPanelChannel = controlPanelChannel
 				.Replace("${Major}", ApiHeaders.Version.Major.ToString(CultureInfo.InvariantCulture), StringComparison.Ordinal)

--- a/src/Tgstation.Server.Host/Controllers/HomeController.cs
+++ b/src/Tgstation.Server.Host/Controllers/HomeController.cs
@@ -24,7 +24,6 @@ using Tgstation.Server.Host.Security;
 using Tgstation.Server.Host.Security.OAuth;
 using Tgstation.Server.Host.Swarm;
 using Tgstation.Server.Host.System;
-using Wangkanai.Detection;
 
 namespace Tgstation.Server.Host.Controllers
 {
@@ -80,11 +79,6 @@ namespace Tgstation.Server.Host.Controllers
 		readonly IServerControl serverControl;
 
 		/// <summary>
-		/// The <see cref="IBrowserResolver"/> for the <see cref="HomeController"/>
-		/// </summary>
-		readonly IBrowserResolver browserResolver;
-
-		/// <summary>
 		/// The <see cref="GeneralConfiguration"/> for the <see cref="HomeController"/>.
 		/// </summary>
 		readonly GeneralConfiguration generalConfiguration;
@@ -106,7 +100,6 @@ namespace Tgstation.Server.Host.Controllers
 		/// <param name="identityCache">The value of <see cref="identityCache"/></param>
 		/// <param name="oAuthProviders">The value of <see cref="oAuthProviders"/>.</param>
 		/// <param name="platformIdentifier">The value of <see cref="platformIdentifier"/>.</param>
-		/// <param name="browserResolver">The value of <see cref="browserResolver"/></param>
 		/// <param name="swarmService">The value of <see cref="swarmService"/>.</param>
 		/// <param name="serverControl">The value of <see cref="serverControl"/>.</param>
 		/// <param name="generalConfigurationOptions">The <see cref="IOptions{TOptions}"/> containing the value of <see cref="generalConfiguration"/>.</param>
@@ -122,7 +115,6 @@ namespace Tgstation.Server.Host.Controllers
 			IIdentityCache identityCache,
 			IOAuthProviders oAuthProviders,
 			IPlatformIdentifier platformIdentifier,
-			IBrowserResolver browserResolver,
 			ISwarmService swarmService,
 			IServerControl serverControl,
 			IOptions<GeneralConfiguration> generalConfigurationOptions,
@@ -141,7 +133,6 @@ namespace Tgstation.Server.Host.Controllers
 			this.identityCache = identityCache ?? throw new ArgumentNullException(nameof(identityCache));
 			this.platformIdentifier = platformIdentifier ?? throw new ArgumentNullException(nameof(platformIdentifier));
 			this.oAuthProviders = oAuthProviders ?? throw new ArgumentNullException(nameof(oAuthProviders));
-			this.browserResolver = browserResolver ?? throw new ArgumentNullException(nameof(browserResolver));
 			this.swarmService = swarmService ?? throw new ArgumentNullException(nameof(swarmService));
 			this.serverControl = serverControl ?? throw new ArgumentNullException(nameof(serverControl));
 			generalConfiguration = generalConfigurationOptions?.Value ?? throw new ArgumentNullException(nameof(generalConfigurationOptions));
@@ -167,22 +158,20 @@ namespace Tgstation.Server.Host.Controllers
 					HeaderNames.Vary,
 					new StringValues(
 						new[]{
-							HeaderNames.UserAgent,
 							ApiHeaders.ApiVersionHeader
 						}));
 
-			// we only allow authorization header issues
 			if (ApiHeaders == null)
 			{
-				// if we are using a browser and the control panel, redirect to the app page
-				if (controlPanelConfiguration.Enable && browserResolver.Browser.Type != BrowserType.Generic)
+				if (controlPanelConfiguration.Enable)
 				{
-					Logger.LogDebug("Unauthorized browser request (User-Agent: \"{0}\"), redirecting to control panel...", browserResolver.UserAgent);
-					return Redirect(Core.Application.ControlPanelRoute);
+					Logger.LogDebug("No API headers on request, redirecting to control panel...");
+					return Redirect(ControlPanelController.ControlPanelRoute);
 				}
 
 				try
 				{
+					// we only allow authorization header issues
 					var headers = new ApiHeaders(Request.GetTypedHeaders(), true);
 					if (!headers.Compatible())
 						return StatusCode(

--- a/src/Tgstation.Server.Host/Core/Application.cs
+++ b/src/Tgstation.Server.Host/Core/Application.cs
@@ -463,7 +463,7 @@ namespace Tgstation.Server.Host.Core
 			// spa loading if necessary
 			if (controlPanelConfiguration.Enable)
 			{
-				logger.LogWarning("Web control panel enabled. This is a highly WIP feature!");
+				logger.LogInformation("Web control panel enabled.");
 				applicationBuilder.UseFileServer(new FileServerOptions
 				{
 					RequestPath = ControlPanelController.ControlPanelRoute,
@@ -472,7 +472,7 @@ namespace Tgstation.Server.Host.Core
 				});
 			}
 			else
-				logger.LogDebug("Web control panel disabled!");
+				logger.LogTrace("Web control panel disabled!");
 
 			// authenticate JWT tokens using our security pipeline if present, returns 401 if bad
 			applicationBuilder.UseAuthentication();

--- a/src/Tgstation.Server.Host/Core/Application.cs
+++ b/src/Tgstation.Server.Host/Core/Application.cs
@@ -220,9 +220,6 @@ namespace Tgstation.Server.Host.Core
 				services.AddSwaggerGenNewtonsoftSupport();
 			}
 
-			// enable browser detection
-			services.AddDetectionCore().AddBrowser();
-
 			// CORS conditionally enabled later
 			services.AddCors();
 

--- a/src/Tgstation.Server.Host/Core/Application.cs
+++ b/src/Tgstation.Server.Host/Core/Application.cs
@@ -56,11 +56,6 @@ namespace Tgstation.Server.Host.Core
 	sealed class Application : SetupApplication
 	{
 		/// <summary>
-		/// Route to the web control panel.
-		/// </summary>
-		public const string ControlPanelRoute = "/app";
-
-		/// <summary>
 		/// The <see cref="IWebHostEnvironment"/> for the <see cref="Application"/>.
 		/// </summary>
 		readonly IWebHostEnvironment hostingEnvironment;
@@ -471,7 +466,7 @@ namespace Tgstation.Server.Host.Core
 				logger.LogWarning("Web control panel enabled. This is a highly WIP feature!");
 				applicationBuilder.UseFileServer(new FileServerOptions
 				{
-					RequestPath = ControlPanelRoute,
+					RequestPath = ControlPanelController.ControlPanelRoute,
 					EnableDefaultFiles = true,
 					EnableDirectoryBrowsing = false
 				});

--- a/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
+++ b/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
@@ -99,7 +99,6 @@
     <PackageReference Include="System.DirectoryServices.AccountManagement" Version="5.0.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.8.0" />
     <PackageReference Include="System.Management" Version="5.0.0" />
-    <PackageReference Include="Wangkanai.Detection.Browser" Version="2.0.1" />
     <PackageReference Include="Z.EntityFramework.Plus.EFCore" Version="3.1.8" />
   </ItemGroup>
 


### PR DESCRIPTION
:cl: HTTP API
GET `/` no longer redirects to the web control panel based on `User-Agent` header. Now does so based on lack of `Api` header.
/:cl:

Closes #1219