### PR TITLE
Elasticsearch log ingest support

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,13 +138,13 @@ Create an `appsettings.Production.yml` file next to `appsettings.yml`. This will
 - `ControlPanel:AllowedOrigins`: Set the Access-Control-Allow-Origin headers to this list of origins for all responses (also enables all headers and methods). This is overridden by `ControlPanel:AllowAnyOrigin`
 
 - `Elasticsearch`: tgstation-server-v4 also supports automatically ingesting its logs to ElasticSearch. You can set this up in the setup wizard, or with the following configuration:
-	```yml
-	Elasticsearch:
-  	  Enable: true
-  	  Host: http://192.168.0.200:9200
-  	  Username: youruserhere
-  	  Password: yourpasshere
-	```
+  ```yml
+  Elasticsearch:
+    Enable: true
+    Host: http://192.168.0.200:9200
+    Username: youruserhere
+    Password: yourpasshere
+  ```
 
 - `Swarm`: This section should be left `null` unless using the server swarm system. If this is to happen, ensure all swarm servers are set to connect to the same database.
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,15 @@ Create an `appsettings.Production.yml` file next to `appsettings.yml`. This will
 
 - `ControlPanel:AllowedOrigins`: Set the Access-Control-Allow-Origin headers to this list of origins for all responses (also enables all headers and methods). This is overridden by `ControlPanel:AllowAnyOrigin`
 
+- `Elasticsearch`: tgstation-server-v4 also supports automatically ingesting its logs to ElasticSearch. You can set this up in the setup wizard, or with the following configuration:
+	```yml
+	Elasticsearch:
+  	  Enable: true
+  	  Host: http://192.168.0.200:9200
+  	  Username: youruserhere
+  	  Password: yourpasshere
+	```
+
 - `Swarm`: This section should be left `null` unless using the server swarm system. If this is to happen, ensure all swarm servers are set to connect to the same database.
 
 - `Swarm:PrivateKey`: Should be a secure string set identically on all swarmed servers.

--- a/build/Version.props
+++ b/build/Version.props
@@ -4,7 +4,7 @@
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
     <TgsCoreVersion>4.12.0</TgsCoreVersion>
-    <TgsConfigVersion>3.0.0</TgsConfigVersion>
+    <TgsConfigVersion>3.0.1</TgsConfigVersion>
     <TgsApiVersion>9.0.1</TgsApiVersion>
     <TgsApiLibraryVersion>9.0.0</TgsApiLibraryVersion>
     <TgsClientVersion>10.0.0</TgsClientVersion>

--- a/build/Version.props
+++ b/build/Version.props
@@ -4,7 +4,7 @@
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
     <TgsCoreVersion>4.12.0</TgsCoreVersion>
-    <TgsConfigVersion>3.0.1</TgsConfigVersion>
+    <TgsConfigVersion>3.1.0</TgsConfigVersion>
     <TgsApiVersion>9.0.1</TgsApiVersion>
     <TgsApiLibraryVersion>9.0.0</TgsApiLibraryVersion>
     <TgsClientVersion>10.0.0</TgsClientVersion>

--- a/src/Tgstation.Server.Host/Configuration/ElasticsearchConfiguration.cs
+++ b/src/Tgstation.Server.Host/Configuration/ElasticsearchConfiguration.cs
@@ -1,0 +1,53 @@
+﻿namespace Tgstation.Server.Host.Configuration
+	{
+	/// <summary>
+	/// Configuration options pertaining to elasticsearch log storage.
+	/// </summary>
+	sealed class ElasticsearchConfiguration
+	{
+		/// <summary>
+		/// The key for the <see cref="Microsoft.Extensions.Configuration.IConfigurationSection"/> the <see cref="ElasticsearchConfiguration"/> resides in.
+		/// </summary>
+		public const string Section = "Elasticsearch";
+
+		/// <summary>
+		/// Default value of <see cref="Enable"/>.
+		/// </summary>
+		const bool DefaultEnable = false;
+
+		/// <summary>
+		/// Default value of <see cref="Host"/>.
+		/// </summary>
+		const string DefaultHost = "http://127.0.0.1:9200"; // localhost
+
+		/// <summary>
+		/// Default value of <see cref="Username"/>.
+		/// </summary>
+		const string DefaultUsername = "my_username";
+
+		/// <summary>
+		/// Default value of <see cref="Password"/>.
+		/// </summary>
+		const string DefaultPassword = "my_password";
+
+		/// <summary>
+		/// Do we want to enable elasticsearch or not?.
+		/// </summary>
+		public bool Enable { get; set; } = DefaultEnable;
+
+		/// <summary>
+		/// The host of the elasticsearch endpoint.
+		/// </summary>
+		public string Host { get; set; } = DefaultHost;
+
+		/// <summary>
+		/// Username for elasticsearch.
+		/// </summary>
+		public string Username { get; set; } = DefaultUsername;
+
+		/// <summary>
+		/// Password for elasticsearch.
+		/// </summary>
+		public string Password { get; set; } = DefaultPassword;
+	}
+}

--- a/src/Tgstation.Server.Host/Configuration/ElasticsearchConfiguration.cs
+++ b/src/Tgstation.Server.Host/Configuration/ElasticsearchConfiguration.cs
@@ -11,11 +11,6 @@
 		public const string Section = "Elasticsearch";
 
 		/// <summary>
-		/// Default value of <see cref="Enable"/>.
-		/// </summary>
-		const bool DefaultEnable = false;
-
-		/// <summary>
 		/// Default value of <see cref="Host"/>.
 		/// </summary>
 		const string DefaultHost = "http://127.0.0.1:9200"; // localhost
@@ -33,7 +28,7 @@
 		/// <summary>
 		/// Do we want to enable elasticsearch or not?.
 		/// </summary>
-		public bool Enable { get; set; } = DefaultEnable;
+		public bool Enable { get; set; }
 
 		/// <summary>
 		/// The host of the elasticsearch endpoint.

--- a/src/Tgstation.Server.Host/Core/Application.cs
+++ b/src/Tgstation.Server.Host/Core/Application.cs
@@ -151,6 +151,7 @@ namespace Tgstation.Server.Host.Core
 						config.MinimumLevel.Override("System.Net.Http.HttpClient", microsoftEventLevel.Value);
 					}
 				},
+				Configuration,
 				sinkConfig =>
 				{
 					if (postSetupServices.FileLoggingConfiguration.Disable)

--- a/src/Tgstation.Server.Host/Core/Application.cs
+++ b/src/Tgstation.Server.Host/Core/Application.cs
@@ -120,6 +120,7 @@ namespace Tgstation.Server.Host.Core
 			services.UseStandardConfig<UpdatesConfiguration>(Configuration);
 			services.UseStandardConfig<ControlPanelConfiguration>(Configuration);
 			services.UseStandardConfig<SwarmConfiguration>(Configuration);
+			services.UseStandardConfig<ElasticsearchConfiguration>(Configuration);
 
 			// enable options which give us config reloading
 			services.AddOptions();
@@ -151,7 +152,6 @@ namespace Tgstation.Server.Host.Core
 						config.MinimumLevel.Override("System.Net.Http.HttpClient", microsoftEventLevel.Value);
 					}
 				},
-				Configuration,
 				sinkConfig =>
 				{
 					if (postSetupServices.FileLoggingConfiguration.Disable)
@@ -179,7 +179,7 @@ namespace Tgstation.Server.Host.Core
 						flushToDiskInterval: TimeSpan.FromSeconds(2),
 						rollingInterval: RollingInterval.Day,
 						rollOnFileSizeLimit: true);
-				});
+				}, postSetupServices.ElasticsearchConfiguration);
 
 			// configure bearer token validation
 			services

--- a/src/Tgstation.Server.Host/Core/Application.cs
+++ b/src/Tgstation.Server.Host/Core/Application.cs
@@ -120,7 +120,6 @@ namespace Tgstation.Server.Host.Core
 			services.UseStandardConfig<UpdatesConfiguration>(Configuration);
 			services.UseStandardConfig<ControlPanelConfiguration>(Configuration);
 			services.UseStandardConfig<SwarmConfiguration>(Configuration);
-			services.UseStandardConfig<ElasticsearchConfiguration>(Configuration);
 
 			// enable options which give us config reloading
 			services.AddOptions();
@@ -179,7 +178,8 @@ namespace Tgstation.Server.Host.Core
 						flushToDiskInterval: TimeSpan.FromSeconds(2),
 						rollingInterval: RollingInterval.Day,
 						rollOnFileSizeLimit: true);
-				}, postSetupServices.ElasticsearchConfiguration);
+				},
+				postSetupServices.ElasticsearchConfiguration);
 
 			// configure bearer token validation
 			services

--- a/src/Tgstation.Server.Host/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Tgstation.Server.Host/Extensions/ServiceCollectionExtensions.cs
@@ -60,13 +60,13 @@ namespace Tgstation.Server.Host.Extensions
 		/// <param name="serviceCollection">The <see cref="IServiceCollection"/> to configure.</param>
 		/// <param name="configurationAction">Additional configuration for a given <see cref="LoggerConfiguration"/>.</param>
 		/// <param name="sinkConfigurationAction">Additional configuration for a given <see cref="LoggerSinkConfiguration"/>.</param>
-		/// <param name="esc">Configuration for a given <see cref="ElasticsearchConfiguration"/>.</param>
+		/// <param name="elasticsearchConfiguration">Configuration for a given <see cref="ElasticsearchConfiguration"/>.</param>
 		/// <returns>The updated <paramref name="serviceCollection"/>.</returns>
 		public static IServiceCollection SetupLogging(
 			this IServiceCollection serviceCollection,
 			Action<LoggerConfiguration> configurationAction,
 			Action<LoggerSinkConfiguration> sinkConfigurationAction = null,
-			ElasticsearchConfiguration esc = null)
+			ElasticsearchConfiguration elasticsearchConfiguration = null)
 			=> serviceCollection.AddLogging(builder =>
 			{
 				builder.ClearProviders();
@@ -89,18 +89,18 @@ namespace Tgstation.Server.Host.Extensions
 						sinkConfigurationAction?.Invoke(sinkConfiguration);
 					});
 
-				if (esc != null)
+				if (elasticsearchConfiguration != null)
 				{
-					if (esc.Enable)
+					if (elasticsearchConfiguration.Enable)
 					{
-						if (esc.Host == null)
+						if (elasticsearchConfiguration.Host == null)
 							throw new InvalidOperationException("Elasticsearch endpoint is null!");
 
-						configuration.WriteTo.Elasticsearch(new ElasticsearchSinkOptions(new Uri(esc.Host))
+						configuration.WriteTo.Elasticsearch(new ElasticsearchSinkOptions(new Uri(elasticsearchConfiguration.Host))
 						{
 							// Yes I know this means they cannot use a self signed cert unless they also have authentication, but lets be real here
 							// No one is going to be doing one of thsoe but not the other
-							ModifyConnectionSettings = x => (!string.IsNullOrEmpty(esc.Username) && !string.IsNullOrEmpty(esc.Password)) ? x.BasicAuthentication(esc.Username, esc.Password).ServerCertificateValidationCallback((o, certificate, arg3, arg4) => { return true; }) : null,
+							ModifyConnectionSettings = x => (!string.IsNullOrEmpty(elasticsearchConfiguration.Username) && !string.IsNullOrEmpty(elasticsearchConfiguration.Password)) ? x.BasicAuthentication(elasticsearchConfiguration.Username, elasticsearchConfiguration.Password).ServerCertificateValidationCallback((o, certificate, arg3, arg4) => { return true; }) : null,
 							CustomFormatter = new EcsTextFormatter(),
 							AutoRegisterTemplate = true,
 							AutoRegisterTemplateVersion = AutoRegisterTemplateVersion.ESv7,

--- a/src/Tgstation.Server.Host/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Tgstation.Server.Host/Extensions/ServiceCollectionExtensions.cs
@@ -3,13 +3,13 @@ using System.Diagnostics;
 using System.Globalization;
 
 using Elastic.CommonSchema.Serilog;
-
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Serilog;
 using Serilog.Configuration;
 using Serilog.Sinks.Elasticsearch;
+
 using Tgstation.Server.Host.Configuration;
 
 namespace Tgstation.Server.Host.Extensions
@@ -59,14 +59,14 @@ namespace Tgstation.Server.Host.Extensions
 		/// </summary>
 		/// <param name="serviceCollection">The <see cref="IServiceCollection"/> to configure.</param>
 		/// <param name="configurationAction">Additional configuration for a given <see cref="LoggerConfiguration"/>.</param>
-		/// <param name="tgsConfiguration">The service configuration for a given <see cref="IConfiguration"/>.</param>
 		/// <param name="sinkConfigurationAction">Additional configuration for a given <see cref="LoggerSinkConfiguration"/>.</param>
+		/// <param name="esc">Configuration for a given <see cref="ElasticsearchConfiguration"/>.</param>
 		/// <returns>The updated <paramref name="serviceCollection"/>.</returns>
 		public static IServiceCollection SetupLogging(
 			this IServiceCollection serviceCollection,
 			Action<LoggerConfiguration> configurationAction,
-			IConfiguration tgsConfiguration,
-			Action<LoggerSinkConfiguration> sinkConfigurationAction = null)
+			Action<LoggerSinkConfiguration> sinkConfigurationAction = null,
+			ElasticsearchConfiguration esc = null)
 			=> serviceCollection.AddLogging(builder =>
 			{
 				builder.ClearProviders();
@@ -89,28 +89,24 @@ namespace Tgstation.Server.Host.Extensions
 						sinkConfigurationAction?.Invoke(sinkConfiguration);
 					});
 
-				string elasticsearchEndpoint = tgsConfiguration.GetSection("Elasticsearch").GetSection("Host").Value;
-				string elasticsearchUser = tgsConfiguration.GetSection("Elasticsearch").GetSection("Username").Value;
-				string elasticsearchPassword = tgsConfiguration.GetSection("Elasticsearch").GetSection("Password").Value;
-				string raw_bool = tgsConfiguration.GetSection("Elasticsearch").GetSection("Enable").Value;
-				bool elasticsearchEnabled = false;
-
-				if (!string.IsNullOrEmpty(raw_bool))
-					elasticsearchEnabled = bool.Parse(raw_bool);
-
-				if (elasticsearchEnabled)
+				if (esc != null)
 				{
-					if (elasticsearchEndpoint == null)
-						throw new InvalidOperationException("Elasticsearch endpoint is null!");
-
-					configuration.WriteTo.Elasticsearch(new ElasticsearchSinkOptions(new Uri(elasticsearchEndpoint))
+					if (esc.Enable)
 					{
-						ModifyConnectionSettings = x => (!string.IsNullOrEmpty(elasticsearchUser) && !string.IsNullOrEmpty(elasticsearchPassword)) ? x.BasicAuthentication(elasticsearchUser, elasticsearchPassword) : null,
-						CustomFormatter = new EcsTextFormatter(),
-						AutoRegisterTemplate = true,
-						AutoRegisterTemplateVersion = AutoRegisterTemplateVersion.ESv7,
-						IndexFormat = "tgs4-logs",
-					});
+						if (esc.Host == null)
+							throw new InvalidOperationException("Elasticsearch endpoint is null!");
+
+						configuration.WriteTo.Elasticsearch(new ElasticsearchSinkOptions(new Uri(esc.Host))
+						{
+							// Yes I know this means they cannot use a self signed cert unless they also have authentication, but lets be real here
+							// No one is going to be doing one of thsoe but not the other
+							ModifyConnectionSettings = x => (!string.IsNullOrEmpty(esc.Username) && !string.IsNullOrEmpty(esc.Password)) ? x.BasicAuthentication(esc.Username, esc.Password).ServerCertificateValidationCallback((o, certificate, arg3, arg4) => { return true; }) : null,
+							CustomFormatter = new EcsTextFormatter(),
+							AutoRegisterTemplate = true,
+							AutoRegisterTemplateVersion = AutoRegisterTemplateVersion.ESv7,
+							IndexFormat = "tgs4-logs",
+						});
+					}
 				}
 
 				builder.AddSerilog(configuration.CreateLogger(), true);

--- a/src/Tgstation.Server.Host/Setup/IPostSetupServices.cs
+++ b/src/Tgstation.Server.Host/Setup/IPostSetupServices.cs
@@ -29,6 +29,11 @@ namespace Tgstation.Server.Host.Setup
 		FileLoggingConfiguration FileLoggingConfiguration { get; }
 
 		/// <summary>
+		/// The <see cref="Configuration.ElasticsearchConfiguration"/>.
+		/// </summary>
+		ElasticsearchConfiguration ElasticsearchConfiguration { get; }
+
+		/// <summary>
 		/// The <see cref="IPlatformIdentifier"/>.
 		/// </summary>
 		IPlatformIdentifier PlatformIdentifier { get; }

--- a/src/Tgstation.Server.Host/Setup/PostSetupServices.cs
+++ b/src/Tgstation.Server.Host/Setup/PostSetupServices.cs
@@ -29,6 +29,9 @@ namespace Tgstation.Server.Host.Setup
 		/// <inheritdoc />
 		public ILogger<TLoggerType> Logger { get; }
 
+		/// <inheritdoc />
+		public ElasticsearchConfiguration ElasticsearchConfiguration => elasticsearchConfigurationOptions.Value;
+
 		/// <summary>
 		/// Backing <see cref="IOptions{TOptions}"/> for <see cref="GeneralConfiguration"/>.
 		/// </summary>
@@ -50,6 +53,11 @@ namespace Tgstation.Server.Host.Setup
 		readonly IOptions<FileLoggingConfiguration> fileLoggingConfigurationOptions;
 
 		/// <summary>
+		/// Backing <see cref="IOptions{TOptions}"/> for <see cref="ElasticsearchConfiguration"/>.
+		/// </summary>
+		readonly IOptions<ElasticsearchConfiguration> elasticsearchConfigurationOptions;
+
+		/// <summary>
 		/// Initializes a new instance of the <see cref="PostSetupServices{TLoggerType}"/> class.
 		/// </summary>
 		/// <param name="platformIdentifier">The value of <see cref="PlatformIdentifier"/>.</param>
@@ -58,13 +66,15 @@ namespace Tgstation.Server.Host.Setup
 		/// <param name="databaseConfigurationOptions">The <see cref="IOptions{TOptions}"/> containing the value of <see cref="DatabaseConfiguration"/>.</param>
 		/// <param name="securityConfigurationOptions">The <see cref="IOptions{TOptions}"/> containing the value of <see cref="SecurityConfiguration"/>.</param>
 		/// <param name="fileLoggingConfigurationOptions">The <see cref="IOptions{TOptions}"/> containing the value of <see cref="FileLoggingConfiguration"/>.</param>
+		/// <param name="elasticsearchConfigurationOptions">The <see cref="IOptions{TOptions}"/> containing the value of <see cref="ElasticsearchConfiguration"/>.</param>
 		public PostSetupServices(
 			IPlatformIdentifier platformIdentifier,
 			ILoggerFactory loggerFactory,
 			IOptions<GeneralConfiguration> generalConfigurationOptions,
 			IOptions<DatabaseConfiguration> databaseConfigurationOptions,
 			IOptions<SecurityConfiguration> securityConfigurationOptions,
-			IOptions<FileLoggingConfiguration> fileLoggingConfigurationOptions)
+			IOptions<FileLoggingConfiguration> fileLoggingConfigurationOptions,
+			IOptions<ElasticsearchConfiguration> elasticsearchConfigurationOptions)
 		{
 			PlatformIdentifier = platformIdentifier ?? throw new ArgumentNullException(nameof(platformIdentifier));
 			if (loggerFactory == null)
@@ -75,6 +85,7 @@ namespace Tgstation.Server.Host.Setup
 			this.databaseConfigurationOptions = databaseConfigurationOptions ?? throw new ArgumentNullException(nameof(databaseConfigurationOptions));
 			this.securityConfigurationOptions = securityConfigurationOptions ?? throw new ArgumentNullException(nameof(securityConfigurationOptions));
 			this.fileLoggingConfigurationOptions = fileLoggingConfigurationOptions ?? throw new ArgumentNullException(nameof(fileLoggingConfigurationOptions));
+			this.elasticsearchConfigurationOptions = elasticsearchConfigurationOptions ?? throw new ArgumentNullException(nameof(elasticsearchConfigurationOptions));
 		}
 	}
 }

--- a/src/Tgstation.Server.Host/Setup/SetupApplication.cs
+++ b/src/Tgstation.Server.Host/Setup/SetupApplication.cs
@@ -52,7 +52,7 @@ namespace Tgstation.Server.Host.Setup
 			if (services == null)
 				throw new ArgumentNullException(nameof(services));
 
-			services.SetupLogging(config => config.MinimumLevel.Override("Microsoft", LogEventLevel.Warning), Configuration);
+			services.SetupLogging(config => config.MinimumLevel.Override("Microsoft", LogEventLevel.Warning));
 
 			services.AddSingleton(IOManager);
 			services.AddSingleton(AssemblyInformationProvider);
@@ -62,6 +62,7 @@ namespace Tgstation.Server.Host.Setup
 			services.AddSingleton<IPlatformIdentifier, PlatformIdentifier>();
 			services.AddSingleton<IAsyncDelayer, AsyncDelayer>();
 
+			// these configs are what's injected into PostSetupServices
 			services.UseStandardConfig<GeneralConfiguration>(Configuration);
 			services.UseStandardConfig<DatabaseConfiguration>(Configuration);
 			services.UseStandardConfig<SecurityConfiguration>(Configuration);

--- a/src/Tgstation.Server.Host/Setup/SetupApplication.cs
+++ b/src/Tgstation.Server.Host/Setup/SetupApplication.cs
@@ -52,7 +52,7 @@ namespace Tgstation.Server.Host.Setup
 			if (services == null)
 				throw new ArgumentNullException(nameof(services));
 
-			services.SetupLogging(config => config.MinimumLevel.Override("Microsoft", LogEventLevel.Warning));
+			services.SetupLogging(config => config.MinimumLevel.Override("Microsoft", LogEventLevel.Warning), Configuration);
 
 			services.AddSingleton(IOManager);
 			services.AddSingleton(AssemblyInformationProvider);
@@ -66,6 +66,7 @@ namespace Tgstation.Server.Host.Setup
 			services.UseStandardConfig<DatabaseConfiguration>(Configuration);
 			services.UseStandardConfig<SecurityConfiguration>(Configuration);
 			services.UseStandardConfig<FileLoggingConfiguration>(Configuration);
+			services.UseStandardConfig<ElasticsearchConfiguration>(Configuration);
 
 			ConfigureHostedService(services);
 		}

--- a/src/Tgstation.Server.Host/Setup/SetupWizard.cs
+++ b/src/Tgstation.Server.Host/Setup/SetupWizard.cs
@@ -741,6 +741,51 @@ namespace Tgstation.Server.Host.Setup
 		}
 
 		/// <summary>
+		/// Prompts the user to create a <see cref="ElasticsearchConfiguration"/>.
+		/// </summary>
+		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
+		/// <returns>A <see cref="Task{TResult}"/> resulting in the new <see cref="ElasticsearchConfiguration"/>.</returns>
+		async Task<ElasticsearchConfiguration> ConfigureElasticsearch(CancellationToken cancellationToken) {
+			var elasticsearchConfiguration = new ElasticsearchConfiguration();
+			await console.WriteAsync(null, true, cancellationToken).ConfigureAwait(false);
+			elasticsearchConfiguration.Enable = await PromptYesNo("Enable logging to an external ElasticSearch server? (y/n): ", cancellationToken).ConfigureAwait(false);
+
+			if (elasticsearchConfiguration.Enable)
+			{
+				do
+				{
+					await console.WriteAsync("ElasticSearch server endpoint (Include protocol and port, leave blank for http://127.0.0.1:9200): ", false, cancellationToken).ConfigureAwait(false);
+					elasticsearchConfiguration.Host = await console.ReadLineAsync(false, cancellationToken).ConfigureAwait(false);
+					if (!String.IsNullOrWhiteSpace(elasticsearchConfiguration.Host))
+					{
+						break;
+					}
+				}
+				while (true);
+
+				do
+				{
+					await console.WriteAsync("Enter Elasticsearch username: ", false, cancellationToken).ConfigureAwait(false);
+					elasticsearchConfiguration.Username = await console.ReadLineAsync(false, cancellationToken).ConfigureAwait(false);
+					if (!String.IsNullOrWhiteSpace(elasticsearchConfiguration.Username)) {
+						break;
+					}
+				} while (true);
+
+				do
+				{
+					await console.WriteAsync("Enter password: ", false, cancellationToken).ConfigureAwait(false);
+					elasticsearchConfiguration.Password = await console.ReadLineAsync(true, cancellationToken).ConfigureAwait(false);
+					if (!String.IsNullOrWhiteSpace(elasticsearchConfiguration.Username)) {
+						break;
+					}
+				} while (true);
+			}
+
+			return elasticsearchConfiguration;
+		}
+
+		/// <summary>
 		/// Prompts the user to create a <see cref="ControlPanelConfiguration"/>.
 		/// </summary>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
@@ -834,6 +879,7 @@ namespace Tgstation.Server.Host.Setup
 		/// <param name="databaseConfiguration">The <see cref="DatabaseConfiguration"/> to save.</param>
 		/// <param name="newGeneralConfiguration">The <see cref="GeneralConfiguration"/> to save.</param>
 		/// <param name="fileLoggingConfiguration">The <see cref="FileLoggingConfiguration"/> to save.</param>
+		/// <param name="elasticsearchConfiguration">The <see cref="ElasticsearchConfiguration"/> to save.</param>
 		/// <param name="controlPanelConfiguration">The <see cref="ControlPanelConfiguration"/> to save.</param>
 		/// <param name="swarmConfiguration">The <see cref="SwarmConfiguration"/> to save.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
@@ -844,6 +890,7 @@ namespace Tgstation.Server.Host.Setup
 			DatabaseConfiguration databaseConfiguration,
 			GeneralConfiguration newGeneralConfiguration,
 			FileLoggingConfiguration fileLoggingConfiguration,
+			ElasticsearchConfiguration elasticsearchConfiguration,
 			ControlPanelConfiguration controlPanelConfiguration,
 			SwarmConfiguration swarmConfiguration,
 			CancellationToken cancellationToken)
@@ -857,6 +904,7 @@ namespace Tgstation.Server.Host.Setup
 				{ DatabaseConfiguration.Section, databaseConfiguration },
 				{ GeneralConfiguration.Section, newGeneralConfiguration },
 				{ FileLoggingConfiguration.Section, fileLoggingConfiguration },
+				{ ElasticsearchConfiguration.Section, elasticsearchConfiguration },
 				{ ControlPanelConfiguration.Section, controlPanelConfiguration },
 				{ SwarmConfiguration.Section, swarmConfiguration },
 			};
@@ -931,6 +979,8 @@ namespace Tgstation.Server.Host.Setup
 
 			var fileLoggingConfiguration = await ConfigureLogging(cancellationToken).ConfigureAwait(false);
 
+			var elasticSearchConfiguration = await ConfigureElasticsearch(cancellationToken).ConfigureAwait(false);
+
 			var controlPanelConfiguration = await ConfigureControlPanel(cancellationToken).ConfigureAwait(false);
 
 			var swarmConfiguration = await ConfigureSwarm(cancellationToken).ConfigureAwait(false);
@@ -943,6 +993,7 @@ namespace Tgstation.Server.Host.Setup
 				databaseConfiguration,
 				newGeneralConfiguration,
 				fileLoggingConfiguration,
+				elasticSearchConfiguration,
 				controlPanelConfiguration,
 				swarmConfiguration,
 				cancellationToken)

--- a/src/Tgstation.Server.Host/Setup/SetupWizard.cs
+++ b/src/Tgstation.Server.Host/Setup/SetupWizard.cs
@@ -745,7 +745,8 @@ namespace Tgstation.Server.Host.Setup
 		/// </summary>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the new <see cref="ElasticsearchConfiguration"/>.</returns>
-		async Task<ElasticsearchConfiguration> ConfigureElasticsearch(CancellationToken cancellationToken) {
+		async Task<ElasticsearchConfiguration> ConfigureElasticsearch(CancellationToken cancellationToken)
+		{
 			var elasticsearchConfiguration = new ElasticsearchConfiguration();
 			await console.WriteAsync(null, true, cancellationToken).ConfigureAwait(false);
 			elasticsearchConfiguration.Enable = await PromptYesNo("Enable logging to an external ElasticSearch server? (y/n): ", cancellationToken).ConfigureAwait(false);
@@ -767,19 +768,23 @@ namespace Tgstation.Server.Host.Setup
 				{
 					await console.WriteAsync("Enter Elasticsearch username: ", false, cancellationToken).ConfigureAwait(false);
 					elasticsearchConfiguration.Username = await console.ReadLineAsync(false, cancellationToken).ConfigureAwait(false);
-					if (!String.IsNullOrWhiteSpace(elasticsearchConfiguration.Username)) {
+					if (!String.IsNullOrWhiteSpace(elasticsearchConfiguration.Username))
+					{
 						break;
 					}
-				} while (true);
+				}
+				while (true);
 
 				do
 				{
 					await console.WriteAsync("Enter password: ", false, cancellationToken).ConfigureAwait(false);
 					elasticsearchConfiguration.Password = await console.ReadLineAsync(true, cancellationToken).ConfigureAwait(false);
-					if (!String.IsNullOrWhiteSpace(elasticsearchConfiguration.Username)) {
+					if (!String.IsNullOrWhiteSpace(elasticsearchConfiguration.Username))
+					{
 						break;
 					}
-				} while (true);
+				}
+				while (true);
 			}
 
 			return elasticsearchConfiguration;

--- a/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
+++ b/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
@@ -67,6 +67,7 @@
     <PackageReference Include="Cyberboss.AspNetCore.AsyncInitializer" Version="1.2.0" />
     <PackageReference Include="Cyberboss.SmartIrc4net.Standard" Version="0.4.6" />
     <PackageReference Include="Discord.Net.WebSocket" Version="2.3.1" />
+    <PackageReference Include="Elastic.CommonSchema.Serilog" Version="1.5.3" />
     <PackageReference Include="GitLabApiClient" Version="1.7.0" />
     <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0034" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.13" />
@@ -91,6 +92,7 @@
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.Async" Version="1.4.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="8.4.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Tgstation.Server.Host.Tests/Setup/TestSetupWizard.cs
+++ b/tests/Tgstation.Server.Host.Tests/Setup/TestSetupWizard.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Hosting;
+﻿using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
@@ -50,7 +50,7 @@ namespace Tgstation.Server.Host.Setup.Tests
 		}
 
 		[TestMethod]
-		public async Task TestWithUserStupiditiy()
+		public async Task TestWithUserStupidity()
 		{
 			var mockIOManager = new Mock<IIOManager>();
 			var mockConsole = new Mock<IConsole>();
@@ -203,6 +203,8 @@ namespace Tgstation.Server.Host.Setup.Tests
 				"not actually verified because lol mocks /../!@#$%^&*()/..///.",
 				"Warning",
 				String.Empty,
+				// elasticsearch config
+				"n", // were not validating this travesty in CI
 				//cp config
 				"y",
 				"n",

--- a/tests/Tgstation.Server.Host.Tests/Setup/TestSetupWizard.cs
+++ b/tests/Tgstation.Server.Host.Tests/Setup/TestSetupWizard.cs
@@ -239,6 +239,8 @@ namespace Tgstation.Server.Host.Setup.Tests
 				"fake",
 				"None",
 				"Critical",
+				// elasticsearch config
+				"n", // were not validating this travesty in CI
 				//cp config
 				"y",
 				"n",

--- a/tests/Tgstation.Server.Host.Tests/Setup/TestSetupWizard.cs
+++ b/tests/Tgstation.Server.Host.Tests/Setup/TestSetupWizard.cs
@@ -175,6 +175,8 @@ namespace Tgstation.Server.Host.Setup.Tests
 				"y",
 				//logging config
 				"no",
+				// elasticsearch config
+				"n", // were not validating this travesty in CI
 				//cp config
 				"y",
 				"y",


### PR DESCRIPTION
This adds elasticsearch ingesting for the existing serilogs into an ELK stack for easier searching.
```yml
Elasticsearch:
  Enable: true
  Host: http://192.168.0.200:9200
  Username: youruserhere
  Password: yourpasshere
```

:cl: Core
Added the ability to auto ingest logs into an elasticsearch stack
/:cl:

:cl: Configuration
The new configuration version is `3.1.0`
Added an `Elasticsearch` section with entries for your elasticsearch `Host`, `Username`, `Password`, and `Enable`d status.
/:cl:
