### PR TITLE
Service installer will now ask to remove old ones

### DIFF
--- a/src/Tgstation.Server.Host.Service/Program.cs
+++ b/src/Tgstation.Server.Host.Service/Program.cs
@@ -120,27 +120,29 @@ namespace Tgstation.Server.Host.Service
 						return; // oh no, it's retarded...
 
 					// First check if the service already exists
-					foreach (ServiceController sc in ServiceController.GetServices())
+					if (Environment.UserInteractive)
 					{
-						if (sc.ServiceName == "tgstation-server" || sc.ServiceName == "tgstation-server-4")
+						foreach (ServiceController sc in ServiceController.GetServices())
 						{
-							DialogResult result = MessageBox.Show($"You already have another TGS service installed ({sc.ServiceName}). Would you like to uninstall it now? Pressing \"No\" will cancel this install.", "TGS Service", MessageBoxButtons.YesNo);
-							if (result != DialogResult.Yes)
+							if (sc.ServiceName == "tgstation-server" || sc.ServiceName == "tgstation-server-4")
 							{
-								Environment.Exit(1);
-								return; // is this needed after exit?
-							}
+								DialogResult result = MessageBox.Show($"You already have another TGS service installed ({sc.ServiceName}). Would you like to uninstall it now? Pressing \"No\" will cancel this install.", "TGS Service", MessageBoxButtons.YesNo);
+								if (result != DialogResult.Yes)
+								{
+									return; // is this needed after exit?
+								}
 
-							// Stop it first to give it some cleanup time
-							if (sc.Status == ServiceControllerStatus.Running)
-								sc.Stop();
+								// Stop it first to give it some cleanup time
+								if (sc.Status == ServiceControllerStatus.Running)
+									sc.Stop();
 
-							// And remove it
-							using (ServiceInstaller si = new ServiceInstaller())
-							{
-								si.Context = new InstallContext($"old-{sc.ServiceName}-uninstall.log", null);
-								si.ServiceName = ServerService.Name;
-								si.Uninstall(null);
+								// And remove it
+								using (ServiceInstaller si = new ServiceInstaller())
+								{
+									si.Context = new InstallContext($"old-{sc.ServiceName}-uninstall.log", null);
+									si.ServiceName = ServerService.Name;
+									si.Uninstall(null);
+								}
 							}
 						}
 					}

--- a/src/Tgstation.Server.Host.Service/Program.cs
+++ b/src/Tgstation.Server.Host.Service/Program.cs
@@ -139,7 +139,7 @@ namespace Tgstation.Server.Host.Service
 								using (ServiceInstaller si = new ServiceInstaller())
 								{
 									si.Context = new InstallContext($"old-{sc.ServiceName}-uninstall.log", null);
-									si.ServiceName = ServerService.Name;
+									si.ServiceName = sc.ServiceName;
 									si.Uninstall(null);
 								}
 							}

--- a/src/Tgstation.Server.Host.Service/Program.cs
+++ b/src/Tgstation.Server.Host.Service/Program.cs
@@ -121,20 +121,19 @@ namespace Tgstation.Server.Host.Service
 
 					// First check if the service already exists
 					if (Environment.UserInteractive)
-					{
 						foreach (ServiceController sc in ServiceController.GetServices())
-						{
 							if (sc.ServiceName == "tgstation-server" || sc.ServiceName == "tgstation-server-4")
 							{
 								DialogResult result = MessageBox.Show($"You already have another TGS service installed ({sc.ServiceName}). Would you like to uninstall it now? Pressing \"No\" will cancel this install.", "TGS Service", MessageBoxButtons.YesNo);
 								if (result != DialogResult.Yes)
-								{
 									return; // is this needed after exit?
-								}
 
 								// Stop it first to give it some cleanup time
 								if (sc.Status == ServiceControllerStatus.Running)
+								{
 									sc.Stop();
+									sc.WaitForStatus(ServiceControllerStatus.Stopped);
+								}
 
 								// And remove it
 								using (ServiceInstaller si = new ServiceInstaller())
@@ -144,8 +143,6 @@ namespace Tgstation.Server.Host.Service
 									si.Uninstall(null);
 								}
 							}
-						}
-					}
 
 					using (var processInstaller = new ServiceProcessInstaller())
 					using (var installer = new ServiceInstaller())

--- a/src/Tgstation.Server.Host.Service/Program.cs
+++ b/src/Tgstation.Server.Host.Service/Program.cs
@@ -136,7 +136,8 @@ namespace Tgstation.Server.Host.Service
 								sc.Stop();
 
 							// And remove it
-							using (ServiceInstaller si = new ServiceInstaller()) {
+							using (ServiceInstaller si = new ServiceInstaller())
+							{
 								si.Context = new InstallContext($"old-{sc.ServiceName}-uninstall.log", null);
 								si.ServiceName = ServerService.Name;
 								si.Uninstall(null);


### PR DESCRIPTION
:cl: Host Watchdog
The service installer will now offer to uninstall an existing/old service if one exists.
/:cl:

Basically when migrating from V4 --> V5, I ran into this issue and had to use powershell bodging to remove the old service. This is a much more appropriate means of doing so. 