### PR TITLE
Fix repository rights not being counted

### DIFF
--- a/src/Tgstation.Server.Host/Controllers/InstanceController.cs
+++ b/src/Tgstation.Server.Host/Controllers/InstanceController.cs
@@ -607,7 +607,8 @@ namespace Tgstation.Server.Host.Controllers
 				await DatabaseContext.Save(cancellationToken);
 
 			if (cantList && !instance.InstancePermissionSets.Any(instanceUser => instanceUser.PermissionSetId == AuthenticationContext.PermissionSet.Id.Value &&
-				(instanceUser.ByondRights != ByondRights.None ||
+				(instanceUser.RepositoryRights != RepositoryRights.None ||
+				instanceUser.ByondRights != ByondRights.None ||
 				instanceUser.ChatBotRights != ChatBotRights.None ||
 				instanceUser.ConfigurationRights != ConfigurationRights.None ||
 				instanceUser.DreamDaemonRights != DreamDaemonRights.None ||


### PR DESCRIPTION
:cl: HTTP API
Fixed not being able to access an instance's metadata if you had only repository rights for that instance.
/:cl:

Credit @AffectedArc07 for helping me find this one