### PR TITLE
v4.14.3 fix batch

### DIFF
--- a/.github/workflows/ci-suite.yml
+++ b/.github/workflows/ci-suite.yml
@@ -789,7 +789,19 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./ServerUpdatePackage.zip
           asset_name: ServerUpdatePackage.zip
-          asset_content_type: application/zip
+          asset_content_type: application/zip- name: Create comment
+
+  deploy-docker:
+    name: Post Comment To Server Update Thread
+    needs: [deploy-tgs]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post Comment
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token: ${{ secrets.DEV_PUSH_TOKEN }}
+          issue-number: 1322
+          body: \[tgstation-server-v${{ env.TGS_VERSION }}](${{ steps.create_release.outputs.html_url }}) released.
 
   deploy-docker:
     name: Deploy TGS (Docker)

--- a/.github/workflows/ci-suite.yml
+++ b/.github/workflows/ci-suite.yml
@@ -789,9 +789,9 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./ServerUpdatePackage.zip
           asset_name: ServerUpdatePackage.zip
-          asset_content_type: application/zip- name: Create comment
+          asset_content_type: application/zip
 
-  deploy-docker:
+  post-deploy-comment:
     name: Post Comment To Server Update Thread
     needs: [deploy-tgs]
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-suite.yml
+++ b/.github/workflows/ci-suite.yml
@@ -791,12 +791,7 @@ jobs:
           asset_name: ServerUpdatePackage.zip
           asset_content_type: application/zip
 
-  post-deploy-comment:
-    name: Post Comment To Server Update Thread
-    needs: [deploy-tgs]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Post Comment
+      - name: Post Comment to Server Update Thread
         uses: peter-evans/create-or-update-comment@v1
         with:
           token: ${{ secrets.DEV_PUSH_TOKEN }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,6 +13,6 @@ Vulnerabilities should ideally be reported by directly messaging one of the main
 
 Here is a list of their discord IDs.
 
-- Cyberboss#8246
+- Cyberboss#0016
 
 Once reported, they will handle the processing of the security advisory.

--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>4.14.2</TgsCoreVersion>
+    <TgsCoreVersion>4.14.3</TgsCoreVersion>
     <TgsConfigVersion>4.0.0</TgsConfigVersion>
     <TgsApiVersion>9.2.0</TgsApiVersion>
     <TgsApiLibraryVersion>9.2.0</TgsApiLibraryVersion>

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordProvider.cs
@@ -374,9 +374,8 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 			var fields = BuildUpdateEmbedFields(revisionInformation, byondVersion, gitHubOwner, gitHubRepo, localCommitPushed);
 			var embed = new Embed
 			{
-				Author = new EmbedAuthor
+				Author = new EmbedAuthor(assemblyInformationProvider.VersionPrefix)
 				{
-					Name = assemblyInformationProvider.VersionPrefix,
 					Url = "https://github.com/tgstation/tgstation-server",
 					IconUrl = "https://avatars0.githubusercontent.com/u/1363778?s=280&v=4",
 				},

--- a/src/Tgstation.Server.Host/Components/Events/EventConsumer.cs
+++ b/src/Tgstation.Server.Host/Components/Events/EventConsumer.cs
@@ -39,8 +39,9 @@ namespace Tgstation.Server.Host.Components.Events
 			if (watchdog == null)
 				throw new InvalidOperationException("EventConsumer used without watchdog set!");
 
-			await configuration.HandleEvent(eventType, parameters, cancellationToken).ConfigureAwait(false);
+			var scriptTask = configuration.HandleEvent(eventType, parameters, cancellationToken);
 			await watchdog.HandleEvent(eventType, parameters, cancellationToken).ConfigureAwait(false);
+			await scriptTask.ConfigureAwait(false);
 		}
 
 		/// <summary>

--- a/src/Tgstation.Server.Host/Components/StaticFiles/Configuration.cs
+++ b/src/Tgstation.Server.Host/Components/StaticFiles/Configuration.cs
@@ -631,7 +631,11 @@ namespace Tgstation.Server.Host.Components.StaticFiles
 					await ioManager.WriteAllBytes(staticIgnorePath, Array.Empty<byte>(), cancellationToken).ConfigureAwait(false);
 			}
 
-			await Task.WhenAll(ioManager.CreateDirectory(CodeModificationsSubdirectory, cancellationToken), ioManager.CreateDirectory(EventScriptsSubdirectory, cancellationToken), ValidateStaticFolder()).ConfigureAwait(false);
+			await Task.WhenAll(
+				ioManager.CreateDirectory(CodeModificationsSubdirectory, cancellationToken),
+				ioManager.CreateDirectory(EventScriptsSubdirectory, cancellationToken),
+				ValidateStaticFolder())
+				.ConfigureAwait(false);
 		}
 
 		/// <summary>

--- a/src/Tgstation.Server.Host/Components/Watchdog/BasicWatchdog.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/BasicWatchdog.cs
@@ -111,7 +111,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 					var eventType = Server.TerminationWasRequested
 						? EventType.WorldEndProcess
 						: EventType.WatchdogCrash;
-					await EventConsumer.HandleEvent(eventType, Enumerable.Empty<string>(), cancellationToken).ConfigureAwait(false);
+					await HandleNonRelayedEvent(eventType, Enumerable.Empty<string>(), cancellationToken).ConfigureAwait(false);
 
 					var exitWord = Server.TerminationWasRequested ? "exited" : "crashed";
 					if (Server.RebootState == Session.RebootState.Shutdown)
@@ -146,7 +146,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 					gracefulRebootRequired = false;
 					Server.ResetRebootState();
 
-					await EventConsumer.HandleEvent(EventType.WorldReboot, Enumerable.Empty<string>(), cancellationToken).ConfigureAwait(false);
+					await HandleNonRelayedEvent(EventType.WorldReboot, Enumerable.Empty<string>(), cancellationToken).ConfigureAwait(false);
 
 					switch (rebootState)
 					{
@@ -173,7 +173,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 					await HandleNewDmbAvailable(cancellationToken).ConfigureAwait(false);
 					break;
 				case MonitorActivationReason.ActiveServerPrimed:
-					await EventConsumer.HandleEvent(EventType.WorldPrime, Enumerable.Empty<string>(), cancellationToken).ConfigureAwait(false);
+					await HandleNonRelayedEvent(EventType.WorldPrime, Enumerable.Empty<string>(), cancellationToken).ConfigureAwait(false);
 					break;
 				case MonitorActivationReason.Heartbeat:
 				default:

--- a/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
@@ -91,11 +91,6 @@ namespace Tgstation.Server.Host.Components.Watchdog
 		protected IAsyncDelayer AsyncDelayer { get; }
 
 		/// <summary>
-		/// The <see cref="IEventConsumer"/> that is not the <see cref="WatchdogBase"/>.
-		/// </summary>
-		protected IEventConsumer EventConsumer { get; }
-
-		/// <summary>
 		/// The <see cref="Api.Models.Instance"/> for the <see cref="WatchdogBase"/>.
 		/// </summary>
 		readonly Api.Models.Instance metadata;
@@ -109,6 +104,11 @@ namespace Tgstation.Server.Host.Components.Watchdog
 		/// <see cref="SemaphoreSlim"/> used for <see cref="DisposeAndNullControllers"/>.
 		/// </summary>
 		readonly SemaphoreSlim controllerDisposeSemaphore;
+
+		/// <summary>
+		/// The <see cref="IEventConsumer"/> that is not the <see cref="WatchdogBase"/>.
+		/// </summary>
+		readonly IEventConsumer eventConsumer;
 
 		/// <summary>
 		/// The <see cref="IJobManager"/> for the <see cref="WatchdogBase"/>.
@@ -205,7 +205,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 			this.jobManager = jobManager ?? throw new ArgumentNullException(nameof(jobManager));
 			AsyncDelayer = asyncDelayer ?? throw new ArgumentNullException(nameof(asyncDelayer));
 			this.diagnosticsIOManager = diagnosticsIOManager ?? throw new ArgumentNullException(nameof(diagnosticsIOManager));
-			EventConsumer = eventConsumer ?? throw new ArgumentNullException(nameof(eventConsumer));
+			this.eventConsumer = eventConsumer ?? throw new ArgumentNullException(nameof(eventConsumer));
 			this.remoteDeploymentManagerFactory = remoteDeploymentManagerFactory ?? throw new ArgumentNullException(nameof(remoteDeploymentManagerFactory));
 			Logger = logger ?? throw new ArgumentNullException(nameof(logger));
 			ActiveLaunchParameters = initialLaunchParameters ?? throw new ArgumentNullException(nameof(initialLaunchParameters));
@@ -505,7 +505,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 					cancellationToken); // simple announce
 				if (reattachInfo == null)
 					announceTask = Task.WhenAll(
-						EventConsumer.HandleEvent(EventType.WatchdogLaunch, Enumerable.Empty<string>(), cancellationToken),
+						HandleNonRelayedEvent(EventType.WatchdogLaunch, Enumerable.Empty<string>(), cancellationToken),
 						announceTask);
 			}
 			else
@@ -674,6 +674,25 @@ namespace Tgstation.Server.Host.Components.Watchdog
 				metadata,
 				newCompileJob);
 			return remoteDeploymentManager.ApplyDeployment(newCompileJob, ActiveCompileJob, cancellationToken);
+		}
+
+		/// <summary>
+		/// Handle a given <paramref name="eventType"/> without re-throwing errors.
+		/// </summary>
+		/// <param name="eventType">The <see cref="EventType"/>.</param>
+		/// <param name="parameters">An <see cref="IEnumerable{T}"/> of <see cref="string"/> parameters for <paramref name="eventType"/>.</param>
+		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
+		/// <returns>A <see cref="Task"/> representing the running operation.</returns>
+		protected async Task HandleNonRelayedEvent(EventType eventType, IEnumerable<string> parameters, CancellationToken cancellationToken)
+		{
+			try
+			{
+				await eventConsumer.HandleEvent(eventType, parameters, cancellationToken);
+			}
+			catch (JobException ex)
+			{
+				Logger.LogError(ex, "Suppressing exception triggered by event!");
+			}
 		}
 
 		/// <summary>
@@ -954,7 +973,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 				return;
 			if (!graceful)
 			{
-				var eventTask = EventConsumer.HandleEvent(
+				var eventTask = HandleNonRelayedEvent(
 					releaseServers
 						? EventType.WatchdogDetach
 						: EventType.WatchdogShutdown,

--- a/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
+++ b/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="../../build/Version.props" />
 
   <PropertyGroup>
@@ -87,7 +87,7 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.11" />
     <PackageReference Include="Octokit" Version="0.50.0" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="3.2.6" />
-    <PackageReference Include="Remora.Discord" Version="3.0.54" />
+    <PackageReference Include="Remora.Discord" Version="3.0.58" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />

--- a/tests/Tgstation.Server.Host.Tests/Components/Chat/Providers/TestDiscordProvider.cs
+++ b/tests/Tgstation.Server.Host.Tests/Components/Chat/Providers/TestDiscordProvider.cs
@@ -61,8 +61,6 @@ namespace Tgstation.Server.Host.Components.Chat.Providers.Tests
 		[TestMethod]
 		public async Task TestConnectWithFakeTokenFails()
 		{
-			Assert.Inconclusive("Doesn't happen, see https://github.com/Nihlus/Remora.Discord/issues/99 for resolution");
-
 			var mockLogger = new Mock<ILogger<DiscordProvider>>();
 			await using var provider = new DiscordProvider(mockJobManager, Mock.Of<IAssemblyInformationProvider>(), mockLogger.Object, new ChatBot
 			{


### PR DESCRIPTION
:cl:
Invalid Discord tokens will now fail the chat bot re-connection job.
Event scripts and DMAPI events now trigger in parallel.
Fixed certain scripts exiting with a non-zero exit code crashing the watchdog monitor.
/:cl: