### PR TITLE
Fix RepositoryRights.SetSha and SetReference being able to be bypassed. Fix repo tracking error

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>4.16.0</TgsCoreVersion>
+    <TgsCoreVersion>4.16.1</TgsCoreVersion>
     <TgsConfigVersion>4.1.0</TgsConfigVersion>
     <TgsApiVersion>9.3.0</TgsApiVersion>
     <TgsApiLibraryVersion>9.3.1</TgsApiLibraryVersion>

--- a/src/Tgstation.Server.Host/Components/Repository/Repository.cs
+++ b/src/Tgstation.Server.Host/Components/Repository/Repository.cs
@@ -830,15 +830,18 @@ namespace Tgstation.Server.Host.Components.Repository
 			{
 				// Maybe (likely) a remote?
 				var remoteName = $"origin/{committish}";
-				var potentialBranch = libGitRepo.Branches.FirstOrDefault(
+				var remoteBranch = libGitRepo.Branches.FirstOrDefault(
 					branch => branch.FriendlyName.Equals(remoteName, StringComparison.Ordinal));
 				cancellationToken.ThrowIfCancellationRequested();
 
-				if (potentialBranch == default)
+				if (remoteBranch == default)
 					throw;
 
-				logger.LogDebug("Creating local branch for {0}...", potentialBranch.FriendlyName);
-				libGitRepo.CreateBranch(committish, potentialBranch.Tip);
+				logger.LogDebug("Creating local branch for {0}...", remoteBranch.FriendlyName);
+				var branch = libGitRepo.CreateBranch(committish, remoteBranch.Tip);
+
+				libGitRepo.Branches.Update(branch, branchUpdate => branchUpdate.TrackedBranch = remoteBranch.CanonicalName);
+
 				cancellationToken.ThrowIfCancellationRequested();
 
 				RunCheckout();

--- a/src/Tgstation.Server.Host/Controllers/RepositoryController.cs
+++ b/src/Tgstation.Server.Host/Controllers/RepositoryController.cs
@@ -371,7 +371,9 @@ namespace Tgstation.Server.Host.Controllers
 				|| CheckModified(x => x.ShowTestMergeCommitters, RepositoryRights.ChangeTestMergeCommits)
 				|| CheckModified(x => x.PostTestMergeComment, RepositoryRights.ChangeTestMergeCommits)
 				|| CheckModified(x => x.UpdateSubmodules, RepositoryRights.ChangeSubmoduleUpdate)
-				|| (model.UpdateFromOrigin == true && !userRights.HasFlag(RepositoryRights.UpdateBranch)))
+				|| (model.UpdateFromOrigin == true && !userRights.HasFlag(RepositoryRights.UpdateBranch))
+				|| (model.CheckoutSha != null && !userRights.HasFlag(RepositoryRights.SetSha))
+				|| (model.Reference != null && model.UpdateFromOrigin != true && !userRights.HasFlag(RepositoryRights.SetReference))) // don't care if it's the same reference, we want to forbid them before starting the job
 				return Forbid();
 
 			if (model.AccessToken?.Length == 0 && model.AccessUser?.Length == 0)


### PR DESCRIPTION
:cl:
Fixed being able to bypass the checkout repository permissions with other repository permissions.
Fixed checking out a remote branch not setting tracking details correctly.
/:cl:

Fixes #1355