### PR TITLE
Add submodule updates

### DIFF
--- a/src/Tgstation.Server.Api/Models/Request/RepositoryUpdateRequest.cs
+++ b/src/Tgstation.Server.Api/Models/Request/RepositoryUpdateRequest.cs
@@ -17,9 +17,14 @@ namespace Tgstation.Server.Api.Models.Request
 		public string? CheckoutSha { get; set; }
 
 		/// <summary>
-		/// Do the equivalent of a git pull. Will attempt to merge unless <see cref="RepositoryApiBase.Reference"/> is also specified in which case a hard reset will be performed after checking out.
+		/// Do the equivalent of a `git pull`. Will attempt to merge unless <see cref="RepositoryApiBase.Reference"/> is also specified in which case a hard reset will be performed after checking out.
 		/// </summary>
 		public bool? UpdateFromOrigin { get; set; }
+
+		/// <summary>
+		/// Do the equivalent of a `git submodule update --init --recursive` alongside any resets to origin, checkouts, or test merge additions.
+		/// </summary>
+		public bool? UpdateSubmodules { get; set; }
 
 		/// <summary>
 		/// <see cref="TestMergeParameters"/> for new <see cref="TestMerge"/>s. Note that merges that conflict will not be performed.

--- a/src/Tgstation.Server.Host/Components/Events/EventType.cs
+++ b/src/Tgstation.Server.Host/Components/Events/EventType.cs
@@ -143,5 +143,11 @@
 		/// </summary>
 		[EventScript("DreamDaemonLaunch")]
 		DreamDaemonLaunch,
+
+		/// <summary>
+		/// After a single submodule update is performed. Parameters: Updated submodule name
+		/// </summary>
+		[EventScript("RepoSubmoduleUpdate")]
+		RepoSubmoduleUpdate,
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Instance.cs
+++ b/src/Tgstation.Server.Host/Components/Instance.cs
@@ -404,7 +404,13 @@ namespace Tgstation.Server.Host.Components
 					if (!preserveTestMerges)
 					{
 						logger.LogTrace("Resetting to origin...");
-						await repo.ResetToOrigin(NextProgressReporter(), cancellationToken).ConfigureAwait(false);
+						await repo.ResetToOrigin(
+							repositorySettings.AccessUser,
+							repositorySettings.AccessToken,
+							true,
+							NextProgressReporter(),
+							cancellationToken)
+						.ConfigureAwait(false);
 
 						var currentHead = repo.Head;
 

--- a/src/Tgstation.Server.Host/Components/Repository/IRepository.cs
+++ b/src/Tgstation.Server.Host/Components/Repository/IRepository.cs
@@ -43,10 +43,19 @@ namespace Tgstation.Server.Host.Components.Repository
 		/// Checks out a given <paramref name="committish"/>.
 		/// </summary>
 		/// <param name="committish">The sha or reference to checkout.</param>
+		/// <param name="username">The username used for fetching from submodule repositories.</param>
+		/// <param name="password">The password used for fetching from submodule repositories.</param>
+		/// <param name="updateSubmodules">If a submodule update should be attempted after the merge.</param>
 		/// <param name="progressReporter"><see cref="Action{T1}"/> to report 0-100 <see cref="int"/> progress of the operation.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task"/> representing the running operation.</returns>
-		Task CheckoutObject(string committish, Action<int> progressReporter, CancellationToken cancellationToken);
+		Task CheckoutObject(
+			string committish,
+			string username,
+			string password,
+			bool updateSubmodules,
+			Action<int> progressReporter,
+			CancellationToken cancellationToken);
 
 		/// <summary>
 		/// Attempt to merge the revision specified by a given set of <paramref name="testMergeParameters"/> into HEAD.
@@ -54,12 +63,21 @@ namespace Tgstation.Server.Host.Components.Repository
 		/// <param name="testMergeParameters">The <see cref="TestMergeParameters"/> of the pull request.</param>
 		/// <param name="committerName">The name of the merge committer.</param>
 		/// <param name="committerEmail">The e-mail of the merge committer.</param>
-		/// <param name="username">The username to fetch from the origin repository.</param>
-		/// <param name="password">The password to fetch from the origin repository.</param>
+		/// <param name="username">The username used to fetch from the origin and submodule repositories.</param>
+		/// <param name="password">The password used to fetch from the origin and submodule repositories.</param>
+		/// <param name="updateSubmodules">If a submodule update should be attempted after the merge.</param>
 		/// <param name="progressReporter"><see cref="Action{T1}"/> to report 0-100 <see cref="int"/> progress of the operation.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in a <see cref="Nullable{T}"/> <see cref="bool"/> representing the merge result that is <see langword="true"/> after a fast forward or up to date, <see langword="false"/> on a non-fast-forward, <see langword="null"/> on a conflict.</returns>
-		Task<bool?> AddTestMerge(TestMergeParameters testMergeParameters, string committerName, string committerEmail, string username, string password, Action<int> progressReporter, CancellationToken cancellationToken);
+		Task<bool?> AddTestMerge(
+			TestMergeParameters testMergeParameters,
+			string committerName,
+			string committerEmail,
+			string username,
+			string password,
+			bool updateSubmodules,
+			Action<int> progressReporter,
+			CancellationToken cancellationToken);
 
 		/// <summary>
 		/// Fetch commits from the origin repository.
@@ -74,10 +92,18 @@ namespace Tgstation.Server.Host.Components.Repository
 		/// <summary>
 		/// Requires the current HEAD to be a tracked reference. Hard resets the reference to what it tracks on the origin repository.
 		/// </summary>
+		/// <param name="username">The username used for fetching from submodule repositories.</param>
+		/// <param name="password">The password used for fetching from submodule repositories.</param>
+		/// <param name="updateSubmodules">If a submodule update should be attempted after the merge.</param>
 		/// <param name="progressReporter"><see cref="Action{T1}"/> to report 0-100 <see cref="int"/> progress of the operation.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the SHA of the new HEAD.</returns>
-		Task ResetToOrigin(Action<int> progressReporter, CancellationToken cancellationToken);
+		Task ResetToOrigin(
+			string username,
+			string password,
+			bool updateSubmodules,
+			Action<int> progressReporter,
+			CancellationToken cancellationToken);
 
 		/// <summary>
 		/// Requires the current HEAD to be a reference. Hard resets the reference to the given sha.

--- a/tests/Tgstation.Server.Tests/IntegrationTest.cs
+++ b/tests/Tgstation.Server.Tests/IntegrationTest.cs
@@ -1058,7 +1058,7 @@ namespace Tgstation.Server.Tests
 				() => { });
 
 			const string StartSha = "af4da8beb9f9b374b04a3cc4d65acca662e8cc1a";
-			await repo.CheckoutObject(StartSha, progress => { }, default);
+			await repo.CheckoutObject(StartSha, null, null, true, progress => { }, default);
 			var result = await repo.ShaIsParent("2f8588a3ca0f6b027704a2a04381215619de3412", default);
 			Assert.IsTrue(result);
 			Assert.AreEqual(StartSha, repo.Head);


### PR DESCRIPTION
:cl: HTTP API
Added `updateSubmodules` to RepositoryUpdateRequest. When `true`, a shallow submodule init and update will be performed with Checkout, Reset to Origin, and Add Test Merge operations.
/:cl:

:cl:
Added the `RepoSubmoduleUpdate` event. Fires _after_ a _single_ submodule is updated. Does not fire on root repository cloning. Parameter is the submodule name.
/:cl:

Untested, but yeet. Worked on TGS3, should work here.

Closes #1284