### PR TITLE
Adds the accessible property to InstanceResponse

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -5,9 +5,9 @@
   <PropertyGroup>
     <TgsCoreVersion>4.12.1</TgsCoreVersion>
     <TgsConfigVersion>3.1.0</TgsConfigVersion>
-    <TgsApiVersion>9.0.1</TgsApiVersion>
-    <TgsApiLibraryVersion>9.0.0</TgsApiLibraryVersion>
-    <TgsClientVersion>10.0.0</TgsClientVersion>
+    <TgsApiVersion>9.1.0</TgsApiVersion>
+    <TgsApiLibraryVersion>9.1.0</TgsApiLibraryVersion>
+    <TgsClientVersion>10.1.0</TgsClientVersion>
     <TgsDmapiVersion>6.0.4</TgsDmapiVersion>
     <TgsInteropVersion>5.3.0</TgsInteropVersion>
     <TgsHostWatchdogVersion>1.1.1</TgsHostWatchdogVersion>

--- a/src/Tgstation.Server.Api/Models/Response/InstanceResponse.cs
+++ b/src/Tgstation.Server.Api/Models/Response/InstanceResponse.cs
@@ -11,5 +11,10 @@
 		/// <remarks>Due to how <see cref="JobResponse"/>s are children of <see cref="Instance"/>s but moving one requires the <see cref="Instance"/> to be offline, interactions with this <see cref="JobResponse"/> are performed in a non-standard fashion. The <see cref="JobResponse"/> is read by querying the <see cref="Instance"/> again (either via list or ID lookup) and cancelled by making any sort of update to the <see cref="Instance"/>. Once the <see cref="Instance"/> comes back <see cref="Instance.Online"/> it can be queried like a normal job.</remarks>
 		[ResponseOptions]
 		public JobResponse? MoveJob { get; set; }
+
+		/// <summary>
+		/// If the querying user may access this instance.
+		/// </summary>
+		public bool Accessible { get; set; }
 	}
 }

--- a/src/Tgstation.Server.Host/Controllers/ApiController.cs
+++ b/src/Tgstation.Server.Host/Controllers/ApiController.cs
@@ -296,14 +296,14 @@ namespace Tgstation.Server.Host.Controllers
 		/// </summary>
 		/// <typeparam name="TModel">The <see cref="Type"/> of model being generated and returned.</typeparam>
 		/// <param name="queryGenerator">A <see cref="Func{TResult}"/> resulting in a <see cref="Task{TResult}"/> resulting in the generated <see cref="PaginatableResult{TModel}"/>.</param>
