### PR TITLE
Compilation event script improvements

### DIFF
--- a/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
@@ -561,6 +561,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 					{
 						resolvedOutputDirectory,
 						repoOrigin.ToString(),
+						$"{byondLock.Version.Major}.{byondLock.Version.Minor}",
 					},
 					cancellationToken)
 					.ConfigureAwait(false);
@@ -588,6 +589,18 @@ namespace Tgstation.Server.Host.Components.Deployment
 				logger.LogDebug("Selected {0}.dme for compilation!", job.DmeName);
 
 				await ModifyDme(job, cancellationToken).ConfigureAwait(false);
+
+				// run precompile scripts
+				await eventConsumer.HandleEvent(
+					EventType.PreDreamMaker,
+					new List<string>
+					{
+						resolvedOutputDirectory,
+						repoOrigin.ToString(),
+						$"{byondLock.Version.Major}.{byondLock.Version.Minor}",
+					},
+					cancellationToken)
+					.ConfigureAwait(false);
 
 				// run compiler
 				var exitCode = await RunDreamMaker(byondLock.DreamMakerPath, job, cancellationToken).ConfigureAwait(false);
@@ -619,13 +632,22 @@ namespace Tgstation.Server.Host.Components.Deployment
 						{
 							resolvedOutputDirectory,
 							exitCode == 0 ? "1" : "0",
+							$"{byondLock.Version.Major}.{byondLock.Version.Minor}",
 						},
 						cancellationToken)
 						.ConfigureAwait(false);
 					throw;
 				}
 
-				await eventConsumer.HandleEvent(EventType.CompileComplete, new List<string> { resolvedOutputDirectory }, cancellationToken).ConfigureAwait(false);
+				await eventConsumer.HandleEvent(
+					EventType.CompileComplete,
+					new List<string>
+					{
+						resolvedOutputDirectory,
+						$"{byondLock.Version.Major}.{byondLock.Version.Minor}",
+					},
+					cancellationToken)
+					.ConfigureAwait(false);
 
 				logger.LogTrace("Applying static game file symlinks...");
 

--- a/src/Tgstation.Server.Host/Components/Events/EventType.cs
+++ b/src/Tgstation.Server.Host/Components/Events/EventType.cs
@@ -55,7 +55,7 @@
 		ByondActiveVersionChange,
 
 		/// <summary>
-		/// Parameters: Game directory path, origin commit sha
+		/// After the repo is copied, before CodeModifications are applied. Parameters: Game directory path, origin commit sha, byond version
 		/// </summary>
 		[EventScript("PreCompile")]
 		CompileStart,
@@ -67,13 +67,13 @@
 		CompileCancelled,
 
 		/// <summary>
-		/// Parameters: Game directory path, "1" if compile succeeded and api validation failed, "0" otherwise
+		/// Parameters: Game directory path, "1" if compile succeeded and api validation failed, "0" otherwise, BYOND version used
 		/// </summary>
 		[EventScript("CompileFailure")]
 		CompileFailure,
 
 		/// <summary>
-		/// Parameters: Game directory path
+		/// Parameters: Game directory path, BYOND version used
 		/// </summary>
 		[EventScript("PostCompile")]
 		CompileComplete,
@@ -149,5 +149,11 @@
 		/// </summary>
 		[EventScript("RepoSubmoduleUpdate")]
 		RepoSubmoduleUpdate,
+
+		/// <summary>
+		/// After CodeModifications are applied, before DreamMaker is run. Parameters: Game directory path, origin commit sha, byond version
+		/// </summary>
+		[EventScript("PreDreamMaker")]
+		PreDreamMaker,
 	}
 }


### PR DESCRIPTION
:cl:
Added `PreDreamMaker` event script which runs before DreamMaker and after CodeModifications. Parameters: Output directory, repository origin url, BYOND version used.
Added BYOND version used as a parameter to `PreCompile`, `CompileFailure`, and `PostCompile` scripts.
/:cl: