### PR TITLE
Add option to disable branding on deployment embed

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -5,9 +5,9 @@
   <PropertyGroup>
     <TgsCoreVersion>5.2.0</TgsCoreVersion>
     <TgsConfigVersion>4.4.0</TgsConfigVersion>
-    <TgsApiVersion>9.6.0</TgsApiVersion>
-    <TgsApiLibraryVersion>10.0.0</TgsApiLibraryVersion>
-    <TgsClientVersion>11.0.0</TgsClientVersion>
+    <TgsApiVersion>9.7.0</TgsApiVersion>
+    <TgsApiLibraryVersion>10.1.0</TgsApiLibraryVersion>
+    <TgsClientVersion>11.1.0</TgsClientVersion>
     <TgsDmapiVersion>6.0.5</TgsDmapiVersion>
     <TgsInteropVersion>5.3.0</TgsInteropVersion>
     <TgsHostWatchdogVersion>1.2.0</TgsHostWatchdogVersion>

--- a/src/Tgstation.Server.Api/Models/DiscordConnectionStringBuilder.cs
+++ b/src/Tgstation.Server.Api/Models/DiscordConnectionStringBuilder.cs
@@ -25,6 +25,11 @@ namespace Tgstation.Server.Api.Models
 		public bool BasedMeme { get; set; }
 
 		/// <summary>
+		/// If the tgstation-server logo is shown in deployment embeds.
+		/// </summary>
+		public bool DeploymentBranding { get; set; }
+
+		/// <summary>
 		/// The <see cref="DiscordDMOutputDisplayType"/>.
 		/// </summary>
 		public DiscordDMOutputDisplayType DMOutputDisplay { get; set; }
@@ -47,21 +52,25 @@ namespace Tgstation.Server.Api.Models
 				throw new ArgumentNullException(nameof(connectionString));
 
 			var splits = connectionString.Split(';');
+
 			BotToken = splits.First();
+
 			if (splits.Length < 2 || !Enum.TryParse<DiscordDMOutputDisplayType>(splits[1], out var dMOutputDisplayType))
 				dMOutputDisplayType = DiscordDMOutputDisplayType.Always;
 			DMOutputDisplay = dMOutputDisplayType;
+
 			if (splits.Length > 2 && Int32.TryParse(splits[2], out Int32 basedMeme))
-			{
 				BasedMeme = Convert.ToBoolean(basedMeme);
-			}
 			else
-			{
 				BasedMeme = true; // oranges said this needs to be true by default :pensive:
-			}
+
+			if (splits.Length > 3 && Int32.TryParse(splits[3], out Int32 branding))
+				DeploymentBranding = Convert.ToBoolean(branding);
+			else
+				DeploymentBranding = true; // previous default behaviour
 		}
 
 		/// <inheritdoc />
-		public override string ToString() => $"{BotToken};{(int)DMOutputDisplay};{Convert.ToInt32(BasedMeme)}";
+		public override string ToString() => $"{BotToken};{(int)DMOutputDisplay};{Convert.ToInt32(BasedMeme)};{Convert.ToInt32(DeploymentBranding)}";
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordProvider.cs
@@ -71,6 +71,11 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		readonly bool basedMeme;
 
 		/// <summary>
+		/// If the tgstation-server logo is shown in deployment embeds.
+		/// </summary>
+		readonly bool deploymentBranding;
+
+		/// <summary>
 		/// The <see cref="DiscordDMOutputDisplayType"/>.
 		/// </summary>
 		readonly DiscordDMOutputDisplayType outputDisplayType;
@@ -177,6 +182,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 			var botToken = csb.BotToken;
 			basedMeme = csb.BasedMeme;
 			outputDisplayType = csb.DMOutputDisplay;
+			deploymentBranding = csb.DeploymentBranding;
 
 			serviceProvider = new ServiceCollection()
 				.AddDiscordGateway(serviceProvider => botToken)
@@ -282,13 +288,14 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 			localCommitPushed |= revisionInformation.CommitSha == revisionInformation.OriginCommitSha;
 
 			var fields = BuildUpdateEmbedFields(revisionInformation, byondVersion, gitHubOwner, gitHubRepo, localCommitPushed);
+			var author = new EmbedAuthor(assemblyInformationProvider.VersionPrefix)
+			{
+				Url = "https://github.com/tgstation/tgstation-server",
+				IconUrl = "https://avatars0.githubusercontent.com/u/1363778?s=280&v=4",
+			};
 			var embed = new Embed
 			{
-				Author = new EmbedAuthor(assemblyInformationProvider.VersionPrefix)
-				{
-					Url = "https://github.com/tgstation/tgstation-server",
-					IconUrl = "https://avatars0.githubusercontent.com/u/1363778?s=280&v=4",
-				},
+				Author = deploymentBranding ? author : default,
 				Colour = Color.FromArgb(0xF1, 0xC4, 0x0F),
 				Description = "TGS has begun deploying active repository code to production.",
 				Fields = fields,


### PR DESCRIPTION
Closes #1332

:cl: HTTP API
Added an additional flag to the end of Discord connection strings to allow disabling the tgstation-server branding in deployment embeds.
/:cl:
