### PR TITLE
Fix listing jobs not returning progress

### DIFF
--- a/src/Tgstation.Server.Host/Controllers/JobController.cs
+++ b/src/Tgstation.Server.Host/Controllers/JobController.cs
@@ -72,7 +72,7 @@ namespace Tgstation.Server.Host.Controllers
 						.Include(x => x.CancelledBy)
 						.Where(x => x.Instance.Id == Instance.Id && !x.StoppedAt.HasValue)
 						.OrderByDescending(x => x.StartedAt))),
-				null,
+				AddJobProgressResponseTransformer,
 				page,
 				pageSize,
 				cancellationToken);
@@ -99,7 +99,7 @@ namespace Tgstation.Server.Host.Controllers
 						.Include(x => x.CancelledBy)
 						.Where(x => x.Instance.Id == Instance.Id)
 						.OrderByDescending(x => x.StartedAt))),
-				null,
+				AddJobProgressResponseTransformer,
 				page,
 				pageSize,
 				cancellationToken);
@@ -167,6 +167,15 @@ namespace Tgstation.Server.Host.Controllers
 			var api = job.ToApi();
 			api.Progress = jobManager.JobProgress(job);
 			return Json(api);
+		}
+
+		/// <summary>
+		/// Supplements <see cref="JobResponse"/> <see cref="PaginatedResponse{TModel}"/>s with their <see cref="JobResponse.Progress"/>.
+		/// </summary>
+		/// <param name="jobResponse">The <see cref="JobResponse"/> to augment.</param>
+		private void AddJobProgressResponseTransformer(JobResponse jobResponse)
+		{
+			jobResponse.Progress = jobManager.JobProgress(jobResponse);
 		}
 	}
 }

--- a/src/Tgstation.Server.Host/Jobs/IJobManager.cs
+++ b/src/Tgstation.Server.Host/Jobs/IJobManager.cs
@@ -13,9 +13,9 @@ namespace Tgstation.Server.Host.Jobs
 		/// <summary>
 		/// Get the <see cref="Api.Models.Response.JobResponse.Progress"/> for a <paramref name="job"/>
 		/// </summary>
-		/// <param name="job">The <see cref="Job"/> to get <see cref="Api.Models.Response.JobResponse.Progress"/> for</param>
+		/// <param name="job">The <see cref="Api.Models.Internal.Job"/> to get <see cref="Api.Models.Response.JobResponse.Progress"/> for</param>
 		/// <returns>The <see cref="Api.Models.Response.JobResponse.Progress"/> of <paramref name="job"/></returns>
-		int? JobProgress(Job job);
+		int? JobProgress(Api.Models.Internal.Job job);
 
 		/// <summary>
 		/// Registers a given <see cref="Job"/> and begins running it

--- a/src/Tgstation.Server.Host/Jobs/JobManager.cs
+++ b/src/Tgstation.Server.Host/Jobs/JobManager.cs
@@ -303,7 +303,7 @@ namespace Tgstation.Server.Host.Jobs
 		}
 
 		/// <inheritdoc />
-		public int? JobProgress(Job job)
+		public int? JobProgress(Api.Models.Internal.Job job)
 		{
 			if (job == null)
 				throw new ArgumentNullException(nameof(job));

--- a/tests/Tgstation.Server.Tests/Instance/RepositoryTest.cs
+++ b/tests/Tgstation.Server.Tests/Instance/RepositoryTest.cs
@@ -69,6 +69,16 @@ namespace Tgstation.Server.Tests.Instance
 
 			clone = await repositoryClient.Clone(cloneRequest, cancellationToken).ConfigureAwait(false);
 
+			// throwing this small jobs consistency test in here
+			await Task.Delay(TimeSpan.FromSeconds(20), cancellationToken).ConfigureAwait(false);
+			var activeJobs = await JobsClient.ListActive(null, cancellationToken);
+			var allJobs = await JobsClient.List(null, cancellationToken).ConfigureAwait(false);
+
+			Assert.IsTrue(activeJobs.Any(x => x.Id == clone.ActiveJob.Id));
+			Assert.IsTrue(allJobs.Any(x => x.Id == clone.ActiveJob.Id));
+			Assert.IsTrue(activeJobs.First(x => x.Id == clone.ActiveJob.Id).Progress.HasValue);
+			Assert.IsTrue(allJobs.First(x => x.Id == clone.ActiveJob.Id).Progress.HasValue);
+
 			await WaitForJob(clone.ActiveJob, 9000, false, null, cancellationToken).ConfigureAwait(false);
 			var readAfterClone = await repositoryClient.Read(cancellationToken);
 

--- a/tests/Tgstation.Server.Tests/TestingServer.cs
+++ b/tests/Tgstation.Server.Tests/TestingServer.cs
@@ -111,6 +111,7 @@ namespace Tgstation.Server.Tests
 
 			// SPECIFICALLY DELETE THE DEV APPSETTINGS, WE DON'T WANT IT IN THE WAY
 			File.Delete("appsettings.Development.yml");
+			File.Delete("appsettings.Development.json");
 
 			if (!String.IsNullOrEmpty(gitHubAccessToken))
 				args.Add(String.Format(CultureInfo.InvariantCulture, "General:GitHubAccessToken={0}", gitHubAccessToken));


### PR DESCRIPTION
:cl: HTTP API
Paginated job responses will now come with `progress` fields for active jobs.
/:cl:

Thanks @alexkar598 