### PR TITLE
Remove another tgstation-server 4 reference

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>5.0.3</TgsCoreVersion>
+    <TgsCoreVersion>5.0.4</TgsCoreVersion>
     <TgsConfigVersion>4.2.0</TgsConfigVersion>
     <TgsApiVersion>9.6.0</TgsApiVersion>
     <TgsApiLibraryVersion>9.6.1</TgsApiLibraryVersion>

--- a/src/Tgstation.Server.Host/Setup/SetupWizard.cs
+++ b/src/Tgstation.Server.Host/Setup/SetupWizard.cs
@@ -975,7 +975,7 @@ namespace Tgstation.Server.Host.Setup
 		async Task RunWizard(string userConfigFileName, CancellationToken cancellationToken)
 		{
 			// welcome message
-			await console.WriteAsync("Welcome to tgstation-server 4!", true, cancellationToken);
+			await console.WriteAsync("Welcome to tgstation-server!", true, cancellationToken);
 			await console.WriteAsync("This wizard will help you configure your server.", true, cancellationToken);
 
 			var hostingPort = await PromptForHostingPort(cancellationToken);


### PR DESCRIPTION
:cl:
The setup wizard no longer refers to version 4 of the server.
/:cl: