### PR TITLE
Discord fixes (5.2.2)

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>5.2.1</TgsCoreVersion>
+    <TgsCoreVersion>5.2.2</TgsCoreVersion>
     <TgsConfigVersion>4.4.0</TgsConfigVersion>
     <TgsApiVersion>9.7.0</TgsApiVersion>
     <TgsApiLibraryVersion>10.1.0</TgsApiLibraryVersion>

--- a/src/Tgstation.Server.Host/Components/Chat/ChatManager.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/ChatManager.cs
@@ -211,14 +211,14 @@ namespace Tgstation.Server.Host.Components.Chat
 							.ToList();
 				}
 
-				var newMappings = Enumerable.Zip(newChannels, results, (x, y) => new ChannelMapping
+				var newMappings = results.Select(tuple => new ChannelMapping
 				{
-					IsWatchdogChannel = x.IsWatchdogChannel == true,
-					IsUpdatesChannel = x.IsUpdatesChannel == true,
-					IsAdminChannel = x.IsAdminChannel == true,
-					ProviderChannelId = y.RealId,
+					IsWatchdogChannel = tuple.Item1.IsWatchdogChannel == true,
+					IsUpdatesChannel = tuple.Item1.IsUpdatesChannel == true,
+					IsAdminChannel = tuple.Item1.IsAdminChannel == true,
+					ProviderChannelId = tuple.Item2.RealId,
 					ProviderId = connectionId,
-					Channel = y,
+					Channel = tuple.Item2,
 				});
 
 				ulong baseId;

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordProvider.cs
@@ -623,7 +623,8 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 						return null;
 					}
 
-					if (discordChannelResponse.Entity.Type != ChannelType.GuildText)
+					var channelType = discordChannelResponse.Entity.Type;
+					if (channelType != ChannelType.GuildText && channelType != ChannelType.GuildAnnouncement)
 					{
 						Logger.LogWarning("Cound not map channel {0}! Incorrect type: {1}", channelId, discordChannelResponse.Entity.Type);
 						return null;

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordProvider.cs
@@ -592,14 +592,14 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		}
 
 		/// <inheritdoc />
-		protected override async Task<IReadOnlyCollection<ChannelRepresentation>> MapChannelsImpl(IEnumerable<Api.Models.ChatChannel> channels, CancellationToken cancellationToken)
+		protected override async Task<IReadOnlyCollection<Tuple<Api.Models.ChatChannel, ChannelRepresentation>>> MapChannelsImpl(IEnumerable<Api.Models.ChatChannel> channels, CancellationToken cancellationToken)
 		{
 			if (channels == null)
 				throw new ArgumentNullException(nameof(channels));
 
 			bool remapRequired = false;
 
-			async Task<ChannelRepresentation> GetModelChannelFromDBChannel(Api.Models.ChatChannel channelFromDB)
+			async Task<Tuple<Api.Models.ChatChannel, ChannelRepresentation>> GetModelChannelFromDBChannel(Api.Models.ChatChannel channelFromDB)
 			{
 				if (!channelFromDB.DiscordChannelId.HasValue)
 					throw new InvalidOperationException("ChatChannel missing DiscordChannelId!");
@@ -661,7 +661,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 				};
 
 				Logger.LogTrace("Mapped channel {0}: {1}", channelModel.RealId, channelModel.FriendlyName);
-				return channelModel;
+				return Tuple.Create(channelFromDB, channelModel);
 			}
 
 			var tasks = channels
@@ -678,7 +678,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 			lock (mappedChannels)
 			{
 				mappedChannels.Clear();
-				mappedChannels.AddRange(enumerator.Select(x => x.RealId));
+				mappedChannels.AddRange(enumerator.Select(x => x.Item2.RealId));
 			}
 
 			if (remapRequired)

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/IProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/IProvider.cs
@@ -57,8 +57,8 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		/// </summary>
 		/// <param name="channels">The <see cref="Api.Models.ChatChannel"/>s to map.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
-		/// <returns>A <see cref="Task{TResult}"/> resulting in a <see cref="IReadOnlyCollection{T}"/> of the <see cref="ChannelRepresentation"/>s representing <paramref name="channels"/>.</returns>
-		Task<IReadOnlyCollection<ChannelRepresentation>> MapChannels(IEnumerable<Api.Models.ChatChannel> channels, CancellationToken cancellationToken);
+		/// <returns>A <see cref="Task{TResult}"/> resulting in a <see cref="IReadOnlyCollection{T}"/> of the <see cref="Api.Models.ChatChannel"/>'s <see cref="ChannelRepresentation"/>s representing <paramref name="channels"/>.</returns>
+		Task<IReadOnlyCollection<Tuple<Api.Models.ChatChannel, ChannelRepresentation>>> MapChannels(IEnumerable<Api.Models.ChatChannel> channels, CancellationToken cancellationToken);
 
 		/// <summary>
 		/// Send a message to the <see cref="IProvider"/>.

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/IrcProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/IrcProvider.cs
@@ -252,7 +252,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		}
 
 		/// <inheritdoc />
-		protected override Task<IReadOnlyCollection<ChannelRepresentation>> MapChannelsImpl(
+		protected override Task<IReadOnlyCollection<Tuple<ChatChannel, ChannelRepresentation>>> MapChannelsImpl(
 			IEnumerable<ChatChannel> channels,
 			CancellationToken cancellationToken)
 			=> Task.Factory.StartNew(
@@ -285,10 +285,10 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 							else
 								client.RfcJoin(channelToJoin);
 
-						return (IReadOnlyCollection<ChannelRepresentation>)channels
-							.Select(x =>
+						return (IReadOnlyCollection<Tuple<ChatChannel, ChannelRepresentation>>)channels
+							.Select(apiChannel =>
 							{
-								var channelName = x.GetIrcChannelName();
+								var channelName = apiChannel.GetIrcChannelName();
 								ulong? id = null;
 								if (!channelIdMap.Any(y =>
 								{
@@ -302,15 +302,17 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 									channelIdMap.Add(id.Value, channelName);
 								}
 
-								return new ChannelRepresentation
-								{
-									RealId = id.Value,
-									IsAdminChannel = x.IsAdminChannel == true,
-									ConnectionName = address,
-									FriendlyName = channelIdMap[id.Value],
-									IsPrivateChannel = false,
-									Tag = x.Tag,
-								};
+								return Tuple.Create(
+									apiChannel,
+									new ChannelRepresentation
+									{
+										RealId = id.Value,
+										IsAdminChannel = apiChannel.IsAdminChannel == true,
+										ConnectionName = address,
+										FriendlyName = channelIdMap[id.Value],
+										IsPrivateChannel = false,
+										Tag = apiChannel.Tag,
+									});
 							})
 							.ToList();
 					}

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/Provider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/Provider.cs
@@ -117,7 +117,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		public void InitialMappingComplete() => initialConnectionTcs.TrySetResult(null);
 
 		/// <inheritdoc />
-		public async Task<IReadOnlyCollection<ChannelRepresentation>> MapChannels(IEnumerable<Api.Models.ChatChannel> channels, CancellationToken cancellationToken)
+		public async Task<IReadOnlyCollection<Tuple<Api.Models.ChatChannel, ChannelRepresentation>>> MapChannels(IEnumerable<Api.Models.ChatChannel> channels, CancellationToken cancellationToken)
 		{
 			try
 			{
@@ -197,8 +197,10 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		/// </summary>
 		/// <param name="channels">The <see cref="Api.Models.ChatChannel"/>s to map.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
-		/// <returns>A <see cref="Task{TResult}"/> resulting in a <see cref="IReadOnlyCollection{T}"/> of the <see cref="ChannelRepresentation"/>s representing <paramref name="channels"/>.</returns>
-		protected abstract Task<IReadOnlyCollection<ChannelRepresentation>> MapChannelsImpl(IEnumerable<Api.Models.ChatChannel> channels, CancellationToken cancellationToken);
+		/// <returns>A <see cref="Task{TResult}"/> resulting in a <see cref="IReadOnlyCollection{T}"/> of the <see cref="Api.Models.ChatChannel"/>'s <see cref="ChannelRepresentation"/>s representing <paramref name="channels"/>.</returns>
+		protected abstract Task<IReadOnlyCollection<Tuple<Api.Models.ChatChannel, ChannelRepresentation>>> MapChannelsImpl(
+			IEnumerable<Api.Models.ChatChannel> channels,
+			CancellationToken cancellationToken);
 
 		/// <summary>
 		/// Queues a <paramref name="message"/> for <see cref="NextMessage(CancellationToken)"/>.


### PR DESCRIPTION
:cl:
Fixed guild announcement channels not being valid for Discord chat provider.
Fixed failing to map channels causing message dispatch issues.
/:cl: