### PR TITLE
Various fixes (5.1.1)

### DIFF
--- a/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
@@ -257,6 +257,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 							.Select(x => new Models.RepositorySettings
 							{
 								AccessToken = x.AccessToken,
+								AccessUser = x.AccessUser,
 								ShowTestMergeCommitters = x.ShowTestMergeCommitters,
 								PushTestMergeCommits = x.PushTestMergeCommits,
 								PostTestMergeComment = x.PostTestMergeComment,
@@ -513,7 +514,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 					cancellationToken)
 					;
 
-				logger.LogTrace("Deployment will timeout at {0}", DateTimeOffset.Now + dreamMakerSettings.Timeout.Value);
+				logger.LogTrace("Deployment will timeout at {timeoutTime}", DateTimeOffset.UtcNow + dreamMakerSettings.Timeout.Value);
 				using var timeoutTokenSource = new CancellationTokenSource(dreamMakerSettings.Timeout.Value);
 				var timeoutToken = timeoutTokenSource.Token;
 				using (timeoutToken.Register(() => logger.LogWarning("Deployment timed out!")))

--- a/src/Tgstation.Server.Host/Components/Repository/IGitRemoteAdditionalInformation.cs
+++ b/src/Tgstation.Server.Host/Components/Repository/IGitRemoteAdditionalInformation.cs
@@ -18,6 +18,7 @@ namespace Tgstation.Server.Host.Components.Repository
 		/// <param name="repositorySettings">The <see cref="RepositorySettings"/>.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="Models.TestMerge"/> of the <paramref name="parameters"/>.</returns>
+		/// <remarks><see cref="TestMergeApiBase.MergedAt"/> and <see cref="Models.TestMerge.MergedBy"/> will be unset.</remarks>
 		Task<Models.TestMerge> GetTestMerge(
 			TestMergeParameters parameters,
 			RepositorySettings repositorySettings,

--- a/src/Tgstation.Server.Host/Controllers/RepositoryController.cs
+++ b/src/Tgstation.Server.Host/Controllers/RepositoryController.cs
@@ -538,6 +538,7 @@ namespace Tgstation.Server.Host.Controllers
 								}
 
 								testMergeToAdd.MergedBy = mergedBy;
+								testMergeToAdd.MergedAt = DateTimeOffset.UtcNow;
 
 								foreach (var activeTestMerge in previousRevInfo.ActiveTestMerges)
 									lastRevisionInfo.ActiveTestMerges.Add(activeTestMerge);
@@ -839,7 +840,6 @@ namespace Tgstation.Server.Host.Controllers
 									{
 										Author = ex.Message,
 										BodyAtMerge = ex.Message,
-										MergedAt = DateTimeOffset.UtcNow,
 										TitleAtMerge = ex.Message,
 										Comment = newTestMerge.Comment,
 										Number = newTestMerge.Number,

--- a/src/Tgstation.Server.Host/Controllers/UserController.cs
+++ b/src/Tgstation.Server.Host/Controllers/UserController.cs
@@ -221,6 +221,9 @@ namespace Tgstation.Server.Host.Controllers
 
 			if (model.Password != null)
 			{
+				if (model.SystemIdentifier != null)
+					return BadRequest(new ErrorMessageResponse(ErrorCode.UserMismatchPasswordSid));
+
 				var result = TrySetPassword(originalUser, model.Password, false);
 				if (result != null)
 					return result;


### PR DESCRIPTION
:cl:
Fixed Discord deployment embeds not linking the local commit if it existed on remote.
Fixed the `mergedAt` field of all TestMerges being invalid.
Fixed system users being able to lock themselves out by setting a password.
/:cl: