### PR TITLE
Wirewraith, what the hell?

### DIFF
--- a/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
@@ -289,6 +289,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 								};
 
 								logger.LogInformation(Repository.Repository.OriginTrackingErrorTemplate, repoSha);
+								databaseContext.RevisionInformations.Add(revInfo);
 								databaseContext.Instances.Attach(revInfo.Instance);
 								await databaseContext.Save(cancellationToken).ConfigureAwait(false);
 							}

--- a/src/Tgstation.Server.Host/Components/Instance.cs
+++ b/src/Tgstation.Server.Host/Components/Instance.cs
@@ -308,27 +308,14 @@ namespace Tgstation.Server.Host.Components
 						cancellationToken)
 						.ConfigureAwait(false);
 
-					RevisionInformation currentRevInfo = null;
-
 					Task<RevisionInformation> LoadRevInfo() => databaseContext.RevisionInformations
-							.AsQueryable()
-							.Where(x => x.CommitSha == startSha && x.Instance.Id == metadata.Id)
-							.Include(x => x.ActiveTestMerges).ThenInclude(x => x.TestMerge)
-							.FirstOrDefaultAsync(cancellationToken);
+						.AsQueryable()
+						.Where(x => x.CommitSha == startSha && x.Instance.Id == metadata.Id)
+						.Include(x => x.ActiveTestMerges).ThenInclude(x => x.TestMerge)
+						.FirstOrDefaultAsync(cancellationToken);
 
+					RevisionInformation currentRevInfo = null;
 					var hasDbChanges = false;
-
-					// take appropriate auto update actions
-					var shouldSyncTracked = false;
-					var currentRevInfoTask = LoadRevInfo();
-
-					var result = await repo.MergeOrigin(
-						repositorySettings.CommitterName,
-						repositorySettings.CommitterEmail,
-						NextProgressReporter(),
-						cancellationToken)
-						.ConfigureAwait(false);
-
 					async Task UpdateRevInfo(string currentHead, bool onOrigin, IEnumerable<RevInfoTestMerge> updatedTestMerges)
 					{
 						if (currentRevInfo == null)
@@ -363,14 +350,25 @@ namespace Tgstation.Server.Host.Components
 						hasDbChanges = true;
 					}
 
+					// build current commit data if it's missing
+					await UpdateRevInfo(repo.Head, false, null).ConfigureAwait(false);
+
+					var result = await repo.MergeOrigin(
+						repositorySettings.CommitterName,
+						repositorySettings.CommitterEmail,
+						NextProgressReporter(),
+						cancellationToken)
+						.ConfigureAwait(false);
+
 					var preserveTestMerges = repositorySettings.AutoUpdatesKeepTestMerges.Value;
 					var remoteDeploymentManager = remoteDeploymentManagerFactory.CreateRemoteDeploymentManager(
 						metadata,
 						repo.RemoteGitProvider.Value);
+
+					// take appropriate auto update actions
+					var shouldSyncTracked = false;
 					if (result.HasValue)
 					{
-						currentRevInfo = await currentRevInfoTask.ConfigureAwait(false);
-
 						var updatedTestMerges = await remoteDeploymentManager.RemoveMergedTestMerges(
 							repo,
 							repositorySettings,

--- a/src/Tgstation.Server.Host/Components/Repository/Repository.cs
+++ b/src/Tgstation.Server.Host/Components/Repository/Repository.cs
@@ -137,7 +137,8 @@ namespace Tgstation.Server.Host.Components.Repository
 		/// <param name="exception">The current <see cref="LibGit2SharpException"/>.</param>
 		static void CheckBadCredentialsException(LibGit2SharpException exception)
 		{
-			if (exception.Message == "too many redirects or authentication replays")
+			if (exception.Message == "too many redirects or authentication replays"
+				|| exception.Message == ErrorCode.RepoCredentialsRequired.Describe())
 				throw new JobException("Bad git credentials exchange!", exception);
 		}
 

--- a/src/Tgstation.Server.Host/Components/Repository/Repository.cs
+++ b/src/Tgstation.Server.Host/Components/Repository/Repository.cs
@@ -963,8 +963,12 @@ namespace Tgstation.Server.Host.Components.Repository
 					// workaround for https://github.com/libgit2/libgit2/issues/3820
 					// kill off the modules/ folder in .git and try again
 					CheckBadCredentialsException(ex);
-					logger.LogWarning(ex, "Initial update of submodule {0} failed. Deleting .git submodule directory and re-attempting...", submodule.Name);
-					await ioMananger.DeleteDirectory($".git/modules/{submodule.Path}", cancellationToken).ConfigureAwait(false);
+					logger.LogWarning(ex, "Initial update of submodule {0} failed. Deleting submodule directories and re-attempting...", submodule.Name);
+
+					await Task.WhenAll(
+						ioMananger.DeleteDirectory($".git/modules/{submodule.Path}", cancellationToken),
+						ioMananger.DeleteDirectory(submodule.Path, cancellationToken))
+						.ConfigureAwait(false);
 
 					logger.LogTrace("Second update attempt for submodule {0}...", submodule.Name);
 					try

--- a/src/Tgstation.Server.Host/Components/Repository/Repository.cs
+++ b/src/Tgstation.Server.Host/Components/Repository/Repository.cs
@@ -137,9 +137,11 @@ namespace Tgstation.Server.Host.Components.Repository
 		/// <param name="exception">The current <see cref="LibGit2SharpException"/>.</param>
 		static void CheckBadCredentialsException(LibGit2SharpException exception)
 		{
-			if (exception.Message == "too many redirects or authentication replays"
-				|| exception.Message == ErrorCode.RepoCredentialsRequired.Describe())
+			if (exception.Message == "too many redirects or authentication replays")
 				throw new JobException("Bad git credentials exchange!", exception);
+
+			if (exception.Message == ErrorCode.RepoCredentialsRequired.Describe())
+				throw new JobException(ErrorCode.RepoCredentialsRequired);
 		}
 
 		/// <summary>


### PR DESCRIPTION
Fixes #1304 

:cl:
Fixed submodule update errors due to bad credentials not being translated to the correct error code.
Improved submodule update edge case error reset handling.
Fixed bugs relating to updating the DB when a deployment is triggered on an unrecognized commit SHA.
/:cl: