### PR TITLE
Clean up bad calls to HandleEvent

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>4.10.5</TgsCoreVersion>
+    <TgsCoreVersion>4.10.6</TgsCoreVersion>
     <TgsConfigVersion>3.0.0</TgsConfigVersion>
     <TgsApiVersion>9.0.1</TgsApiVersion>
     <TgsApiLibraryVersion>9.0.0</TgsApiLibraryVersion>

--- a/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
@@ -719,7 +719,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 					repoName,
 					cancellationToken);
 
-				var eventTask = eventConsumer.HandleEvent(EventType.DeploymentComplete, null, cancellationToken);
+				var eventTask = eventConsumer.HandleEvent(EventType.DeploymentComplete, Enumerable.Empty<string>(), cancellationToken);
 
 				try
 				{
@@ -841,7 +841,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 			catch (OperationCanceledException)
 			{
 				// DCT: Cancellation token is for job, delaying here is fine
-				await eventConsumer.HandleEvent(EventType.CompileCancelled, null, default).ConfigureAwait(false);
+				await eventConsumer.HandleEvent(EventType.CompileCancelled, Enumerable.Empty<string>(), default).ConfigureAwait(false);
 				throw;
 			}
 			finally

--- a/src/Tgstation.Server.Host/Components/Events/EventConsumer.cs
+++ b/src/Tgstation.Server.Host/Components/Events/EventConsumer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -32,6 +32,9 @@ namespace Tgstation.Server.Host.Components.Events
 		/// <inheritdoc />
 		public async Task HandleEvent(EventType eventType, IEnumerable<string> parameters, CancellationToken cancellationToken)
 		{
+			if (parameters == null)
+				throw new ArgumentNullException(nameof(parameters));
+
 			if (watchdog == null)
 				throw new InvalidOperationException("EventConsumer used without watchdog set!");
 

--- a/src/Tgstation.Server.Host/Components/Events/IEventConsumer.cs
+++ b/src/Tgstation.Server.Host/Components/Events/IEventConsumer.cs
@@ -1,20 +1,20 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Tgstation.Server.Host.Components.Events
 {
 	/// <summary>
-	/// Consumes <see cref="EventType"/>s and takes the appropriate actions
+	/// Consumes <see cref="EventType"/>s and takes the appropriate actions.
 	/// </summary>
 	public interface IEventConsumer
 	{
 		/// <summary>
-		/// Handle a given <paramref name="eventType"/>
+		/// Handle a given <paramref name="eventType"/>.
 		/// </summary>
-		/// <param name="eventType">The <see cref="EventType"/></param>
-		/// <param name="parameters">The parameters for <paramref name="eventType"/></param>
-		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation</param>
+		/// <param name="eventType">The <see cref="EventType"/>.</param>
+		/// <param name="parameters">An <see cref="IEnumerable{T}"/> of <see cref="string"/> parameters for <paramref name="eventType"/>.</param>
+		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task"/> representing the running operation.</returns>
 		Task HandleEvent(EventType eventType, IEnumerable<string> parameters, CancellationToken cancellationToken);
 	}

--- a/src/Tgstation.Server.Host/Components/Instance.cs
+++ b/src/Tgstation.Server.Host/Components/Instance.cs
@@ -375,9 +375,9 @@ namespace Tgstation.Server.Host.Components
 			while (true)
 				try
 				{
-					await Task.Delay(TimeSpan.FromMinutes(minutes > Int32.MaxValue ? Int32.MaxValue : (int)minutes), cancellationToken).ConfigureAwait(false);
+					await Task.Delay(TimeSpan.FromMinutes(minutes > Int32.MaxValue ? Int32.MaxValue : minutes), cancellationToken).ConfigureAwait(false);
 					logger.LogInformation("Beginning auto update...");
-					await eventConsumer.HandleEvent(EventType.InstanceAutoUpdateStart, new List<string>(), cancellationToken).ConfigureAwait(false);
+					await eventConsumer.HandleEvent(EventType.InstanceAutoUpdateStart, Enumerable.Empty<string>(), cancellationToken).ConfigureAwait(false);
 					try
 					{
 						var repositoryUpdateJob = new Job

--- a/src/Tgstation.Server.Host/Components/Interop/Topic/EventNotification.cs
+++ b/src/Tgstation.Server.Host/Components/Interop/Topic/EventNotification.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Tgstation.Server.Host.Components.Events;
@@ -18,17 +19,17 @@ namespace Tgstation.Server.Host.Components.Interop.Topic
 		/// <summary>
 		/// The set of parameters.
 		/// </summary>
-		public IReadOnlyCollection<object> Parameters { get; }
+		public IReadOnlyCollection<string> Parameters { get; }
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="EventNotification"/> <see langword="class"/>.
 		/// </summary>
 		/// <param name="eventType">The value of <see cref="Type"/>.</param>
 		/// <param name="parameters">The <see cref="IEnumerable{T}"/> that forms the value of <see cref="Parameters"/>.</param>
-		public EventNotification(EventType eventType, IEnumerable<object> parameters = null)
+		public EventNotification(EventType eventType, IEnumerable<string> parameters = null)
 		{
 			Type = eventType;
-			Parameters = parameters?.ToList();
+			Parameters = parameters?.ToList() ?? throw new ArgumentNullException(nameof(parameters)); ;
 		}
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Repository/Repository.cs
+++ b/src/Tgstation.Server.Host/Components/Repository/Repository.cs
@@ -440,7 +440,7 @@ namespace Tgstation.Server.Host.Components.Repository
 			if (progressReporter == null)
 				throw new ArgumentNullException(nameof(progressReporter));
 			logger.LogDebug("Fetch origin...");
-			await eventConsumer.HandleEvent(EventType.RepoFetch, Array.Empty<string>(), cancellationToken).ConfigureAwait(false);
+			await eventConsumer.HandleEvent(EventType.RepoFetch, Enumerable.Empty<string>(), cancellationToken).ConfigureAwait(false);
 			await Task.Factory.StartNew(() =>
 			{
 				var remote = libGitRepo.Network.Remotes.First();

--- a/src/Tgstation.Server.Host/Components/StaticFiles/Configuration.cs
+++ b/src/Tgstation.Server.Host/Components/StaticFiles/Configuration.cs
@@ -546,6 +546,9 @@ namespace Tgstation.Server.Host.Components.StaticFiles
 		/// <inheritdoc />
 		public async Task HandleEvent(EventType eventType, IEnumerable<string> parameters, CancellationToken cancellationToken)
 		{
+			if (parameters == null)
+				throw new ArgumentNullException(nameof(parameters));
+
 			await EnsureDirectories(cancellationToken).ConfigureAwait(false);
 
 			if (!EventTypeScriptFileNameMap.TryGetValue(eventType, out var scriptName))

--- a/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
@@ -841,6 +841,9 @@ namespace Tgstation.Server.Host.Components.Watchdog
 		/// <inheritdoc />
 		async Task IEventConsumer.HandleEvent(EventType eventType, IEnumerable<string> parameters, CancellationToken cancellationToken)
 		{
+			if (parameters == null)
+				throw new ArgumentNullException(nameof(parameters));
+
 			// Method explicitly implemented to prevent accidental calls when this.eventConsumer should be used.
 			var activeServer = GetActiveController();
 


### PR DESCRIPTION
:cl:
Fixed event scripts for the `DeploymentComplete` and `CompileFailed` events failing to execute.
/:cl: