### PR TITLE
Invision Community OAuth Support

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -4,8 +4,8 @@
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
     <TgsCoreVersion>4.17.0</TgsCoreVersion>
-    <TgsConfigVersion>4.1.0</TgsConfigVersion>
-    <TgsApiVersion>9.4.0</TgsApiVersion>
+    <TgsConfigVersion>4.2.0</TgsConfigVersion>
+    <TgsApiVersion>9.5.0</TgsApiVersion>
     <TgsApiLibraryVersion>9.4.0</TgsApiLibraryVersion>
     <TgsClientVersion>10.5.0</TgsClientVersion>
     <TgsDmapiVersion>6.0.5</TgsDmapiVersion>

--- a/src/Tgstation.Server.Api/Models/OAuthProvider.cs
+++ b/src/Tgstation.Server.Api/Models/OAuthProvider.cs
@@ -28,5 +28,10 @@ namespace Tgstation.Server.Api.Models
 		/// https://www.keycloak.org
 		/// </summary>
 		Keycloak,
+
+		/// <summary>
+		/// https://invisioncommunity.com/
+		/// </summary>
+		InvisionCommunity,
 	}
 }

--- a/src/Tgstation.Server.Host/Security/OAuth/InvisionCommunityOAuthValidator.cs
+++ b/src/Tgstation.Server.Host/Security/OAuth/InvisionCommunityOAuthValidator.cs
@@ -10,7 +10,7 @@ using Tgstation.Server.Host.System;
 namespace Tgstation.Server.Host.Security.OAuth
 {
 	/// <summary>
-	/// OAuth validator for Discord.
+	/// OAuth validator for Invision Community (selfhosted).
 	/// </summary>
 	sealed class InvisionCommunityOAuthValidator : GenericOAuthValidator
 		{
@@ -18,15 +18,10 @@ namespace Tgstation.Server.Host.Security.OAuth
 		public override OAuthProvider Provider => OAuthProvider.InvisionCommunity;
 
 		/// <inheritdoc />
-		protected override Uri TokenUrl => new Uri($"{BaseProtocolPath}/oauth/token/");
+		protected override Uri TokenUrl => new Uri($"{OAuthConfiguration.ServerUrl}/oauth/token/"); // This needs the trailing slash or it doesnt get the token. Do not remove.
 
 		/// <inheritdoc />
-		protected override Uri UserInformationUrl => new Uri($"{BaseProtocolPath}/api/core/me");
-
-		/// <summary>
-		/// Base path to the server's OAuth endpoint.
-		/// </summary>
-		string BaseProtocolPath => $"{OAuthConfiguration.ServerUrl}";
+		protected override Uri UserInformationUrl => new Uri($"{OAuthConfiguration.ServerUrl}/api/core/me");
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="InvisionCommunityOAuthValidator"/> class.

--- a/src/Tgstation.Server.Host/Security/OAuth/InvisionCommunityOAuthValidator.cs
+++ b/src/Tgstation.Server.Host/Security/OAuth/InvisionCommunityOAuthValidator.cs
@@ -40,7 +40,8 @@ namespace Tgstation.Server.Host.Security.OAuth
 			IAssemblyInformationProvider assemblyInformationProvider,
 			ILogger<InvisionCommunityOAuthValidator> logger,
 			OAuthConfiguration oAuthConfiguration)
-			: base(httpClientFactory, assemblyInformationProvider, logger, oAuthConfiguration) {
+			: base(httpClientFactory, assemblyInformationProvider, logger, oAuthConfiguration)
+		{
 		}
 
 		/// <inheritdoc />

--- a/src/Tgstation.Server.Host/Security/OAuth/InvisionCommunityOAuthValidator.cs
+++ b/src/Tgstation.Server.Host/Security/OAuth/InvisionCommunityOAuthValidator.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Net.Http;
+
+using Microsoft.Extensions.Logging;
+
+using Tgstation.Server.Api.Models;
+using Tgstation.Server.Host.Configuration;
+using Tgstation.Server.Host.System;
+
+namespace Tgstation.Server.Host.Security.OAuth
+{
+	/// <summary>
+	/// OAuth validator for Discord.
+	/// </summary>
+	sealed class InvisionCommunityOAuthValidator : GenericOAuthValidator
+		{
+		/// <inheritdoc />
+		public override OAuthProvider Provider => OAuthProvider.InvisionCommunity;
+
+		/// <inheritdoc />
+		protected override Uri TokenUrl => new Uri($"{BaseProtocolPath}/oauth/token/");
+
+		/// <inheritdoc />
+		protected override Uri UserInformationUrl => new Uri($"{BaseProtocolPath}/api/core/me");
+
+		/// <summary>
+		/// Base path to the server's OAuth endpoint.
+		/// </summary>
+		string BaseProtocolPath => $"{OAuthConfiguration.ServerUrl}";
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="InvisionCommunityOAuthValidator"/> class.
+		/// </summary>
+		/// <param name="httpClientFactory">The <see cref="IHttpClientFactory"/> for the <see cref="GenericOAuthValidator"/>.</param>
+		/// <param name="assemblyInformationProvider">The <see cref="IAssemblyInformationProvider"/> for the <see cref="GenericOAuthValidator"/>.</param>
+		/// <param name="logger">The <see cref="ILogger"/> for the <see cref="GenericOAuthValidator"/>.</param>
+		/// <param name="oAuthConfiguration">The <see cref="OAuthConfiguration"/> for the <see cref="GenericOAuthValidator"/>.</param>
+		public InvisionCommunityOAuthValidator(
+			IHttpClientFactory httpClientFactory,
+			IAssemblyInformationProvider assemblyInformationProvider,
+			ILogger<InvisionCommunityOAuthValidator> logger,
+			OAuthConfiguration oAuthConfiguration)
+			: base(httpClientFactory, assemblyInformationProvider, logger, oAuthConfiguration) {
+		}
+
+		/// <inheritdoc />
+		protected override OAuthTokenRequest CreateTokenRequest(string code) => new OAuthTokenRequest(OAuthConfiguration, code, "profile");
+
+		/// <inheritdoc />
+		protected override string DecodeTokenPayload(dynamic responseJson) => responseJson.access_token;
+
+		/// <inheritdoc />
+		protected override string DecodeUserInformationPayload(dynamic responseJson) => responseJson.id;
+	}
+}

--- a/src/Tgstation.Server.Host/Security/OAuth/OAuthProviders.cs
+++ b/src/Tgstation.Server.Host/Security/OAuth/OAuthProviders.cs
@@ -79,6 +79,14 @@ namespace Tgstation.Server.Host.Security.OAuth
 						assemblyInformationProvider,
 						loggerFactory.CreateLogger<KeycloakOAuthValidator>(),
 						keyCloakConfig));
+
+			if (securityConfiguration.OAuth.TryGetValue(OAuthProvider.InvisionCommunity, out var invisionConfig))
+				validatorsBuilder.Add(
+					new InvisionCommunityOAuthValidator(
+						httpClientFactory,
+						assemblyInformationProvider,
+						loggerFactory.CreateLogger<InvisionCommunityOAuthValidator>(),
+						invisionConfig));
 		}
 
 		/// <inheritdoc />


### PR DESCRIPTION
:cl: Core
Adds Invision Community as an OAuth Provider.
/:cl:

:cl: HTTP API
InvisionCommunity has been added to the OAuthProviders enum.
/:cl:

:cl: Configuration
**The new configuration version is 4.2.0**.
InvisonCommunity can now be configured as an OAuth provider. Takes ClientId, ClientSecret, RedirectUrl and ServerUrl as strings.
/:cl:

TODO:
- [x] Test code
- [x] Handle appropriate API version bumps
- [ ] Update webpanel after this is merged (https://github.com/tgstation/tgstation-server-webpanel/pull/99)

