### PR TITLE
Add -verbose argument to Dream Daemon by default

### DIFF
--- a/src/Tgstation.Server.Host/Components/Session/SessionControllerFactory.cs
+++ b/src/Tgstation.Server.Host/Components/Session/SessionControllerFactory.cs
@@ -282,7 +282,7 @@ namespace Tgstation.Server.Host.Components.Session
 					Guid? logFileGuid = null;
 					var arguments = String.Format(
 						CultureInfo.InvariantCulture,
-						"{0} -port {1} -ports 1-65535 {2}-close -logself -{3} -{4}{5} -params \"{6}\"",
+						"{0} -port {1} -ports 1-65535 {2}-close -verbose -logself -{3} -{4}{5} -params \"{6}\"",
 						dmbProvider.DmbName,
 						launchParameters.Port.Value,
 						launchParameters.AllowWebClient.Value ? "-webclient " : String.Empty,


### PR DESCRIPTION
:cl:
Adds -verbose argument to Dream Daemon by default.
/:cl:

[Why]: # (If this does not close or work on an existing GitHub issue, please add a short description [two lines down] of why you think these changes would benefit the server. If you can't justify it in words, it might not be worth adding.)

TGS3 automatically provided the -verbose argument to DD; TGS4 doesn't, limiting the number of runtimes that can be viewed. The -params option only lets you pass params to world.params or whatever, which means adding -verbose there does nothing.

This follows the same logic as #1301, where instead of adding a custom params arg, -logself was added to the default. Also, feature parity with v3 is good, generally.