### PR TITLE
Fix a null reference exception when test merging

### DIFF
--- a/src/Tgstation.Server.Host/Components/Repository/Repository.cs
+++ b/src/Tgstation.Server.Host/Components/Repository/Repository.cs
@@ -287,7 +287,12 @@ namespace Tgstation.Server.Host.Components.Repository
 
 						cancellationToken.ThrowIfCancellationRequested();
 
-						testMergeParameters.TargetCommitSha = libGitRepo.Lookup(testMergeParameters.TargetCommitSha ?? localBranchName).Sha;
+						var objectName = testMergeParameters.TargetCommitSha ?? localBranchName;
+						var gitObject = libGitRepo.Lookup(objectName);
+						if (gitObject == null)
+							throw new JobException($"Could not find object to merge: {objectName}");
+
+						testMergeParameters.TargetCommitSha = gitObject.Sha;
 
 						cancellationToken.ThrowIfCancellationRequested();
 


### PR DESCRIPTION
:cl:
Converted a possible NullReferenceException while test merging to a proper job error.
/:cl: