### PR TITLE
Fixes being unable to create passwordless IRC bots

### DIFF
--- a/src/Tgstation.Server.Host/Components/Chat/Providers/IrcProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/IrcProvider.cs
@@ -121,7 +121,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 			nickname = ircBuilder.Nickname;
 
 			password = ircBuilder.Password;
-			passwordType = ircBuilder.PasswordType.Value;
+			passwordType = ircBuilder.PasswordType;
 
 			client = new IrcFeatures
 			{

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/IrcProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/IrcProvider.cs
@@ -110,6 +110,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		{
 			if (assemblyInformationProvider == null)
 				throw new ArgumentNullException(nameof(assemblyInformationProvider));
+
 			this.asyncDelayer = asyncDelayer ?? throw new ArgumentNullException(nameof(asyncDelayer));
 
 			var builder = chatBot.CreateConnectionStringBuilder();

--- a/tests/Tgstation.Server.Host.Tests/Components/Chat/Providers/TestIrcProvider.cs
+++ b/tests/Tgstation.Server.Host.Tests/Components/Chat/Providers/TestIrcProvider.cs
@@ -2,8 +2,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
-using System.Reflection;
-using System.Threading;
 using System.Threading.Tasks;
 using Tgstation.Server.Api.Models;
 using Tgstation.Server.Host.Core;

--- a/tests/Tgstation.Server.Host.Tests/Components/Chat/Providers/TestIrcProvider.cs
+++ b/tests/Tgstation.Server.Host.Tests/Components/Chat/Providers/TestIrcProvider.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Tgstation.Server.Api.Models;
+using Tgstation.Server.Host.Core;
+using Tgstation.Server.Host.Jobs;
+using Tgstation.Server.Host.Models;
+using Tgstation.Server.Host.System;
+
+namespace Tgstation.Server.Host.Components.Chat.Providers.Tests
+{
+	[TestClass]
+	public sealed class TestIrcProvider
+	{
+		[TestMethod]
+		public async Task TestConstructionAndDisposal()
+		{
+			Assert.ThrowsException<ArgumentNullException>(() => new IrcProvider(null, null, null, null, null));
+			var mockJobManager = new Mock<IJobManager>();
+			Assert.ThrowsException<ArgumentNullException>(() => new IrcProvider(mockJobManager.Object, null, null, null, null));
+			var mockAss = new Mock<IAssemblyInformationProvider>();
+			Assert.ThrowsException<ArgumentNullException>(() => new IrcProvider(mockJobManager.Object, mockAss.Object, null, null, null));
+			var mockAsyncDelayer = new Mock<IAsyncDelayer>();
+			Assert.ThrowsException<ArgumentNullException>(() => new IrcProvider(mockJobManager.Object, mockAss.Object, mockAsyncDelayer.Object, null, null));
+			var mockLogger = new Mock<ILogger<IrcProvider>>();
+			Assert.ThrowsException<ArgumentNullException>(() => new IrcProvider(mockJobManager.Object, mockAss.Object, mockAsyncDelayer.Object, mockLogger.Object, null));
+
+			var mockBot = new ChatBot
+			{
+				Name = "test",
+				Provider = ChatProvider.Irc
+			};
+
+			Assert.ThrowsException<InvalidOperationException>(() => new IrcProvider(mockJobManager.Object, mockAss.Object, mockAsyncDelayer.Object, mockLogger.Object, mockBot));
+
+			mockBot.ConnectionString = new IrcConnectionStringBuilder
+			{
+				Address = "localhost",
+				Nickname = "test",
+				UseSsl = true,
+				Port = 6667
+			}.ToString();
+
+			await new IrcProvider(mockJobManager.Object, mockAss.Object, mockAsyncDelayer.Object, mockLogger.Object, mockBot).DisposeAsync();
+		}
+	}
+}


### PR DESCRIPTION
Fixes #1255

:cl:
Fixed being unable to create IRC chat bots without a password.
/:cl: