### PR TITLE
Roll LibGit2Sharp back to 0.27.0-preview-0034

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>4.15.6</TgsCoreVersion>
+    <TgsCoreVersion>4.15.7</TgsCoreVersion>
     <TgsConfigVersion>4.0.0</TgsConfigVersion>
     <TgsApiVersion>9.3.0</TgsApiVersion>
     <TgsApiLibraryVersion>9.3.1</TgsApiLibraryVersion>

--- a/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
+++ b/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="../../build/Version.props" />
 
   <PropertyGroup>
@@ -68,7 +68,7 @@
     <PackageReference Include="Cyberboss.SmartIrc4net.Standard" Version="0.4.6" />
     <PackageReference Include="Elastic.CommonSchema.Serilog" Version="1.5.3" />
     <PackageReference Include="GitLabApiClient" Version="1.8.0" />
-    <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0119" />
+    <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0034" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.18" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.18" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">


### PR DESCRIPTION
Ideally this will fix a certain repository clone failure. Going forwards certainly didn't fix goon's issue with test merges.

:cl:
Rolled back libgit2 version to mitigate an issue that prevents repositories from being cloned on some systems.
/:cl: