### PR TITLE
Update ControlPanelVersion to v2.2.0

### DIFF
--- a/build/ControlPanelVersion.props
+++ b/build/ControlPanelVersion.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <!-- This is in it's own file to help incremental building, changing it causes a complete rebuild of the web panel -->
-    <TgsControlPanelVersion>2.1.5</TgsControlPanelVersion>
+    <TgsControlPanelVersion>2.2.0</TgsControlPanelVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Updates webpanel to v2.2.0

:cl: Web Control Panel
Adds a page to select and install new byond versions.
Adds pagination to all lists, instead of only displaying 100 entries.
Adds a faint border to home screen icons.
Adds an automatic retry for user and server info.
Splits the functionality of the X button on jobs into two buttons, the X button dismisses completed jobs and a new button to the right of the progress bar lets you cancel the job.
Reworks all instance editing pages into a single page with tabs.
Removes the concept of "selecting instances". Jobs are now displayed for all instances.
Fixes a bug where the jobs widget would sometimes exit the viewport.
Fixes memory leaks.
Fixes bug where webpanel would not connect to TGS.
/:cl:

its coding socks time