### PR TITLE
Adds trailing newline to readme file

### DIFF
--- a/src/DMAPI/tgs/core/README.md
+++ b/src/DMAPI/tgs/core/README.md
@@ -6,3 +6,4 @@ This folder contains all DMAPI code not directly involved in an API.
 - [core.dm](./core.dm) contains the implementations of the `/world/proc/TgsXXX()` procs. Many map directly to the `/datum/tgs_api` functions. It also contains the /datum selection and setup code.
 - [datum.dm](./datum.dm) contains the `/datum/tgs_api` declarations that all APIs must implement.
 - [tgs_version.dm](./tgs_version.dm) contains the `/datum/tgs_version` definition
+- 


### PR DESCRIPTION
Whenever the dmapi auto-updater action tries to update the dmapi, this file is copied over without the trailing newline causing the linters to lose their mind.

[Base Branch]: # 
master

[Release Notes]: # 
nothing notable

[Why]: #
linters *please*
