### PR TITLE
Fix single server swarms update deadlock

### DIFF
--- a/src/Tgstation.Server.Host/Swarm/SwarmService.cs
+++ b/src/Tgstation.Server.Host/Swarm/SwarmService.cs
@@ -856,6 +856,15 @@ namespace Tgstation.Server.Host.Swarm
 						swarmServers
 							.Where(x => !x.Controller)
 							.Select(x => x.Identifier));
+
+					if (nodesThatNeedToBeReadyToCommit.Count == 0)
+					{
+						logger.LogTrace("Controller has no nodes, setting commit-ready.");
+						var commitTcs = updateCommitTcs;
+						commitTcs?.TrySetResult(true);
+						return commitTcs != null;
+					}
+
 					tasks = swarmServers
 							.Where(x => !x.Controller)
 							.Select(RemotePrepareUpdate)


### PR DESCRIPTION
Credit @ZeWaka for finding this bug

:cl:
Fixed a deadlock when trying to update a server swarm that only had a controller and no nodes.
/:cl: