### PR TITLE
Potential fix for process suspension failure

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>4.12.0</TgsCoreVersion>
+    <TgsCoreVersion>4.12.1</TgsCoreVersion>
     <TgsConfigVersion>3.0.0</TgsConfigVersion>
     <TgsApiVersion>9.0.1</TgsApiVersion>
     <TgsApiLibraryVersion>9.0.0</TgsApiLibraryVersion>

--- a/src/Tgstation.Server.Host/System/IProcessFeatures.cs
+++ b/src/Tgstation.Server.Host/System/IProcessFeatures.cs
@@ -25,7 +25,7 @@ namespace Tgstation.Server.Host.System
 		/// <summary>
 		/// Resume a given suspended <see cref="Process"/>.
 		/// </summary>
-		/// <param name="process">The <see cref="Process"/> to susperesumend.</param>
+		/// <param name="process">The <see cref="Process"/> to suspended.</param>
 		void ResumeProcess(global::System.Diagnostics.Process process);
 
 		/// <summary>

--- a/tests/Tgstation.Server.Host.Tests/System/TestProcessFeatures.cs
+++ b/tests/Tgstation.Server.Host.Tests/System/TestProcessFeatures.cs
@@ -21,7 +21,7 @@ namespace Tgstation.Server.Host.System.Tests
 		public void Init()
 		{
 			features = new PlatformIdentifier().IsWindows
-				? (IProcessFeatures)new WindowsProcessFeatures()
+				? (IProcessFeatures)new WindowsProcessFeatures(Mock.Of<ILogger<WindowsProcessFeatures>>())
 				: new PosixProcessFeatures(new Lazy<IProcessExecutor>(() => null), new DefaultIOManager(), Mock.Of<ILogger<PosixProcessFeatures>>());
 		}
 

--- a/tests/Tgstation.Server.Tests/Instance/WatchdogTest.cs
+++ b/tests/Tgstation.Server.Tests/Instance/WatchdogTest.cs
@@ -227,7 +227,7 @@ namespace Tgstation.Server.Tests.Instance
 			IProcessExecutor executor = null;
 			executor = new ProcessExecutor(
 				new PlatformIdentifier().IsWindows
-					? (IProcessFeatures)new WindowsProcessFeatures()
+					? (IProcessFeatures)new WindowsProcessFeatures(Mock.Of<ILogger<WindowsProcessFeatures>>())
 					: new PosixProcessFeatures(new Lazy<IProcessExecutor>(() => executor), Mock.Of<IIOManager>(), Mock.Of<ILogger<PosixProcessFeatures>>()),
 				Mock.Of<ILogger<ProcessExecutor>>(),
 				LoggerFactory.Create(x => { }));


### PR DESCRIPTION
:cl:
Fixes a potential crash with new deployments in the Windows watchdog.
/:cl:

Probably fixes #1279

Merge with `[TGSDeploy]`