### PR TITLE
Support for describing a job's current stage

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -3,11 +3,11 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>4.14.1</TgsCoreVersion>
+    <TgsCoreVersion>4.15.0</TgsCoreVersion>
     <TgsConfigVersion>4.0.0</TgsConfigVersion>
-    <TgsApiVersion>9.2.0</TgsApiVersion>
-    <TgsApiLibraryVersion>9.2.0</TgsApiLibraryVersion>
-    <TgsClientVersion>10.2.0</TgsClientVersion>
+    <TgsApiVersion>9.3.0</TgsApiVersion>
+    <TgsApiLibraryVersion>9.3.0</TgsApiLibraryVersion>
+    <TgsClientVersion>10.3.0</TgsClientVersion>
     <TgsDmapiVersion>6.0.4</TgsDmapiVersion>
     <TgsInteropVersion>5.3.0</TgsInteropVersion>
     <TgsHostWatchdogVersion>1.1.1</TgsHostWatchdogVersion>

--- a/src/Tgstation.Server.Api/Models/Response/JobResponse.cs
+++ b/src/Tgstation.Server.Api/Models/Response/JobResponse.cs
@@ -21,5 +21,11 @@
 		/// </summary>
 		[ResponseOptions]
 		public int? Progress { get; set; }
+
+		/// <summary>
+		/// Optional description of the job's current .
+		/// </summary>
+		[ResponseOptions]
+		public string? Stage { get; set; }
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
@@ -707,7 +707,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 		/// <returns>A <see cref="Task"/> representing the running operation.</returns>
 		async Task ProgressTask(JobProgressReporter progressReporter, TimeSpan? estimatedDuration, CancellationToken cancellationToken)
 		{
-			progressReporter(currentStage, estimatedDuration.HasValue ? 0 : null);
+			progressReporter(currentStage, estimatedDuration.HasValue ? (int?)0 : null);
 			var sleepInterval = estimatedDuration.HasValue ? estimatedDuration.Value / 100 : TimeSpan.FromMilliseconds(250);
 
 			logger.LogDebug("Compile is expected to take: {0}", estimatedDuration);
@@ -716,7 +716,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 				for (var iteration = 0; iteration < (estimatedDuration.HasValue ? 99 : Int32.MaxValue); ++iteration)
 				{
 					await Task.Delay(sleepInterval, cancellationToken).ConfigureAwait(false);
-					progressReporter(currentStage, estimatedDuration.HasValue ? iteration + 1 : null);
+					progressReporter(currentStage, estimatedDuration.HasValue ? (int?)(iteration + 1) : null);
 				}
 			}
 			catch (OperationCanceledException)

--- a/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
@@ -114,6 +114,11 @@ namespace Tgstation.Server.Host.Components.Deployment
 		string currentDreamMakerOutput;
 
 		/// <summary>
+		/// Current stage to report on the job.
+		/// </summary>
+		string currentStage;
+
+		/// <summary>
 		/// If a compile job is running.
 		/// </summary>
 		bool deploying;
@@ -178,7 +183,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 		public async Task DeploymentProcess(
 			Models.Job job,
 			IDatabaseContextFactory databaseContextFactory,
-			Action<int> progressReporter,
+			JobProgressReporter progressReporter,
 			CancellationToken cancellationToken)
 		{
 			if (job == null)
@@ -450,7 +455,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 		/// <param name="apiValidateTimeout">The API validation timeout.</param>
 		/// <param name="repository">The <see cref="IRepository"/>.</param>
 		/// <param name="remoteDeploymentManager">The <see cref="IRemoteDeploymentManager"/>.</param>
-		/// <param name="progressReporter">The progress reporting <see cref="Action{T}"/>.</param>
+		/// <param name="progressReporter">The <see cref="JobProgressReporter"/> to report progress of the operation.</param>
 		/// <param name="estimatedDuration">The optional estimated <see cref="TimeSpan"/> of the compilation.</param>
 		/// <param name="localCommitExistsOnRemote">Whether or not the <paramref name="repository"/>'s current commit exists on the remote repository.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
@@ -461,7 +466,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 			uint apiValidateTimeout,
 			IRepository repository,
 			IRemoteDeploymentManager remoteDeploymentManager,
-			Action<int> progressReporter,
+			JobProgressReporter progressReporter,
 			TimeSpan? estimatedDuration,
 			bool localCommitExistsOnRemote,
 			CancellationToken cancellationToken)
@@ -469,7 +474,9 @@ namespace Tgstation.Server.Host.Components.Deployment
 			logger.LogTrace("Begin Compile");
 
 			using var progressCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-			var progressTask = estimatedDuration.HasValue ? ProgressTask(progressReporter, estimatedDuration.Value, progressCts.Token) : Task.CompletedTask;
+
+			currentStage = "Reserving BYOND version";
+			var progressTask = ProgressTask(progressReporter, estimatedDuration, progressCts.Token);
 			try
 			{
 				using var byondLock = await byond.UseExecutables(null, cancellationToken).ConfigureAwait(false);
@@ -490,6 +497,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 					RepositoryOrigin = repository.Origin.ToString(),
 				};
 
+				currentStage = "Creating remote deployment notification";
 				await remoteDeploymentManager.StartDeployment(
 					repository,
 					job,
@@ -525,6 +533,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 			catch (OperationCanceledException)
 			{
 				// DCT: Cancellation token is for job, delaying here is fine
+				currentStage = "Running CompileCancelled event";
 				await eventConsumer.HandleEvent(EventType.CompileCancelled, Enumerable.Empty<string>(), default).ConfigureAwait(false);
 				throw;
 			}
@@ -561,7 +570,8 @@ namespace Tgstation.Server.Host.Components.Deployment
 			try
 			{
 				// copy the repository
-				logger.LogTrace("Copying repository to game directory...");
+				logger.LogTrace("Copying repository to game directory");
+				currentStage = "Copying repository";
 				var resolvedOutputDirectory = ioManager.ResolvePath(outputDirectory);
 				var repoOrigin = repository.Origin;
 				using (repository)
@@ -570,6 +580,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 				// repository closed now
 
 				// run precompile scripts
+				currentStage = "Running PreCompile event";
 				await eventConsumer.HandleEvent(
 					EventType.CompileStart,
 					new List<string>
@@ -582,9 +593,10 @@ namespace Tgstation.Server.Host.Components.Deployment
 					.ConfigureAwait(false);
 
 				// determine the dme
+				currentStage = "Determining .dme";
 				if (job.DmeName == null)
 				{
-					logger.LogTrace("Searching for available .dmes...");
+					logger.LogTrace("Searching for available .dmes");
 					var foundPaths = await ioManager.GetFilesWithExtension(resolvedOutputDirectory, DmeExtension, true, cancellationToken).ConfigureAwait(false);
 					var foundPath = foundPaths.FirstOrDefault();
 					if (foundPath == default)
@@ -603,9 +615,11 @@ namespace Tgstation.Server.Host.Components.Deployment
 
 				logger.LogDebug("Selected {0}.dme for compilation!", job.DmeName);
 
+				currentStage = "Modifying .dme";
 				await ModifyDme(job, cancellationToken).ConfigureAwait(false);
 
 				// run precompile scripts
+				currentStage = "Running PreDreamMaker event";
 				await eventConsumer.HandleEvent(
 					EventType.PreDreamMaker,
 					new List<string>
@@ -618,6 +632,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 					.ConfigureAwait(false);
 
 				// run compiler
+				currentStage = "Running DreamMaker";
 				var exitCode = await RunDreamMaker(byondLock.DreamMakerPath, job, cancellationToken).ConfigureAwait(false);
 
 				// verify api
@@ -628,6 +643,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 							ErrorCode.DreamMakerExitCode,
 							new JobException($"Exit code: {exitCode}{Environment.NewLine}{Environment.NewLine}{job.Output}"));
 
+					currentStage = "Validating DMAPI";
 					await VerifyApi(
 						apiValidateTimeout,
 						dreamMakerSettings.ApiValidationSecurityLevel.Value,
@@ -641,6 +657,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 				catch (JobException)
 				{
 					// DD never validated or compile failed
+					currentStage = "Running CompileFailure event";
 					await eventConsumer.HandleEvent(
 						EventType.CompileFailure,
 						new List<string>
@@ -654,6 +671,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 					throw;
 				}
 
+				currentStage = "Running CompileComplete event";
 				await eventConsumer.HandleEvent(
 					EventType.CompileComplete,
 					new List<string>
@@ -665,6 +683,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 					.ConfigureAwait(false);
 
 				logger.LogTrace("Applying static game file symlinks...");
+				currentStage = "Symlinking GameStaticFiles";
 
 				// symlink in the static data
 				await configuration.SymlinkStaticFilesTo(resolvedOutputDirectory, cancellationToken).ConfigureAwait(false);
@@ -673,6 +692,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 			}
 			catch (Exception ex)
 			{
+				currentStage = "Cleaning output directory";
 				await CleanupFailedCompile(job, remoteDeploymentManager, ex).ConfigureAwait(false);
 				throw;
 			}
@@ -681,22 +701,22 @@ namespace Tgstation.Server.Host.Components.Deployment
 		/// <summary>
 		/// Gradually triggers a given <paramref name="progressReporter"/> over a given <paramref name="estimatedDuration"/>.
 		/// </summary>
-		/// <param name="progressReporter">The <see cref="Action{T1}"/> to report progress.</param>
-		/// <param name="estimatedDuration">A <see cref="TimeSpan"/> representing the duration to give progress over.</param>
+		/// <param name="progressReporter">The <see cref="JobProgressReporter"/> to report progress of the operation.</param>
+		/// <param name="estimatedDuration">A <see cref="TimeSpan"/> representing the duration to give progress over if any.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task"/> representing the running operation.</returns>
-		async Task ProgressTask(Action<int> progressReporter, TimeSpan estimatedDuration, CancellationToken cancellationToken)
+		async Task ProgressTask(JobProgressReporter progressReporter, TimeSpan? estimatedDuration, CancellationToken cancellationToken)
 		{
-			progressReporter(0);
-			var sleepInterval = estimatedDuration / 100;
+			progressReporter(currentStage, estimatedDuration.HasValue ? 0 : null);
+			var sleepInterval = estimatedDuration.HasValue ? estimatedDuration.Value / 100 : TimeSpan.FromMilliseconds(250);
 
 			logger.LogDebug("Compile is expected to take: {0}", estimatedDuration);
 			try
 			{
-				for (var iteration = 0; iteration < 99; ++iteration)
+				for (var iteration = 0; iteration < (estimatedDuration.HasValue ? 99 : Int32.MaxValue); ++iteration)
 				{
 					await Task.Delay(sleepInterval, cancellationToken).ConfigureAwait(false);
-					progressReporter(iteration + 1);
+					progressReporter(currentStage, estimatedDuration.HasValue ? iteration + 1 : null);
 				}
 			}
 			catch (OperationCanceledException)

--- a/src/Tgstation.Server.Host/Components/Deployment/IDreamMaker.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/IDreamMaker.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 
 using Tgstation.Server.Host.Database;
+using Tgstation.Server.Host.Jobs;
 using Tgstation.Server.Host.Models;
 
 namespace Tgstation.Server.Host.Components.Deployment
@@ -13,17 +13,17 @@ namespace Tgstation.Server.Host.Components.Deployment
 	public interface IDreamMaker
 	{
 		/// <summary>
-		/// Create and  a compile job and insert it into the database. Meant to be called by a <see cref="Jobs.IJobManager"/>.
+		/// Create and  a compile job and insert it into the database. Meant to be called by a <see cref="IJobManager"/>.
 		/// </summary>
 		/// <param name="job">The running <see cref="Job"/>.</param>
 		/// <param name="databaseContextFactory">The <see cref="IDatabaseContextFactory"/> for the operation.</param>
-		/// <param name="progressReporter">The <see cref="Action{T1}"/> to report compilation progress.</param>
+		/// <param name="progressReporter">The <see cref="JobProgressReporter"/> to report compilation progress.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task"/> representing the running operation.</returns>
 		Task DeploymentProcess(
 			Job job,
 			IDatabaseContextFactory databaseContextFactory,
-			Action<int> progressReporter,
+			JobProgressReporter progressReporter,
 			CancellationToken cancellationToken);
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Instance.cs
+++ b/src/Tgstation.Server.Host/Components/Instance.cs
@@ -256,7 +256,7 @@ namespace Tgstation.Server.Host.Components
 			IInstanceCore core,
 			IDatabaseContextFactory databaseContextFactory,
 			Job job,
-			Action<int> progressReporter,
+			JobProgressReporter progressReporter,
 			CancellationToken cancellationToken)
 			=> databaseContextFactory.UseContext(
 				async databaseContext =>
@@ -277,11 +277,11 @@ namespace Tgstation.Server.Host.Components
 					const int NumSteps = 3;
 					var doneSteps = 0;
 
-					Action<int> NextProgressReporter()
+					JobProgressReporter NextProgressReporter()
 					{
 						var tmpDoneSteps = doneSteps;
 						++doneSteps;
-						return progress => progressReporter((progress + (100 * tmpDoneSteps)) / NumSteps);
+						return (status, progress) => progressReporter(status, (progress + (100 * tmpDoneSteps)) / NumSteps);
 					}
 
 					using var repo = await RepositoryManager.LoadRepository(cancellationToken).ConfigureAwait(false);
@@ -457,7 +457,7 @@ namespace Tgstation.Server.Host.Components
 							throw;
 						}
 
-					progressReporter(5 * ProgressStep);
+					progressReporter(null, 5 * ProgressStep);
 				});
 #pragma warning restore CA1502   // Cyclomatic complexity
 

--- a/src/Tgstation.Server.Host/Components/Repository/IRepository.cs
+++ b/src/Tgstation.Server.Host/Components/Repository/IRepository.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Tgstation.Server.Api.Models;
+using Tgstation.Server.Host.Jobs;
 
 namespace Tgstation.Server.Host.Components.Repository
 {
@@ -46,7 +47,7 @@ namespace Tgstation.Server.Host.Components.Repository
 		/// <param name="username">The username used for fetching from submodule repositories.</param>
 		/// <param name="password">The password used for fetching from submodule repositories.</param>
 		/// <param name="updateSubmodules">If a submodule update should be attempted after the merge.</param>
-		/// <param name="progressReporter"><see cref="Action{T1}"/> to report 0-100 <see cref="int"/> progress of the operation.</param>
+		/// <param name="progressReporter">The <see cref="JobProgressReporter"/> to report progress of the operation.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task"/> representing the running operation.</returns>
 		Task CheckoutObject(
@@ -54,7 +55,7 @@ namespace Tgstation.Server.Host.Components.Repository
 			string username,
 			string password,
 			bool updateSubmodules,
-			Action<int> progressReporter,
+			JobProgressReporter progressReporter,
 			CancellationToken cancellationToken);
 
 		/// <summary>
@@ -66,7 +67,7 @@ namespace Tgstation.Server.Host.Components.Repository
 		/// <param name="username">The username used to fetch from the origin and submodule repositories.</param>
 		/// <param name="password">The password used to fetch from the origin and submodule repositories.</param>
 		/// <param name="updateSubmodules">If a submodule update should be attempted after the merge.</param>
-		/// <param name="progressReporter"><see cref="Action{T1}"/> to report 0-100 <see cref="int"/> progress of the operation.</param>
+		/// <param name="progressReporter">The <see cref="JobProgressReporter"/> to report progress of the operation.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in a <see cref="Nullable{T}"/> <see cref="bool"/> representing the merge result that is <see langword="true"/> after a fast forward or up to date, <see langword="false"/> on a non-fast-forward, <see langword="null"/> on a conflict.</returns>
 		Task<bool?> AddTestMerge(
@@ -76,7 +77,7 @@ namespace Tgstation.Server.Host.Components.Repository
 			string username,
 			string password,
 			bool updateSubmodules,
-			Action<int> progressReporter,
+			JobProgressReporter progressReporter,
 			CancellationToken cancellationToken);
 
 		/// <summary>
@@ -84,10 +85,14 @@ namespace Tgstation.Server.Host.Components.Repository
 		/// </summary>
 		/// <param name="username">The username to fetch from the origin repository.</param>
 		/// <param name="password">The password to fetch from the origin repository.</param>
-		/// <param name="progressReporter"><see cref="Action{T1}"/> to report 0-100 <see cref="int"/> progress of the operation.</param>
+		/// <param name="progressReporter">The <see cref="JobProgressReporter"/> to report progress of the operation.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task"/> representing the running operation.</returns>
-		Task FetchOrigin(string username, string password, Action<int> progressReporter, CancellationToken cancellationToken);
+		Task FetchOrigin(
+			string username,
+			string password,
+			JobProgressReporter progressReporter,
+			CancellationToken cancellationToken);
 
 		/// <summary>
 		/// Requires the current HEAD to be a tracked reference. Hard resets the reference to what it tracks on the origin repository.
@@ -95,34 +100,34 @@ namespace Tgstation.Server.Host.Components.Repository
 		/// <param name="username">The username used for fetching from submodule repositories.</param>
 		/// <param name="password">The password used for fetching from submodule repositories.</param>
 		/// <param name="updateSubmodules">If a submodule update should be attempted after the merge.</param>
-		/// <param name="progressReporter"><see cref="Action{T1}"/> to report 0-100 <see cref="int"/> progress of the operation.</param>
+		/// <param name="progressReporter">The <see cref="JobProgressReporter"/> to report progress of the operation.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the SHA of the new HEAD.</returns>
 		Task ResetToOrigin(
 			string username,
 			string password,
 			bool updateSubmodules,
-			Action<int> progressReporter,
+			JobProgressReporter progressReporter,
 			CancellationToken cancellationToken);
 
 		/// <summary>
 		/// Requires the current HEAD to be a reference. Hard resets the reference to the given sha.
 		/// </summary>
 		/// <param name="sha">The sha hash to reset to.</param>
-		/// <param name="progressReporter"><see cref="Action{T1}"/> to report 0-100 <see cref="int"/> progress of the operation.</param>
+		/// <param name="progressReporter">The <see cref="JobProgressReporter"/> to report progress of the operation.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the SHA of the new HEAD.</returns>
-		Task ResetToSha(string sha, Action<int> progressReporter, CancellationToken cancellationToken);
+		Task ResetToSha(string sha, JobProgressReporter progressReporter, CancellationToken cancellationToken);
 
 		/// <summary>
 		/// Requires the current HEAD to be a tracked reference. Merges the reference to what it tracks on the origin repository.
 		/// </summary>
 		/// <param name="committerName">The name of the merge committer.</param>
 		/// <param name="committerEmail">The e-mail of the merge committer.</param>
-		/// <param name="progressReporter"><see cref="Action{T1}"/> to report 0-100 <see cref="int"/> progress of the operation.</param>
+		/// <param name="progressReporter">The <see cref="JobProgressReporter"/> to report progress of the operation.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in a <see cref="Nullable{T}"/> <see cref="bool"/> representing the merge result that is <see langword="true"/> after a fast forward, <see langword="false"/> on a merge or up to date, <see langword="null"/> on a conflict.</returns>
-		Task<bool?> MergeOrigin(string committerName, string committerEmail, Action<int> progressReporter, CancellationToken cancellationToken);
+		Task<bool?> MergeOrigin(string committerName, string committerEmail, JobProgressReporter progressReporter, CancellationToken cancellationToken);
 
 		/// <summary>
 		/// Runs the synchronize event script and attempts to push any changes made to the <see cref="IRepository"/> if on a tracked branch.
@@ -131,11 +136,18 @@ namespace Tgstation.Server.Host.Components.Repository
 		/// <param name="password">The password to fetch from the origin repository.</param>
 		/// <param name="committerName">The name of the potential committer.</param>
 		/// <param name="committerEmail">The e-mail of the potential committer.</param>
-		/// <param name="progressReporter"><see cref="Action{T1}"/> to report 0-100 <see cref="int"/> progress of the operation.</param>
+		/// <param name="progressReporter">The <see cref="JobProgressReporter"/> to report progress of the operation.</param>
 		/// <param name="synchronizeTrackedBranch">If the synchronizations should be made to the tracked reference as opposed to a temporary branch.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in <see langword="true"/> if commits were pushed to the tracked origin reference, <see langword="false"/> otherwise.</returns>
-		Task<bool> Sychronize(string username, string password, string committerName, string committerEmail, Action<int> progressReporter, bool synchronizeTrackedBranch, CancellationToken cancellationToken);
+		Task<bool> Sychronize(
+			string username,
+			string password,
+			string committerName,
+			string committerEmail,
+			JobProgressReporter progressReporter,
+			bool synchronizeTrackedBranch,
+			CancellationToken cancellationToken);
 
 		/// <summary>
 		/// Copies the current working directory to a given <paramref name="path"/>.

--- a/src/Tgstation.Server.Host/Components/Repository/IRepositoryManager.cs
+++ b/src/Tgstation.Server.Host/Components/Repository/IRepositoryManager.cs
@@ -2,6 +2,8 @@
 using System.Threading;
 using System.Threading.Tasks;
 
+using Tgstation.Server.Host.Jobs;
+
 namespace Tgstation.Server.Host.Components.Repository
 {
 	/// <summary>
@@ -15,7 +17,7 @@ namespace Tgstation.Server.Host.Components.Repository
 		bool InUse { get; }
 
 		/// <summary>
-		/// If a <see cref="CloneRepository(Uri, string, string, string, Action{int}, bool, CancellationToken)"/> operation is in progress.
+		/// If a <see cref="CloneRepository(Uri, string, string, string, JobProgressReporter, bool, CancellationToken)"/> operation is in progress.
 		/// </summary>
 		bool CloneInProgress { get; }
 
@@ -33,7 +35,7 @@ namespace Tgstation.Server.Host.Components.Repository
 		/// <param name="initialBranch">The branch to clone.</param>
 		/// <param name="username">The username to clone from <paramref name="url"/>.</param>
 		/// <param name="password">The password to clone from <paramref name="url"/>.</param>
-		/// <param name="progressReporter">A function to report 0-100 progress of the clone.</param>
+		/// <param name="progressReporter">The <see cref="JobProgressReporter"/> for progress of the clone.</param>
 		/// <param name="recurseSubmodules">If submodules should be recusively cloned and initialized.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>The newly cloned <see cref="IRepository"/>, <see langword="null"/> if one already exists.</returns>
@@ -42,7 +44,7 @@ namespace Tgstation.Server.Host.Components.Repository
 			string initialBranch,
 			string username,
 			string password,
-			Action<int> progressReporter,
+			JobProgressReporter progressReporter,
 			bool recurseSubmodules,
 			CancellationToken cancellationToken);
 

--- a/src/Tgstation.Server.Host/Components/Repository/RepositoryManager.cs
+++ b/src/Tgstation.Server.Host/Components/Repository/RepositoryManager.cs
@@ -104,7 +104,7 @@ namespace Tgstation.Server.Host.Components.Repository
 			string initialBranch,
 			string username,
 			string password,
-			Action<int> progressReporter,
+			JobProgressReporter progressReporter,
 			bool recurseSubmodules,
 			CancellationToken cancellationToken)
 		{
@@ -136,7 +136,7 @@ namespace Tgstation.Server.Host.Components.Repository
 								OnTransferProgress = (a) =>
 								{
 									var percentage = 100 * (((float)a.IndexedObjects + a.ReceivedObjects) / (a.TotalObjects * 2));
-									progressReporter((int)percentage);
+									progressReporter("Cloning", (int)percentage);
 									return !cancellationToken.IsCancellationRequested;
 								},
 								RecurseSubmodules = recurseSubmodules,

--- a/src/Tgstation.Server.Host/Controllers/JobController.cs
+++ b/src/Tgstation.Server.Host/Controllers/JobController.cs
@@ -167,7 +167,7 @@ namespace Tgstation.Server.Host.Controllers
 			if (job == default)
 				return NotFound();
 			var api = job.ToApi();
-			api.Progress = jobManager.JobProgress(job);
+			jobManager.SetJobProgress(api);
 			return Json(api);
 		}
 
@@ -178,7 +178,7 @@ namespace Tgstation.Server.Host.Controllers
 		/// <returns>A <see cref="Task"/> representing the running operation.</returns>
 		private Task AddJobProgressResponseTransformer(JobResponse jobResponse)
 		{
-			jobResponse.Progress = jobManager.JobProgress(jobResponse);
+			jobManager.SetJobProgress(jobResponse);
 			return Task.CompletedTask;
 		}
 	}

--- a/src/Tgstation.Server.Host/Jobs/IJobManager.cs
+++ b/src/Tgstation.Server.Host/Jobs/IJobManager.cs
@@ -2,7 +2,7 @@
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Hosting;
-
+using Tgstation.Server.Api.Models.Response;
 using Tgstation.Server.Host.Models;
 
 namespace Tgstation.Server.Host.Jobs
@@ -13,11 +13,10 @@ namespace Tgstation.Server.Host.Jobs
 	public interface IJobManager : IHostedService
 	{
 		/// <summary>
-		/// Get the <see cref="Api.Models.Response.JobResponse.Progress"/> for a <paramref name="job"/>.
+		/// Set the <see cref="JobResponse.Progress"/> and <see cref="JobResponse.Stage"/> for a given <paramref name="apiResponse"/>.
 		/// </summary>
-		/// <param name="job">The <see cref="Api.Models.Internal.Job"/> to get <see cref="Api.Models.Response.JobResponse.Progress"/> for.</param>
-		/// <returns>The <see cref="Api.Models.Response.JobResponse.Progress"/> of <paramref name="job"/>.</returns>
-		int? JobProgress(Api.Models.Internal.Job job);
+		/// <param name="apiResponse">The <see cref="JobResponse"/> to update.</param>
+		void SetJobProgress(JobResponse apiResponse);
 
 		/// <summary>
 		/// Registers a given <see cref="Job"/> and begins running it.

--- a/src/Tgstation.Server.Host/Jobs/JobEntrypoint.cs
+++ b/src/Tgstation.Server.Host/Jobs/JobEntrypoint.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 
 using Tgstation.Server.Host.Components;
@@ -14,13 +13,13 @@ namespace Tgstation.Server.Host.Jobs
 	/// <param name="instance">The <see cref="IInstanceCore"/> the job is running on. <see langword="null"/> only when performing an instance move operation.</param>
 	/// <param name="databaseContextFactory">The <see cref="IDatabaseContextFactory"/> for the operation.</param>
 	/// <param name="job">The running <see cref="Job"/>.</param>
-	/// <param name="progressReporter">A <see cref="Action{T1}"/> that will update the progress of the job.</param>
+	/// <param name="progressReporter">The <see cref="JobProgressReporter"/> for the job.</param>
 	/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 	/// <returns>A <see cref="Task"/> representing the running operation.</returns>
 	public delegate Task JobEntrypoint(
 		IInstanceCore instance,
 		IDatabaseContextFactory databaseContextFactory,
 		Job job,
-		Action<int> progressReporter,
+		JobProgressReporter progressReporter,
 		CancellationToken cancellationToken);
 }

--- a/src/Tgstation.Server.Host/Jobs/JobHandler.cs
+++ b/src/Tgstation.Server.Host/Jobs/JobHandler.cs
@@ -45,6 +45,11 @@ namespace Tgstation.Server.Host.Jobs
 		public int? Progress { get; set; }
 
 		/// <summary>
+		/// The stage of the job.
+		/// </summary>
+		public string Stage { get; set; }
+
+		/// <summary>
 		/// Wait for <see cref="task"/> to complete.
 		/// </summary>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>

--- a/src/Tgstation.Server.Host/Jobs/JobManager.cs
+++ b/src/Tgstation.Server.Host/Jobs/JobManager.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Serilog.Context;
-
+using Tgstation.Server.Api.Models.Response;
 using Tgstation.Server.Host.Components;
 using Tgstation.Server.Host.Database;
 using Tgstation.Server.Host.Extensions;
@@ -221,15 +221,16 @@ namespace Tgstation.Server.Host.Jobs
 		}
 
 		/// <inheritdoc />
-		public int? JobProgress(Api.Models.Internal.Job job)
+		public void SetJobProgress(JobResponse apiResponse)
 		{
-			if (job == null)
-				throw new ArgumentNullException(nameof(job));
+			if (apiResponse == null)
+				throw new ArgumentNullException(nameof(apiResponse));
 			lock (synchronizationLock)
 			{
-				if (!jobs.TryGetValue(job.Id.Value, out var handler))
-					return null;
-				return handler.Progress;
+				if (!jobs.TryGetValue(apiResponse.Id.Value, out var handler))
+					return;
+				apiResponse.Progress = handler.Progress;
+				apiResponse.Stage = handler.Stage;
 			}
 		}
 
@@ -293,11 +294,18 @@ namespace Tgstation.Server.Host.Jobs
 						var oldJob = job;
 						job = new Job { Id = oldJob.Id };
 
-						void UpdateProgress(int progress)
+						void UpdateProgress(string stage, int? progress)
 						{
+							if (progress.HasValue
+								&& (progress.Value < 0 || progress.Value > 100))
+								throw new ArgumentOutOfRangeException(nameof(progress), "Progress must be a value from 0-100!");
+
 							lock (synchronizationLock)
 								if (jobs.TryGetValue(oldJob.Id.Value, out var handler))
+								{
+									handler.Stage = stage;
 									handler.Progress = progress;
+								}
 						}
 
 						await activationTcs.Task.WithToken(cancellationToken).ConfigureAwait(false);

--- a/src/Tgstation.Server.Host/Jobs/JobProgressReporter.cs
+++ b/src/Tgstation.Server.Host/Jobs/JobProgressReporter.cs
@@ -1,0 +1,13 @@
+﻿using Tgstation.Server.Host.Models;
+
+namespace Tgstation.Server.Host.Jobs
+{
+	/// <summary>
+	/// Progress reporter for a <see cref="Job"/>.
+	/// </summary>
+	/// <param name="stage">A description of what the job is currently doing.</param>
+	/// <param name="progress">The progress of the job on a scale from 0-100.</param>
+	public delegate void JobProgressReporter(
+		string stage,
+		int? progress);
+}

--- a/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
+++ b/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="../../build/Version.props" />
 
   <PropertyGroup>
@@ -26,7 +26,7 @@
     <DockerfileContext>..\..</DockerfileContext>
   </PropertyGroup>
 
-  <Target Name="ClientInstall" Inputs="../../build/ControlPanelVersion.props" Outputs="$(NpmInstallStampFile)">
+  <Target Name="ClientInstall" BeforeTargets="ResolveAssemblyReferences" Inputs="../../build/ControlPanelVersion.props" Outputs="$(NpmInstallStampFile)">
     <Message Text="Pulling web control panel..." Importance="high" />
     <RemoveDir Directories="ClientApp" />
     <Exec Command="git clone https://github.com/tgstation/tgstation-server-webpanel --branch v$(TgsControlPanelVersion) --depth 1 ClientApp" />

--- a/tests/Tgstation.Server.Tests/IntegrationTest.cs
+++ b/tests/Tgstation.Server.Tests/IntegrationTest.cs
@@ -1061,7 +1061,7 @@ namespace Tgstation.Server.Tests
 				() => { });
 
 			const string StartSha = "af4da8beb9f9b374b04a3cc4d65acca662e8cc1a";
-			await repo.CheckoutObject(StartSha, null, null, true, progress => { }, default);
+			await repo.CheckoutObject(StartSha, null, null, true, (stage, progress) => { }, default);
 			var result = await repo.ShaIsParent("2f8588a3ca0f6b027704a2a04381215619de3412", default);
 			Assert.IsTrue(result);
 			Assert.AreEqual(StartSha, repo.Head);


### PR DESCRIPTION
:cl: HTTP API
JobResponses now come with a `stage` field. Like `progress`, this _may_ be set to a description of an individual step within a job if the job is running.
/:cl: