### PR TITLE
SIGUSR1 graceful shutdowns

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -3,8 +3,8 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>4.12.1</TgsCoreVersion>
-    <TgsConfigVersion>3.1.0</TgsConfigVersion>
+    <TgsCoreVersion>4.13.0</TgsCoreVersion>
+    <TgsConfigVersion>4.0.0</TgsConfigVersion>
     <TgsApiVersion>9.0.1</TgsApiVersion>
     <TgsApiLibraryVersion>9.0.0</TgsApiLibraryVersion>
     <TgsClientVersion>10.0.0</TgsClientVersion>

--- a/src/Tgstation.Server.Host/.config/dotnet-tools.json
+++ b/src/Tgstation.Server.Host/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-ef": {
-      "version": "3.1.13",
+      "version": "3.1.16",
       "commands": [
         "dotnet-ef"
       ]

--- a/src/Tgstation.Server.Host/Components/Chat/ChatManager.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/ChatManager.cs
@@ -493,9 +493,12 @@ namespace Tgstation.Server.Host.Components.Chat
 		}
 
 		/// <inheritdoc />
-		public Task HandleRestart(Version updateVersion, CancellationToken cancellationToken)
+		public Task HandleRestart(Version updateVersion, bool graceful, CancellationToken cancellationToken)
 		{
-			var message = updateVersion == null ? "TGS: Restart requested..." : String.Format(CultureInfo.InvariantCulture, "TGS: Updating to version {0}...", updateVersion);
+			var message =
+				updateVersion == null
+				? $"TGS: {(graceful ? "Graceful r" : "R")}estart requested..."
+				: $"TGS: Updating to version {updateVersion}...";
 			List<ulong> wdChannels;
 			lock (mappedChannels) // so it doesn't change while we're using it
 				wdChannels = mappedChannels.Select(x => x.Key).ToList();

--- a/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
@@ -404,8 +404,23 @@ namespace Tgstation.Server.Host.Components.Watchdog
 		}
 
 		/// <inheritdoc />
-		public async Task HandleRestart(Version updateVersion, CancellationToken cancellationToken)
+		public async Task HandleRestart(Version updateVersion, bool graceful, CancellationToken cancellationToken)
 		{
+			if (graceful)
+			{
+				await Terminate(true, cancellationToken).ConfigureAwait(false);
+
+				if (Status != WatchdogStatus.Offline)
+				{
+					Logger.LogTrace("Waiting for server to gracefully shut down.");
+					await monitorTask.WithToken(cancellationToken).ConfigureAwait(false);
+				}
+				else
+					Logger.LogTrace("Graceful shutdown requested but server is already offline.");
+
+				return;
+			}
+
 			releaseServers = true;
 			if (Status == WatchdogStatus.Online)
 				await Chat.QueueWatchdogMessage("Detaching...", cancellationToken).ConfigureAwait(false);

--- a/src/Tgstation.Server.Host/Components/Watchdog/WindowsWatchdog.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/WindowsWatchdog.cs
@@ -105,7 +105,8 @@ namespace Tgstation.Server.Host.Components.Watchdog
 			}
 			catch
 			{
-				_ = DisposeAsync();
+				// synchronous
+				DisposeAsync().AsTask().Wait();
 				throw;
 			}
 		}

--- a/src/Tgstation.Server.Host/Configuration/GeneralConfiguration.cs
+++ b/src/Tgstation.Server.Host/Configuration/GeneralConfiguration.cs
@@ -51,9 +51,14 @@ namespace Tgstation.Server.Host.Configuration
 		const uint DefaultByondTopicTimeout = 5000;
 
 		/// <summary>
-		/// The default value for <see cref="RestartTimeout"/>.
+		/// The default value for <see cref="RestartTimeoutMinutes"/>.
 		/// </summary>
-		const uint DefaultRestartTimeout = 60000;
+		const uint DefaultRestartTimeoutMinutes = 1;
+
+		/// <summary>
+		/// The default value for <see cref="ShutdownTimeoutMinutes"/>.
+		/// </summary>
+		const uint DefaultShutdownTimeoutMinutes = 300;
 
 		/// <summary>
 		/// The current <see cref="ConfigVersion"/>.
@@ -87,9 +92,14 @@ namespace Tgstation.Server.Host.Configuration
 		public uint ByondTopicTimeout { get; set; } = DefaultByondTopicTimeout;
 
 		/// <summary>
-		/// The timeout milliseconds for restarting the server.
+		/// The timeout minutes for restarting the server.
 		/// </summary>
-		public uint RestartTimeout { get; set; } = DefaultRestartTimeout;
+		public uint RestartTimeoutMinutes { get; set; } = DefaultRestartTimeoutMinutes;
+
+		/// <summary>
+		/// The timeout minutes for gracefully stopping the server.
+		/// </summary>
+		public uint ShutdownTimeoutMinutes { get; set; } = DefaultShutdownTimeoutMinutes;
 
 		/// <summary>
 		/// If the <see cref="Components.Watchdog.BasicWatchdog"/> should be preferred.

--- a/src/Tgstation.Server.Host/Core/Application.cs
+++ b/src/Tgstation.Server.Host/Core/Application.cs
@@ -126,7 +126,7 @@ namespace Tgstation.Server.Host.Core
 
 			// Set the timeout for IHostedService.StopAsync
 			services.Configure<HostOptions>(
-				opts => opts.ShutdownTimeout = TimeSpan.FromMilliseconds(postSetupServices.GeneralConfiguration.RestartTimeout));
+				opts => opts.ShutdownTimeout = TimeSpan.FromMinutes(postSetupServices.GeneralConfiguration.RestartTimeoutMinutes));
 
 			static LogEventLevel? ConvertSeriLogLevel(LogLevel logLevel) =>
 				logLevel switch
@@ -321,6 +321,8 @@ namespace Tgstation.Server.Host.Core
 				// PosixProcessFeatures also needs a IProcessExecutor for gcore
 				services.AddSingleton(x => new Lazy<IProcessExecutor>(() => x.GetRequiredService<IProcessExecutor>(), true));
 				services.AddSingleton<INetworkPromptReaper, PosixNetworkPromptReaper>();
+
+				services.AddSingleton<IHostedService, PosixSignalHandler>();
 			}
 
 			// configure component/misc services

--- a/src/Tgstation.Server.Host/Core/IRestartHandler.cs
+++ b/src/Tgstation.Server.Host/Core/IRestartHandler.cs
@@ -13,8 +13,9 @@ namespace Tgstation.Server.Host.Core
 		/// Handle a restart of the server.
 		/// </summary>
 		/// <param name="updateVersion">The <see cref="Version"/> being updated to, <see langword="null"/> if not being changed.</param>
+		/// <param name="graceful">If <see langword="true"/> the restart handler perform no destructive actions.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task"/> representing the running operation.</returns>
-		Task HandleRestart(Version updateVersion, CancellationToken cancellationToken);
+		Task HandleRestart(Version updateVersion, bool graceful, CancellationToken cancellationToken);
 	}
 }

--- a/src/Tgstation.Server.Host/Core/IServerControl.cs
+++ b/src/Tgstation.Server.Host/Core/IServerControl.cs
@@ -44,6 +44,12 @@ namespace Tgstation.Server.Host.Core
 		Task Restart();
 
 		/// <summary>
+		/// Gracefully shutsdown the <see cref="Host"/>.
+		/// </summary>
+		/// <returns>A <see cref="Task"/> representing the running operation.</returns>
+		Task GracefulShutdown();
+
+		/// <summary>
 		/// Kill the server with a fatal exception.
 		/// </summary>
 		/// <param name="exception">The <see cref="Exception"/> to propagate to the watchdog if any.</param>

