### PR TITLE
Fix GitHub rate limits stopping watchdog from launching

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>5.2.2</TgsCoreVersion>
+    <TgsCoreVersion>5.2.3</TgsCoreVersion>
     <TgsConfigVersion>4.4.0</TgsConfigVersion>
     <TgsApiVersion>9.7.0</TgsApiVersion>
     <TgsApiLibraryVersion>10.1.0</TgsApiLibraryVersion>

--- a/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
@@ -661,18 +661,26 @@ namespace Tgstation.Server.Host.Components.Watchdog
 		/// <param name="newCompileJob">The new <see cref="Models.CompileJob"/> being applied.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task"/> representing the running operation.</returns>
-		protected Task BeforeApplyDmb(Models.CompileJob newCompileJob, CancellationToken cancellationToken)
+		protected async Task BeforeApplyDmb(Models.CompileJob newCompileJob, CancellationToken cancellationToken)
 		{
 			if (newCompileJob.Id == ActiveCompileJob?.Id)
 			{
 				Logger.LogTrace("Same compile job, not sending deployment event");
-				return Task.CompletedTask;
+				return;
 			}
 
 			var remoteDeploymentManager = remoteDeploymentManagerFactory.CreateRemoteDeploymentManager(
 				metadata,
 				newCompileJob);
-			return remoteDeploymentManager.ApplyDeployment(newCompileJob, ActiveCompileJob, cancellationToken);
+
+			try
+			{
+				await remoteDeploymentManager.ApplyDeployment(newCompileJob, ActiveCompileJob, cancellationToken);
+			}
+			catch (Exception ex)
+			{
+				Logger.LogWarning(ex, "Failed to apply remote deployment!");
+			}
 		}
 
 		/// <summary>

--- a/src/Tgstation.Server.Host/Controllers/UserController.cs
+++ b/src/Tgstation.Server.Host/Controllers/UserController.cs
@@ -110,8 +110,7 @@ namespace Tgstation.Server.Host.Controllers
 			var totalUsers = await DatabaseContext
 				.Users
 				.AsQueryable()
-				.CountAsync(cancellationToken)
-				;
+				.CountAsync(cancellationToken);
 			if (totalUsers >= generalConfiguration.UserLimit)
 				return Conflict(new ErrorMessageResponse(ErrorCode.UserLimitReached));
 


### PR DESCRIPTION
:cl:
Fixed having GitHub deployments enabled potentially causing the watchdog to fail to start if the token was rate limited.
/:cl:

Fixes #1413