-		/// <param name="resultTransformer">An <see cref="Action{T1}"/> to transform the <typeparamref name="TModel"/>s after being queried.</param>
+		/// <param name="resultTransformer">A <see cref="Func{T, TResult}"/> to transform the <typeparamref name="TModel"/>s after being queried.</param>
 		/// <param name="pageQuery">The requested page from the query.</param>
 		/// <param name="pageSizeQuery">The requested page size from the query.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> for the operation.</returns>
 		protected Task<IActionResult> Paginated<TModel>(
 			Func<Task<PaginatableResult<TModel>>> queryGenerator,
-			Action<TModel> resultTransformer,
+			Func<TModel, Task> resultTransformer,
 			int? pageQuery,
 			int? pageSizeQuery,
 			CancellationToken cancellationToken) => PaginatedImpl(
@@ -319,14 +319,14 @@ namespace Tgstation.Server.Host.Controllers
 		/// <typeparam name="TModel">The <see cref="Type"/> of model being generated.</typeparam>
 		/// <typeparam name="TApiModel">The <see cref="Type"/> of model being returned.</typeparam>
 		/// <param name="queryGenerator">A <see cref="Func{TResult}"/> resulting in a <see cref="Task{TResult}"/> resulting in the generated <see cref="PaginatableResult{TModel}"/>.</param>
-		/// <param name="resultTransformer">An <see cref="Action{T1}"/> to transform the <typeparamref name="TApiModel"/>s after being queried.</param>
+		/// <param name="resultTransformer">A <see cref="Func{T, TResult}"/> to transform the <typeparamref name="TApiModel"/>s after being queried.</param>
 		/// <param name="pageQuery">The requested page from the query.</param>
 		/// <param name="pageSizeQuery">The requested page size from the query.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> for the operation.</returns>
 		protected Task<IActionResult> Paginated<TModel, TApiModel>(
 			Func<Task<PaginatableResult<TModel>>> queryGenerator,
-			Action<TApiModel> resultTransformer,
+			Func<TApiModel, Task> resultTransformer,
 			int? pageQuery,
 			int? pageSizeQuery,
 			CancellationToken cancellationToken)
@@ -344,14 +344,14 @@ namespace Tgstation.Server.Host.Controllers
 		/// <typeparam name="TModel">The <see cref="Type"/> of model being generated. If different from <typeparamref name="TResultModel"/>, must implement <see cref="IApiTransformable{TApiModel}"/> for <typeparamref name="TResultModel"/>.</typeparam>
 		/// <typeparam name="TResultModel">The <see cref="Type"/> of model being returned.</typeparam>
 		/// <param name="queryGenerator">A <see cref="Func{TResult}"/> resulting in a <see cref="Task{TResult}"/> resulting in the generated <see cref="PaginatableResult{TModel}"/>.</param>
-		/// <param name="resultTransformer">An <see cref="Action{T1}"/> to transform the <typeparamref name="TResultModel"/>s after being queried.</param>
+		/// <param name="resultTransformer">A <see cref="Func{T, TResult}"/> to transform the <typeparamref name="TResultModel"/>s after being queried.</param>
 		/// <param name="pageQuery">The requested page from the query.</param>
 		/// <param name="pageSizeQuery">The requested page size from the query.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="IActionResult"/> for the operation.</returns>
 		async Task<IActionResult> PaginatedImpl<TModel, TResultModel>(
 			Func<Task<PaginatableResult<TModel>>> queryGenerator,
-			Action<TResultModel> resultTransformer,
+			Func<TResultModel, Task> resultTransformer,
 			int? pageQuery,
 			int? pageSizeQuery,
 			CancellationToken cancellationToken)
@@ -406,7 +406,7 @@ namespace Tgstation.Server.Host.Controllers
 
 			if (resultTransformer != null)
 				foreach (var finalResult in finalResults)
-					resultTransformer(finalResult);
+					await resultTransformer(finalResult).ConfigureAwait(false);
 
 			var carryTheOne = totalResults % pageSize != 0
 				? 1

--- a/src/Tgstation.Server.Host/Controllers/ChatController.cs
+++ b/src/Tgstation.Server.Host/Controllers/ChatController.cs
@@ -198,6 +198,8 @@ namespace Tgstation.Server.Host.Controllers
 				{
 					if (connectionStrings)
 						chatBot.ConnectionString = null;
+
+					return Task.CompletedTask;
 				},
 				page,
 				pageSize,

--- a/src/Tgstation.Server.Host/Controllers/JobController.cs
+++ b/src/Tgstation.Server.Host/Controllers/JobController.cs
@@ -175,9 +175,11 @@ namespace Tgstation.Server.Host.Controllers
 		/// Supplements <see cref="JobResponse"/> <see cref="PaginatedResponse{TModel}"/>s with their <see cref="JobResponse.Progress"/>.
 		/// </summary>
 		/// <param name="jobResponse">The <see cref="JobResponse"/> to augment.</param>
-		private void AddJobProgressResponseTransformer(JobResponse jobResponse)
+		/// <returns>A <see cref="Task"/> representing the running operation.</returns>
+		private Task AddJobProgressResponseTransformer(JobResponse jobResponse)
 		{
 			jobResponse.Progress = jobManager.JobProgress(jobResponse);
+			return Task.CompletedTask;
 		}
 	}
 }


### PR DESCRIPTION
:cl: HTTP API
The InstanceResponse now contains the `accessible` property. This will be `true` if the current user has a valid InstancePermissionSet for the instance, `false` otherwise.
/:cl:

Closes #1278 