### PR TITLE
Make github testmerge comments collapsible

### DIFF
--- a/src/Tgstation.Server.Host/Components/Deployment/Remote/GitHubRemoteDeploymentManager.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/Remote/GitHubRemoteDeploymentManager.cs
@@ -283,7 +283,7 @@ namespace Tgstation.Server.Host.Components.Deployment.Remote
 			string remoteRepositoryName,
 			bool updated) => String.Format(
 			CultureInfo.InvariantCulture,
-			"#### Test Merge {4}{0}{0}##### Server Instance{0}{5}{1}{0}{0}##### Revision{0}Origin: {6}{0}Pull Request: {2}{0}Server: {7}{3}{8}",
+			"#### Test Merge {4}{0}{0}<details><summary>Details</summary>{0}{0}##### Server Instance{0}{5}{1}{0}{0}##### Revision{0}Origin: {6}{0}Pull Request: {2}{0}Server: {7}{3}{8}{0}</details>",
 			Environment.NewLine,
 			repositorySettings.ShowTestMergeCommitters.Value
 				? String.Format(


### PR DESCRIPTION
:cl:
The GitHub comment when you test merge is now collapsed by default.
/:cl:

This is a webedit btw

---------------
#### Test Merge Updated

<details><summary>Details</summary>

##### Server Instance
TGMC
##### Merged By
Lewdcifer

##### Revision
Origin: 1a7897fb75c0bc591fc470eeb19602cedd44f913
Pull Request: 91cc309b623ea746cb2c657369e892fd4da3e772
Server: 39862f7d553c85a605709fa41bd5380a2f39c840

##### Comment

[GitHub Deployments](https://github.com/tgstation/TerraGov-Marine-Corps/deployments/activity_log?environment=TGS%3A%20TGMC)
</details>

---------------

Is better than 

--------------
#### Test Merge Updated

##### Server Instance
TGMC
##### Merged By
Lewdcifer

##### Revision
Origin: 1a7897fb75c0bc591fc470eeb19602cedd44f913
Pull Request: 91cc309b623ea746cb2c657369e892fd4da3e772
Server: 39862f7d553c85a605709fa41bd5380a2f39c840

##### Comment

[GitHub Deployments](https://github.com/tgstation/TerraGov-Marine-Corps/deployments/activity_log?environment=TGS%3A%20TGMC)

