### PR TITLE
v4.10.4

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>4.10.3</TgsCoreVersion>
+    <TgsCoreVersion>4.10.4</TgsCoreVersion>
     <TgsConfigVersion>3.0.0</TgsConfigVersion>
     <TgsApiVersion>9.0.1</TgsApiVersion>
     <TgsApiLibraryVersion>9.0.0</TgsApiLibraryVersion>

--- a/src/Tgstation.Server.Host/Controllers/JobController.cs
+++ b/src/Tgstation.Server.Host/Controllers/JobController.cs
@@ -69,6 +69,7 @@ namespace Tgstation.Server.Host.Controllers
 						.Jobs
 						.AsQueryable()
 						.Include(x => x.StartedBy)
+						.Include(x => x.CancelledBy)
 						.Where(x => x.Instance.Id == Instance.Id && !x.StoppedAt.HasValue)
 						.OrderByDescending(x => x.StartedAt))),
 				null,
@@ -95,6 +96,7 @@ namespace Tgstation.Server.Host.Controllers
 						.Jobs
 						.AsQueryable()
 						.Include(x => x.StartedBy)
+						.Include(x => x.CancelledBy)
 						.Where(x => x.Instance.Id == Instance.Id)
 						.OrderByDescending(x => x.StartedAt))),
 				null,
@@ -121,6 +123,7 @@ namespace Tgstation.Server.Host.Controllers
 			var job = await DatabaseContext
 				.Jobs
 				.AsQueryable()
+				.Include(x => x.StartedBy)
 				.Where(x => x.Id == id && x.Instance.Id == Instance.Id)
 				.FirstOrDefaultAsync(cancellationToken)
 				.ConfigureAwait(false);
@@ -156,6 +159,7 @@ namespace Tgstation.Server.Host.Controllers
 				.AsQueryable()
 				.Where(x => x.Id == id && x.Instance.Id == Instance.Id)
 				.Include(x => x.StartedBy)
+				.Include(x => x.CancelledBy)
 				.FirstOrDefaultAsync(cancellationToken)
 				.ConfigureAwait(false);
 			if (job == default)


### PR DESCRIPTION
:cl: HTTP API
Fixed JobResponse's `cancelledBy` field never being set.
Fixed JobResponse's `startedBy` never being set in the response to DELETE `/Job`.
/:cl:

:cl:
Fixed an occasional 500 error while generating the response for cancelled jobs.
/:cl: