### PR TITLE
Make the DMAPI didn't validate error more descriptive

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -3,10 +3,10 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>4.16.1</TgsCoreVersion>
+    <TgsCoreVersion>4.16.2</TgsCoreVersion>
     <TgsConfigVersion>4.1.0</TgsConfigVersion>
-    <TgsApiVersion>9.3.0</TgsApiVersion>
-    <TgsApiLibraryVersion>9.3.1</TgsApiLibraryVersion>
+    <TgsApiVersion>9.3.1</TgsApiVersion>
+    <TgsApiLibraryVersion>9.3.2</TgsApiLibraryVersion>
     <TgsClientVersion>10.4.1</TgsClientVersion>
     <TgsDmapiVersion>6.0.4</TgsDmapiVersion>
     <TgsInteropVersion>5.3.0</TgsInteropVersion>

--- a/src/Tgstation.Server.Api/Models/ErrorCode.cs
+++ b/src/Tgstation.Server.Api/Models/ErrorCode.cs
@@ -327,7 +327,7 @@ namespace Tgstation.Server.Api.Models
 		/// <summary>
 		/// The DMAPI never validated itself
 		/// </summary>
-		[Description("DreamDaemon did not validate the DMAPI!")]
+		[Description("DreamDaemon did not validate the DMAPI! This can occur if your world is encountering runtime errors during startup.")]
 		DreamMakerNeverValidated,
 
 		/// <summary>

--- a/tests/Tgstation.Server.Tests/Instance/ByondTest.cs
+++ b/tests/Tgstation.Server.Tests/Instance/ByondTest.cs
@@ -1,4 +1,4 @@
-using Castle.Core.Logging;
+﻿using Castle.Core.Logging;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -60,7 +60,7 @@ namespace Tgstation.Server.Tests.Instance
 			};
 			var test = await byondClient.SetActiveVersion(newModel, null, cancellationToken).ConfigureAwait(false);
 			Assert.IsNotNull(test.InstallJob);
-			await WaitForJob(test.InstallJob, 120, false, null, cancellationToken).ConfigureAwait(false);
+			await WaitForJob(test.InstallJob, 180, false, null, cancellationToken).ConfigureAwait(false);
 			var currentShit = await byondClient.ActiveVersion(cancellationToken).ConfigureAwait(false);
 			Assert.AreEqual(newModel.Version.Semver(), currentShit.Version);
 

--- a/tests/Tgstation.Server.Tests/UsersTest.cs
+++ b/tests/Tgstation.Server.Tests/UsersTest.cs
@@ -1,4 +1,4 @@
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -193,6 +193,17 @@ namespace Tgstation.Server.Tests
 			Assert.AreEqual(1, group.Users.Count);
 			Assert.AreEqual(testUser2.Id, group.Users.First().Id);
 			Assert.IsNotNull(group.PermissionSet);
+
+			testUserUpdate.Group = null;
+			testUserUpdate.PermissionSet = new PermissionSet
+			{
+				AdministrationRights = RightsHelper.AllRights<AdministrationRights>(),
+				InstanceManagerRights = RightsHelper.AllRights<InstanceManagerRights>(),
+			};
+
+			testUser2 = await serverClient.Users.Update(testUserUpdate, cancellationToken);
+			Assert.IsNull(testUser2.Group);
+			Assert.IsNotNull(testUser2.PermissionSet);
 		}
 
 		async Task TestCreateSysUser(CancellationToken cancellationToken)


### PR DESCRIPTION
Closes #1354

:cl: HTTP API
Improved the description of the DMAPI deployment error to suggest other probable causes.
Cloning with credentials now requires the ability to change credentials.
Committer details set on clone now save as expected.
/:cl: