### PR TITLE
Fix git log reading for tgsv3

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -8,7 +8,7 @@
     <TgsApiVersion>9.3.1</TgsApiVersion>
     <TgsApiLibraryVersion>9.3.2</TgsApiLibraryVersion>
     <TgsClientVersion>10.4.1</TgsClientVersion>
-    <TgsDmapiVersion>6.0.4</TgsDmapiVersion>
+    <TgsDmapiVersion>6.0.5</TgsDmapiVersion>
     <TgsInteropVersion>5.3.0</TgsInteropVersion>
     <TgsHostWatchdogVersion>1.1.1</TgsHostWatchdogVersion>
     <TgsContainerScriptVersion>1.2.0</TgsContainerScriptVersion>

--- a/src/DMAPI/tgs.dm
+++ b/src/DMAPI/tgs.dm
@@ -1,6 +1,6 @@
 // tgstation-server DMAPI
 
-#define TGS_DMAPI_VERSION "6.0.4"
+#define TGS_DMAPI_VERSION "6.0.5"
 
 // All functions and datums outside this document are subject to change with any version and should not be relied on.
 

--- a/src/DMAPI/tgs/v3210/api.dm
+++ b/src/DMAPI/tgs/v3210/api.dm
@@ -70,7 +70,7 @@
 			commit = logs[2]
 		else
 			TGS_ERROR_LOG("Error parsing commit logs")
-	
+
 	logs = TGS_FILE2LIST(".git/logs/refs/remotes/origin/master")
 	if(logs.len)
 		logs = splittext(logs[logs.len], " ")

--- a/src/DMAPI/tgs/v3210/api.dm
+++ b/src/DMAPI/tgs/v3210/api.dm
@@ -66,11 +66,19 @@
 
 	var/list/logs = file2list(".git/logs/HEAD")
 	if(logs.len)
-		logs = splittext(logs[logs.len - 1], " ")
-		commit = logs[2]
+		logs = splittext(logs[logs.len], " ")
+		if (logs.len >= 2)
+			commit = logs[2]
+		else
+			TGS_ERROR_LOG("Error parsing commit logs")
+	
 	logs = file2list(".git/logs/refs/remotes/origin/master")
 	if(logs.len)
-		originmastercommit = splittext(logs[logs.len - 1], " ")[2]
+		logs = splittext(logs[logs.len], " ")
+		if (logs.len >= 2)
+			originmastercommit = logs[2]
+		else
+			TGS_ERROR_LOG("Error parsing origin commmit logs")
 
 	if(world.system_type != MS_WINDOWS)
 		TGS_ERROR_LOG("This API version is only supported on Windows. Not running on Windows. Aborting initialization!")

--- a/src/DMAPI/tgs/v3210/api.dm
+++ b/src/DMAPI/tgs/v3210/api.dm
@@ -28,6 +28,8 @@
 
 #define SERVICE_RETURN_SUCCESS "SUCCESS"
 
+#define TGS_FILE2LIST(filename) (splittext(trim_left(trim_right(file2text(filename))), "\n"))
+
 /datum/tgs_api/v3210
 	var/reboot_mode = REBOOT_MODE_NORMAL
 	var/comms_key
@@ -53,9 +55,6 @@
 			return copytext(text, 1, i + 1)
 	return ""
 
-/datum/tgs_api/v3210/proc/file2list(filename)
-	return splittext(trim_left(trim_right(file2text(filename))), "\n")
-
 /datum/tgs_api/v3210/OnWorldNew(minimum_required_security_level)
 	. = FALSE
 
@@ -64,7 +63,7 @@
 	if(!instance_name)
 		instance_name = "TG Station Server" //maybe just upgraded
 
-	var/list/logs = file2list(".git/logs/HEAD")
+	var/list/logs = TGS_FILE2LIST(".git/logs/HEAD")
 	if(logs.len)
 		logs = splittext(logs[logs.len], " ")
 		if (logs.len >= 2)
@@ -72,7 +71,7 @@
 		else
 			TGS_ERROR_LOG("Error parsing commit logs")
 	
-	logs = file2list(".git/logs/refs/remotes/origin/master")
+	logs = TGS_FILE2LIST(".git/logs/refs/remotes/origin/master")
 	if(logs.len)
 		logs = splittext(logs[logs.len], " ")
 		if (logs.len >= 2)
@@ -234,3 +233,5 @@
 #undef SERVICE_REQUEST_API_VERSION
 
 #undef SERVICE_RETURN_SUCCESS
+
+#undef TGS_FILE2LIST

--- a/src/Tgstation.Server.Host/Components/Byond/ByondManager.cs
+++ b/src/Tgstation.Server.Host/Components/Byond/ByondManager.cs
@@ -305,7 +305,7 @@ namespace Tgstation.Server.Host.Components.Byond
 			else if (version.Build > 0)
 				throw new JobException(ErrorCode.ByondNonExistentCustomVersion);
 			else
-				logger.LogDebug("Requested BYOND version {0} not currently installed. Doing so now...");
+				logger.LogDebug("Requested BYOND version {0} not currently installed. Doing so now...", versionKey);
 
 			// okay up to us to install it then
 			try

--- a/src/Tgstation.Server.Host/Components/InstanceManager.cs
+++ b/src/Tgstation.Server.Host/Components/InstanceManager.cs
@@ -252,7 +252,8 @@ namespace Tgstation.Server.Host.Components
 				{
 					logger.LogCritical(
 						innerEx,
-						"Error reverting database after failing to move instance {0}! Attempting to detach...");
+						"Error reverting database after failing to move instance {0}! Attempting to detach...",
+						instance.Id);
 
 					try
 					{
@@ -421,7 +422,7 @@ namespace Tgstation.Server.Host.Components
 						}
 						catch (Exception ex)
 						{
-							logger.LogError(ex, "Failed to online instance {0}!");
+							logger.LogError(ex, "Failed to online instance {0}!", metadata.Id);
 						}
 					});
 

--- a/src/Tgstation.Server.Host/Core/Application.cs
+++ b/src/Tgstation.Server.Host/Core/Application.cs
@@ -395,13 +395,6 @@ namespace Tgstation.Server.Host.Core
 			logger.LogDebug("Content Root: {0}", hostingEnvironment.ContentRootPath);
 			logger.LogTrace("Web Root: {0}", hostingEnvironment.WebRootPath);
 
-			if (generalConfiguration.MinimumPasswordLength > Limits.MaximumStringLength)
-			{
-				logger.LogCritical("Configured minimum password length ({0}) is greater than the maximum database string length ({1})!");
-				serverControl.Die(new InvalidOperationException("Minimum password length greater than database limit!"));
-				return;
-			}
-
 			// attempt to restart the server if the configuration changes
 			if (serverControl.WatchdogPresent)
 				ChangeToken.OnChange(Configuration.GetReloadToken, () =>

--- a/src/Tgstation.Server.Host/Security/IdentityCache.cs
+++ b/src/Tgstation.Server.Host/Security/IdentityCache.cs
@@ -72,7 +72,7 @@ namespace Tgstation.Server.Host.Security
 					asyncDelayer,
 					() =>
 					{
-						logger.LogDebug("Expiring system identity cache for user {1}", uid, user.Id);
+						logger.LogDebug("Expiring system identity cache for user {0}", user.Id);
 						lock (cachedIdentities)
 							cachedIdentities.Remove(user.Id.Value);
 					},


### PR DESCRIPTION
`file2list` already trims the trailing blank line, skipping the last line like this was unnecessary and run timing on fresh reclones

:cl: DMAPI
Fix git commit log parsing for api version v3210
/:cl:

