### PR TITLE
Remove annoying I don't respond to this channel message

### DIFF
--- a/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordProvider.cs
@@ -557,9 +557,6 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 					if (mentionedUs)
 					{
 						Logger.LogTrace("Ignoring mention from {0} ({1}) by {2} ({3}). Channel not mapped!", e.Channel.Id, e.Channel.Name, e.Author.Id, e.Author.Username);
-
-						// DCT: None available
-						await SendMessage(e.Channel.Id, "I do not respond to this channel!", default).ConfigureAwait(false);
 					}
 
 					return;


### PR DESCRIPTION
(note: basebranch can't be updated because the branch base was already dev)

:cl:
Removes annoying spam message when the bot ignores a command in a channel it doesn't respond in.
/:cl:


[Why]: # (If this does not close or work on an existing GitHub issue, please add a short description [two lines down] of why you think these changes would benefit the server. If you can't justify it in words, it might not be worth adding.)

This is spammy and stupid and the whole point of making the bot not respond in certain channels is to avoid spamming that channel with bot messages.