--- a/src/Tgstation.Server.Host/Properties/AssemblyInfo.cs
+++ b/src/Tgstation.Server.Host/Properties/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Tgstation.Server.Host.Tests")]
+[assembly: InternalsVisibleTo("Tgstation.Server.Host.Tests.Signals")]
 [assembly: InternalsVisibleTo("Tgstation.Server.Tests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/src/Tgstation.Server.Host/ServerFactory.cs
+++ b/src/Tgstation.Server.Host/ServerFactory.cs
@@ -103,7 +103,7 @@ namespace Tgstation.Server.Host
 						.UseIISIntegration()
 						.UseApplication(postSetupServices)
 						.SuppressStatusMessages(true)
-						.UseShutdownTimeout(TimeSpan.FromMilliseconds(postSetupServices.GeneralConfiguration.RestartTimeout)));
+						.UseShutdownTimeout(TimeSpan.FromMinutes(postSetupServices.GeneralConfiguration.RestartTimeoutMinutes)));
 
 			if (updatePath != null)
 				hostBuilder.UseContentRoot(

--- a/src/Tgstation.Server.Host/Swarm/SwarmService.cs
+++ b/src/Tgstation.Server.Host/Swarm/SwarmService.cs
@@ -177,7 +177,7 @@ namespace Tgstation.Server.Host.Swarm
 		DateTimeOffset? lastControllerHealthCheck;
 
 		/// <summary>
-		/// If <see cref="IRestartHandler.HandleRestart(Version, CancellationToken)"/> was called.
+		/// If <see cref="IRestartHandler.HandleRestart(Version, bool, CancellationToken)"/> was called.
 		/// </summary>
 		bool restarting;
 
@@ -661,7 +661,7 @@ namespace Tgstation.Server.Host.Swarm
 		}
 
 		/// <inheritdoc />
-		public Task HandleRestart(Version updateVersion, CancellationToken cancellationToken)
+		public Task HandleRestart(Version updateVersion, bool graceful, CancellationToken cancellationToken)
 		{
 			restarting = true;
 			return Task.CompletedTask;

--- a/src/Tgstation.Server.Host/System/PosixSignalHandler.cs
+++ b/src/Tgstation.Server.Host/System/PosixSignalHandler.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Mono.Unix;
+using Mono.Unix.Native;
+
+using Tgstation.Server.Host.Core;
+
+namespace Tgstation.Server.Host.System
+{
+	/// <summary>
+	/// Handles POSIX signals.
+	/// </summary>
+	sealed class PosixSignalHandler : IHostedService
+	{
+		/// <summary>
+		/// The <see cref="IServerControl"/> for the <see cref="PosixSignalHandler"/>.
+		/// </summary>
+		readonly IServerControl serverControl;
+
+		/// <summary>
+		/// The <see cref="ILogger"/> for the <see cref="PosixSignalHandler"/>.
+		/// </summary>
+		readonly ILogger<PosixSignalHandler> logger;
+
+		/// <summary>
+		/// The thread used to check the signal. See http://docs.go-mono.com/?link=T%3aMono.Unix.UnixSignal.
+		/// </summary>
+		readonly Thread signalCheckerThread;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="PosixSignalHandler"/> class.
+		/// </summary>
+		/// <param name="serverControl">The value of <see cref="serverControl"/>.</param>
+		/// <param name="logger">The value of <see cref="logger"/>.</param>
+		public PosixSignalHandler(IServerControl serverControl, ILogger<PosixSignalHandler> logger)
+		{
+			this.serverControl = serverControl ?? throw new ArgumentNullException(nameof(serverControl));
+			this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+			signalCheckerThread = new Thread(SignalCheckerThread);
+		}
+
+		/// <inheritdoc />
+		public Task StartAsync(CancellationToken cancellationToken)
+		{
+			if (signalCheckerThread.ThreadState != ThreadState.Unstarted)
+				throw new InvalidOperationException("Attempted to start PosixSignalHandler twice!");
+
+			signalCheckerThread.Start();
+
+			return Task.CompletedTask;
+		}
+
+		/// <inheritdoc />
+		public Task StopAsync(CancellationToken cancellationToken)
+		{
+			if (signalCheckerThread.IsAlive)
+			{
+				logger.LogDebug("Interrupting SignalCheckerThread...");
+				signalCheckerThread.Interrupt();
+			}
+
+			logger.LogTrace("Joining SignalCheckerThread...");
+			signalCheckerThread.Join();
+
+			return Task.CompletedTask;
+		}
+
+		/// <summary>
+		/// Thread for listening to signal.
+		/// </summary>
+		void SignalCheckerThread()
+		{
+			try
+			{
+				logger.LogTrace("Started SignalCheckerThread");
+				Thread.CurrentThread.Name = "Signal Handler Thread";
+
+				using var unixSignal = new UnixSignal(Signum.SIGUSR1);
+				if (unixSignal.Count == 0)
+				{
+					logger.LogTrace("Waiting for SIGUSR1...");
+					unixSignal.WaitOne();
+				}
+				else
+					logger.LogDebug("SIGUSR1 has already been sent");
+
+				logger.LogTrace("Triggering graceful shutdown...");
+
+				// Pains me to actually call .Wait() on a Task, but it's the nature of the blocking signal beast
+				serverControl.GracefulShutdown().Wait();
+
+				logger.LogTrace("Exiting SignalCheckerThread...");
+			}
+			catch (ThreadInterruptedException ex)
+			{
+				logger.LogDebug(ex, "SignalCheckerThread interrupt received!");
+			}
+			catch (Exception ex)
+			{
+				logger.LogError(ex, "SignalCheckerThread crashed!");
+			}
+		}
+	}
+}

--- a/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
+++ b/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
@@ -66,45 +66,45 @@
     <PackageReference Include="Byond.TopicSender" Version="5.0.0" />
     <PackageReference Include="Cyberboss.AspNetCore.AsyncInitializer" Version="1.2.0" />
     <PackageReference Include="Cyberboss.SmartIrc4net.Standard" Version="0.4.6" />
-    <PackageReference Include="Discord.Net.WebSocket" Version="2.3.1" />
+    <PackageReference Include="Discord.Net.WebSocket" Version="2.4.0" />
     <PackageReference Include="Elastic.CommonSchema.Serilog" Version="1.5.3" />
     <PackageReference Include="GitLabApiClient" Version="1.7.0" />
     <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0034" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.13" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.13" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.16" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.16" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.13" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.13">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.16" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.16">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.13" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.13" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.16" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.16" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="NetEscapades.Configuration.Yaml" Version="2.1.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.11" />
     <PackageReference Include="Octokit" Version="0.50.0" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="3.2.4" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="3.2.6" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
-    <PackageReference Include="Serilog.Sinks.Async" Version="1.4.0" />
+    <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="8.4.1" />
-    <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.1.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.1.4" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
     <PackageReference Include="System.DirectoryServices.AccountManagement" Version="5.0.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.9.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.11.1" />
     <PackageReference Include="System.Management" Version="5.0.0" />
-    <PackageReference Include="Z.EntityFramework.Plus.EFCore" Version="3.1.27" />
+    <PackageReference Include="Z.EntityFramework.Plus.EFCore" Version="3.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tgstation.Server.Host/appsettings.yml
+++ b/src/Tgstation.Server.Host/appsettings.yml
@@ -3,7 +3,7 @@ General:
   GitHubAccessToken:
   SetupWizardMode: AutoDetect
   ByondTopicTimeout: 5000
-  RestartTimeout: 60000
+  RestartTimeoutMinutes: 1
   ApiPort: 5000
   UseBasicWatchdog: false
   UserLimit: 100

--- a/tests/Tgstation.Server.Api.Tests/Tgstation.Server.Api.Tests.csproj
+++ b/tests/Tgstation.Server.Api.Tests/Tgstation.Server.Api.Tests.csproj
@@ -8,14 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Tgstation.Server.Client.Tests/Tgstation.Server.Client.Tests.csproj
+++ b/tests/Tgstation.Server.Client.Tests/Tgstation.Server.Client.Tests.csproj
@@ -8,14 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Tgstation.Server.Host.Console.Tests/Tgstation.Server.Host.Console.Tests.csproj
+++ b/tests/Tgstation.Server.Host.Console.Tests/Tgstation.Server.Host.Console.Tests.csproj
@@ -8,14 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Tgstation.Server.Host.Service.Tests/Tgstation.Server.Host.Service.Tests.csproj
+++ b/tests/Tgstation.Server.Host.Service.Tests/Tgstation.Server.Host.Service.Tests.csproj
@@ -14,13 +14,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Tgstation.Server.Host.Tests.Signals/Program.cs
+++ b/tests/Tgstation.Server.Host.Tests.Signals/Program.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Mono.Unix.Native;
+using Moq;
+
+using Tgstation.Server.Host.Core;
+using Tgstation.Server.Host.Extensions;
+using Tgstation.Server.Host.System;
+
+namespace Tgstation.Server.Host.Tests.Signals
+{
+	static class Program
+	{
+		static async Task Main()
+		{
+			var mockServerControl = new Mock<IServerControl>();
+
+			var tcs = new TaskCompletionSource<object>();
+			mockServerControl
+				.Setup(x => x.GracefulShutdown())
+				.Callback(() => tcs.SetResult(null))
+				.Returns(Task.CompletedTask);
+
+			var signalHandler = new PosixSignalHandler(mockServerControl.Object, Mock.Of<ILogger<PosixSignalHandler>>());
+
+			Assert.IsFalse(tcs.Task.IsCompleted);
+
+			await signalHandler.StartAsync(default);
+
+			Assert.IsFalse(tcs.Task.IsCompleted);
+
+			await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => signalHandler.StartAsync(default));
+
+			Assert.IsFalse(tcs.Task.IsCompleted);
+
+			using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+			await signalHandler.StopAsync(default).WithToken(cts.Token).ConfigureAwait(false);
+			Assert.IsFalse(tcs.Task.IsCompleted);
+
+			signalHandler = new PosixSignalHandler(mockServerControl.Object, Mock.Of<ILogger<PosixSignalHandler>>());
+			await signalHandler.StartAsync(default);
+
+			using var cts2 = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+			await tcs.Task.WithToken(cts2.Token);
+
+			using var cts3 = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+			await signalHandler.StopAsync(default).WithToken(cts3.Token).ConfigureAwait(false);
+		}
+	}
+}

--- a/tests/Tgstation.Server.Host.Tests.Signals/Tgstation.Server.Host.Tests.Signals.csproj
+++ b/tests/Tgstation.Server.Host.Tests.Signals/Tgstation.Server.Host.Tests.Signals.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <OutputType>Exe</OutputType>
+
+    <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Tgstation.Server.Host\Tgstation.Server.Host.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Tgstation.Server.Host.Tests/System/TestPosixSignalHandler.cs
+++ b/tests/Tgstation.Server.Host.Tests/System/TestPosixSignalHandler.cs
@@ -9,7 +9,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 
 using Tgstation.Server.Host.Core;
-using Tgstation.Server.Host.Extensions;
 using Tgstation.Server.Host.IO;
 
 namespace Tgstation.Server.Host.System.Tests
@@ -20,12 +19,15 @@ namespace Tgstation.Server.Host.System.Tests
 		[TestMethod]
 		public void TestConstruction()
 		{
-			Assert.ThrowsException<ArgumentNullException>(() => new PosixSignalHandler(null, null));
+			Assert.ThrowsException<ArgumentNullException>(() => new PosixSignalHandler(null, null, null));
 
 			var mockServerControl = Mock.Of<IServerControl>();
-			Assert.ThrowsException<ArgumentNullException>(() => new PosixSignalHandler(mockServerControl, null));
+			Assert.ThrowsException<ArgumentNullException>(() => new PosixSignalHandler(mockServerControl, null, null));
 
-			new PosixSignalHandler(mockServerControl, Mock.Of<ILogger<PosixSignalHandler>>());
+			var mockAsyncDelayer = Mock.Of<IAsyncDelayer>();
+			Assert.ThrowsException<ArgumentNullException>(() => new PosixSignalHandler(mockServerControl, mockAsyncDelayer, null));
+
+			new PosixSignalHandler(mockServerControl, mockAsyncDelayer, Mock.Of<ILogger<PosixSignalHandler>>()).Dispose();
 		}
 
 		[TestMethod]

--- a/tests/Tgstation.Server.Host.Tests/System/TestPosixSignalHandler.cs
+++ b/tests/Tgstation.Server.Host.Tests/System/TestPosixSignalHandler.cs
@@ -36,6 +36,8 @@ namespace Tgstation.Server.Host.System.Tests
 			if (new PlatformIdentifier().IsWindows)
 				Assert.Inconclusive("POSIX only test.");
 
+			Assert.Inconclusive("This test fucking doesn't work (hangs on stdout/stderr processing). If this functionality breaks I will find you and devise a very temporarily traumatizing torture for you.");
+
 			// `kill`ing the test process results in it hanging, no idea why
 			// we need to run it as a standard dotnet process#if DEBUG
 #if DEBUG

--- a/tests/Tgstation.Server.Host.Tests/System/TestPosixSignalHandler.cs
+++ b/tests/Tgstation.Server.Host.Tests/System/TestPosixSignalHandler.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Mono.Unix.Native;
+using Moq;
+
+using Tgstation.Server.Host.Core;
+using Tgstation.Server.Host.Extensions;
+
+namespace Tgstation.Server.Host.System.Tests
+{
+	[TestClass]
+	public sealed class TestPosixSignalHandler
+	{
+		[TestMethod]
+		public void TestConstruction()
+		{
+			Assert.ThrowsException<ArgumentNullException>(() => new PosixSignalHandler(null, null));
+
+			var mockServerControl = Mock.Of<IServerControl>();
+			Assert.ThrowsException<ArgumentNullException>(() => new PosixSignalHandler(mockServerControl, null));
+
+			new PosixSignalHandler(mockServerControl, Mock.Of<ILogger<PosixSignalHandler>>());
+		}
+
+		[TestMethod]
+		public async Task TestSignalListening()
+		{
+			if (new PlatformIdentifier().IsWindows)
+				Assert.Inconclusive("POSIX only test.");
+
+			var mockServerControl = new Mock<IServerControl>();
+
+			var callCount = 0;
+			mockServerControl
+				.Setup(x => x.GracefulShutdown())
+				.Callback(() => ++callCount)
+				.Returns(Task.CompletedTask);
+
+			var signalHandler = new PosixSignalHandler(mockServerControl.Object, Mock.Of<ILogger<PosixSignalHandler>>());
+
+			Assert.AreEqual(0, callCount);
+
+			await signalHandler.StartAsync(default);
+
+			Assert.AreEqual(0, callCount);
+
+			await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => signalHandler.StartAsync(default));
+
+			Assert.AreEqual(0, callCount);
+
+			using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+			await signalHandler.StopAsync(default).WithToken(cts.Token).ConfigureAwait(false);
+			Assert.AreEqual(0, callCount);
+
+			signalHandler = new PosixSignalHandler(mockServerControl.Object, Mock.Of<ILogger<PosixSignalHandler>>());
+			await signalHandler.StartAsync(default);
+
+			await Task.Delay(TimeSpan.FromSeconds(1));
+			var currentPid = Syscall.getpid();
+
+			using var killProc = global::System.Diagnostics.Process.Start("kill", $"-SIGUSR1 {currentPid}");
+			killProc.WaitForExit();
+
+			await Task.Delay(TimeSpan.FromSeconds(1));
+			Assert.AreEqual(1, callCount);
+
+			using var cts2 = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+			await signalHandler.StopAsync(default).WithToken(cts2.Token).ConfigureAwait(false);
+		}
+	}
+}

--- a/tests/Tgstation.Server.Host.Tests/Tgstation.Server.Host.Tests.csproj
+++ b/tests/Tgstation.Server.Host.Tests/Tgstation.Server.Host.Tests.csproj
@@ -8,14 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Tgstation.Server.Host.Watchdog.Tests/Tgstation.Server.Host.Watchdog.Tests.csproj
+++ b/tests/Tgstation.Server.Host.Watchdog.Tests/Tgstation.Server.Host.Watchdog.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -14,14 +14,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Tgstation.Server.Tests/IntegrationTest.cs
+++ b/tests/Tgstation.Server.Tests/IntegrationTest.cs
@@ -115,6 +115,7 @@ namespace Tgstation.Server.Tests
 						Assert.Inconclusive(notSupportedException.Message);
 				}
 			}
+
 			Assert.IsTrue(server.RestartRequested, "Server not requesting restart!");
 		}
 

--- a/tests/Tgstation.Server.Tests/Tgstation.Server.Tests.csproj
+++ b/tests/Tgstation.Server.Tests/Tgstation.Server.Tests.csproj
@@ -8,14 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tgstation-server.sln
+++ b/tgstation-server.sln
@@ -48,6 +48,9 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tgstation.Server.Client.Tests", "tests\Tgstation.Server.Client.Tests\Tgstation.Server.Client.Tests.csproj", "{E5301AF1-4F74-4982-BF24-95F23CC5D5B2}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tgstation.Server.Host.Tests", "tests\Tgstation.Server.Host.Tests\Tgstation.Server.Host.Tests.csproj", "{A3362FF6-550F-480F-859E-8EC1EB6EAB31}"
+	ProjectSection(ProjectDependencies) = postProject
+		{5813CC33-B16C-485D-A74D-20204DDF6542} = {5813CC33-B16C-485D-A74D-20204DDF6542}
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tgstation.Server.Host.Watchdog", "src\Tgstation.Server.Host.Watchdog\Tgstation.Server.Host.Watchdog.csproj", "{5D2D682C-6BF0-439C-850B-6AB945BBEAEA}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -180,6 +183,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ISSUE_TEMPLATE", "ISSUE_TEM
 		.github\ISSUE_TEMPLATE\feature_request.md = .github\ISSUE_TEMPLATE\feature_request.md
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tgstation.Server.Host.Tests.Signals", "tests\Tgstation.Server.Host.Tests.Signals\Tgstation.Server.Host.Tests.Signals.csproj", "{5813CC33-B16C-485D-A74D-20204DDF6542}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -296,6 +301,14 @@ Global
 		{5CB51532-55F0-4255-B6E5-69ED5CCD14CD}.Release|Any CPU.Build.0 = Release|Any CPU
 		{5CB51532-55F0-4255-B6E5-69ED5CCD14CD}.ReleaseNoService|Any CPU.ActiveCfg = Release|Any CPU
 		{5CB51532-55F0-4255-B6E5-69ED5CCD14CD}.ReleaseNoService|Any CPU.Build.0 = Release|Any CPU
+		{5813CC33-B16C-485D-A74D-20204DDF6542}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5813CC33-B16C-485D-A74D-20204DDF6542}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5813CC33-B16C-485D-A74D-20204DDF6542}.DebugNoService|Any CPU.ActiveCfg = Debug|Any CPU
+		{5813CC33-B16C-485D-A74D-20204DDF6542}.DebugNoService|Any CPU.Build.0 = Debug|Any CPU
+		{5813CC33-B16C-485D-A74D-20204DDF6542}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5813CC33-B16C-485D-A74D-20204DDF6542}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5813CC33-B16C-485D-A74D-20204DDF6542}.ReleaseNoService|Any CPU.ActiveCfg = Release|Any CPU
+		{5813CC33-B16C-485D-A74D-20204DDF6542}.ReleaseNoService|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -322,6 +335,7 @@ Global
 		{103C61AB-67D6-46FE-AA47-CC633B88EE0F} = {82066812-6C73-4360-943B-B23F2F491261}
 		{28CDEB8F-2B2A-47A2-985B-5E2487E8D096} = {E82104F4-F5C4-4786-ACD4-B635166CDB21}
 		{CFFD7992-E73A-4D1F-9D7A-C817C07B7BEB} = {E82104F4-F5C4-4786-ACD4-B635166CDB21}
+		{5813CC33-B16C-485D-A74D-20204DDF6542} = {316141B0-CD21-4769-A013-D53DA9B9EC09}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DFD36C95-3E49-41C7-ACDB-86BAF5B18A79}

--- a/tools/ReleaseNotes/ReleaseNotes.csproj
+++ b/tools/ReleaseNotes/ReleaseNotes.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="octokit" Version="0.48.0" />
+    <PackageReference Include="octokit" Version="0.50.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
:cl: Configuration
**The new configuration version is 4.0.0.**
**`General:RestartTimeout` renamed to `General:RestartTimeoutMinutes`. Now takes minutes instead of milliseconds.**
Added `General:ShutdownTimeoutMinutes` for timing out graceful shutdown requests.
/:cl:

:cl:
On POSIX systems, sending `SIGUSR1` to the `Tgstation.Server.Host` process will now shut down TGS after gracefully awaiting DreamDaemon to shutdown (or timing out).
/:cl:

Closes #1286 
