### PR TITLE
Job inner exception logging - Stealing Mark's PR

### DIFF
--- a/src/Tgstation.Server.Host/Jobs/JobManager.cs
+++ b/src/Tgstation.Server.Host/Jobs/JobManager.cs
@@ -334,7 +334,7 @@ namespace Tgstation.Server.Host.Jobs
 					catch (JobException e)
 					{
 						job.ErrorCode = e.ErrorCode;
-						job.ExceptionDetails = String.IsNullOrWhiteSpace(e.Message) ? e.InnerException?.Message : e.Message;
+						job.ExceptionDetails = String.IsNullOrWhiteSpace(e.Message) ? e.InnerException?.Message : e.Message + $" (Inner exception: {e.InnerException?.Message}";
 						LogException(e);
 					}
 					catch (Exception e)

--- a/src/Tgstation.Server.Host/Jobs/JobManager.cs
+++ b/src/Tgstation.Server.Host/Jobs/JobManager.cs
@@ -334,7 +334,7 @@ namespace Tgstation.Server.Host.Jobs
 					catch (JobException e)
 					{
 						job.ErrorCode = e.ErrorCode;
-						job.ExceptionDetails = String.IsNullOrWhiteSpace(e.Message) ? e.InnerException?.Message : e.Message + $" (Inner exception: {e.InnerException?.Message}";
+						job.ExceptionDetails = String.IsNullOrWhiteSpace(e.Message) ? e.InnerException?.Message : e.Message + $" (Inner exception: {e.InnerException?.Message})";
 						LogException(e);
 					}
 					catch (Exception e)

--- a/tests/Tgstation.Server.Host.Tests/Jobs/TestJobException.cs
+++ b/tests/Tgstation.Server.Host.Tests/Jobs/TestJobException.cs
@@ -11,7 +11,7 @@ namespace Tgstation.Server.Host.Jobs.Tests
 		{
 			new JobException();
 			new JobException("Message");
-			new JobException("Message", new Exception());
+			new JobException("Message", new Exception("Inner Message"));
 		}
 	}
 }


### PR DESCRIPTION
Steals #1364 

:cl:
Jobs now publish inner exceptions. This will be useful for diagnosing TM fails.
/:cl:

