### PR TITLE
JobException InnerException Logging

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>4.17.0</TgsCoreVersion>
+    <TgsCoreVersion>4.17.1</TgsCoreVersion>
     <TgsConfigVersion>4.1.0</TgsConfigVersion>
     <TgsApiVersion>9.4.0</TgsApiVersion>
     <TgsApiLibraryVersion>9.4.0</TgsApiLibraryVersion>

--- a/src/Tgstation.Server.Host/Jobs/JobManager.cs
+++ b/src/Tgstation.Server.Host/Jobs/JobManager.cs
@@ -334,7 +334,7 @@ namespace Tgstation.Server.Host.Jobs
 					catch (JobException e)
 					{
 						job.ErrorCode = e.ErrorCode;
-						job.ExceptionDetails = String.IsNullOrWhiteSpace(e.Message) ? e.InnerException?.Message : e.Message;
+						job.ExceptionDetails = String.IsNullOrWhiteSpace(e.Message) ? e.InnerException?.Message : e.Message + $" (Inner exception: {e.InnerException?.Message}";
 						LogException(e);
 					}
 					catch (Exception e)

--- a/tests/Tgstation.Server.Host.Tests/Jobs/TestJobException.cs
+++ b/tests/Tgstation.Server.Host.Tests/Jobs/TestJobException.cs
@@ -11,7 +11,7 @@ namespace Tgstation.Server.Host.Jobs.Tests
 		{
 			new JobException();
 			new JobException("Message");
-			new JobException("Message", new Exception());
+			new JobException("Message", new Exception("Inner Message"));
 		}
 	}
 }


### PR DESCRIPTION

[Base Branch]: # (Please set the base branch of your pull request appropriately. If you only made a patch, code improvement, non-server code change, or comment/documentation update please target the `master` branch. Otherwise, target the `dev` branch.)

[Release Notes]: # (Your PR should contain a detailed list of notable changes, titled appropriately. This includes any observable changes to the server or DMAPI. See examples below.)

Made this PR because I realised that testmerge conflicts DO actually say which PRs are conflicting, but only in the inner exception. Was originally going to just cram the PR confliction information into the main Exception, but was told to do otherwise. I can change it back if needed. Adjusts test to include an inner exception message since I thought it might be good to have, please tell me if this isn't useful and I'll remove it.

Did not test this, because it's such a minor change and setting up a dev environment seems highly time-consuming (I *will* do it if needed just don't want to have to if I don't need to), so I'm hoping that the unit tests catch everything.

:cl:
Logs JobExceptions' InnerException's message, allowing for better diagnosing of issues.
/:cl:

[Why]: # (If this does not close or work on an existing GitHub issue, please add a short description [two lines down] of why you think these changes would benefit the server. If you can't justify it in words, it might not be worth adding.)
