### PR TITLE
Add a way to skip the BYOND firewall exemption step with config

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -3,8 +3,8 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>5.0.4</TgsCoreVersion>
-    <TgsConfigVersion>4.2.0</TgsConfigVersion>
+    <TgsCoreVersion>5.0.5</TgsCoreVersion>
+    <TgsConfigVersion>4.3.0</TgsConfigVersion>
     <TgsApiVersion>9.6.0</TgsApiVersion>
     <TgsApiLibraryVersion>9.6.1</TgsApiLibraryVersion>
     <TgsClientVersion>10.7.1</TgsClientVersion>

--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>5.0.5</TgsCoreVersion>
+    <TgsCoreVersion>5.0.4</TgsCoreVersion>
     <TgsConfigVersion>4.3.0</TgsConfigVersion>
     <TgsApiVersion>9.6.0</TgsApiVersion>
     <TgsApiLibraryVersion>9.6.1</TgsApiLibraryVersion>

--- a/src/Tgstation.Server.Host/Components/Repository/Repository.cs
+++ b/src/Tgstation.Server.Host/Components/Repository/Repository.cs
@@ -196,7 +196,7 @@ namespace Tgstation.Server.Host.Components.Repository
 
 			var commitMessage = String.Format(
 				CultureInfo.InvariantCulture,
-				"TGS Test merge #{0}{1}{2}",
+				"TGS Test Merge (#{0}){1}{2}",
 				testMergeParameters.Number,
 				testMergeParameters.Comment != null
 					? Environment.NewLine

--- a/src/Tgstation.Server.Host/Configuration/GeneralConfiguration.cs
+++ b/src/Tgstation.Server.Host/Configuration/GeneralConfiguration.cs
@@ -112,6 +112,11 @@ namespace Tgstation.Server.Host.Configuration
 		public bool HostApiDocumentation { get; set; }
 
 		/// <summary>
+		/// If the netsh.exe execution to exempt DreamDaemon from Windows firewall should be skipped.
+		/// </summary>
+		public bool SkipAddingByondFirewallException { get; set; }
+
+		/// <summary>
 		/// Initializes a new instance of the <see cref="GeneralConfiguration"/> class.
 		/// </summary>
 		public GeneralConfiguration()
@@ -133,7 +138,7 @@ namespace Tgstation.Server.Host.Configuration
 
 			if (ConfigVersion == null)
 				logger.LogCritical(
-					"No `ConfigVersion` specified, your configuration may be out of date! The current version is \"{0}\"",
+					"No `ConfigVersion` specified, your configuration may be out of date! The current version is \"{currentVersion}\"",
 					CurrentConfigVersion);
 			else if (ConfigVersion != CurrentConfigVersion)
 				if (ConfigVersion.Major != CurrentConfigVersion.Major)

--- a/src/Tgstation.Server.Host/appsettings.yml
+++ b/src/Tgstation.Server.Host/appsettings.yml
@@ -11,6 +11,7 @@ General:
   InstanceLimit: 10
   ValidInstancePaths:
   HostApiDocumentation: false
+  SkipAddingByondFirewallException: false
 Session:
   HighPriorityLiveDreamDaemon: false
   LowPriorityDeploymentProcesses: true

--- a/tests/Tgstation.Server.Tests/Instance/ByondTest.cs
+++ b/tests/Tgstation.Server.Tests/Instance/ByondTest.cs
@@ -1,5 +1,6 @@
 ﻿using Castle.Core.Logging;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
@@ -13,6 +14,7 @@ using Tgstation.Server.Api.Models.Request;
 using Tgstation.Server.Client;
 using Tgstation.Server.Client.Components;
 using Tgstation.Server.Host.Components.Byond;
+using Tgstation.Server.Host.Configuration;
 using Tgstation.Server.Host.IO;
 using Tgstation.Server.Host.System;
 
@@ -87,10 +89,14 @@ namespace Tgstation.Server.Tests.Instance
 
 		async Task TestCustomInstalls(CancellationToken cancellationToken)
 		{
+			var generalConfigOptionsMock = new Mock<IOptions<GeneralConfiguration>>();
+			generalConfigOptionsMock.SetupGet(x => x.Value).Returns(new GeneralConfiguration());
+
 			var byondInstaller = new PlatformIdentifier().IsWindows
 				? (IByondInstaller)new WindowsByondInstaller(
 					Mock.Of<IProcessExecutor>(),
 					new DefaultIOManager(new AssemblyInformationProvider()),
+					generalConfigOptionsMock.Object,
 					Mock.Of<ILogger<WindowsByondInstaller>>())
 				: new PosixByondInstaller(
 					Mock.Of<IPostWriteHandler>(),


### PR DESCRIPTION
:cl: **Configuration**
**The new Configuration version is 4.3.0**
Added `General:SkipAddingByondFirewallException` to skip adding firewall exceptions for new BYOND installs.
/:cl: