### PR TITLE
EventScript for when a deployment dir is cleared

### DIFF
--- a/src/Tgstation.Server.Host/Components/Deployment/DmbFactory.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/DmbFactory.cs
@@ -100,22 +100,22 @@ namespace Tgstation.Server.Host.Components.Deployment
 		/// <param name="databaseContextFactory">The value of <see cref="databaseContextFactory"/>.</param>
 		/// <param name="ioManager">The value of <see cref="ioManager"/>.</param>
 		/// <param name="remoteDeploymentManagerFactory">The value of <see cref="remoteDeploymentManagerFactory"/>.</param>
-		/// <param name="logger">The value of <see cref="logger"/>.</param>
 		/// <param name="eventConsumer">The value of <see cref="eventConsumer"/>.</param>
+		/// <param name="logger">The value of <see cref="logger"/>.</param>
 		/// <param name="metadata">The value of <see cref="metadata"/>.</param>
 		public DmbFactory(
 			IDatabaseContextFactory databaseContextFactory,
 			IIOManager ioManager,
 			IRemoteDeploymentManagerFactory remoteDeploymentManagerFactory,
-			ILogger<DmbFactory> logger,
 			IEventConsumer eventConsumer,
+			ILogger<DmbFactory> logger,
 			Api.Models.Instance metadata)
 		{
 			this.databaseContextFactory = databaseContextFactory ?? throw new ArgumentNullException(nameof(databaseContextFactory));
 			this.ioManager = ioManager ?? throw new ArgumentNullException(nameof(ioManager));
 			this.remoteDeploymentManagerFactory = remoteDeploymentManagerFactory ?? throw new ArgumentNullException(nameof(remoteDeploymentManagerFactory));
-			this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
 			this.eventConsumer = eventConsumer ?? throw new ArgumentNullException(nameof(eventConsumer));
+			this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
 			this.metadata = metadata ?? throw new ArgumentNullException(nameof(metadata));
 
 			cleanupTask = Task.CompletedTask;
@@ -367,7 +367,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 				try
 				{
 					++deleting;
-					await eventConsumer.HandleEvent(EventType.DeploymentCleanedUp, new List<string> { x }, cancellationToken);
+					await eventConsumer.HandleEvent(EventType.DeploymentCleanup, new List<string> { x }, cancellationToken);
 					await ioManager.DeleteDirectory(x, cancellationToken);
 				}
 				catch (OperationCanceledException)
@@ -400,6 +400,8 @@ namespace Tgstation.Server.Host.Components.Deployment
 		{
 			async Task HandleCleanup()
 			{
+				// This needs to happen first
+				await eventConsumer.HandleEvent(EventType.DeploymentCleanup, new List<string> { job.DirectoryName.ToString() }, cleanupCts.Token);
 				var deleteJob = ioManager.DeleteDirectory(job.DirectoryName.ToString(), cleanupCts.Token);
 				var remoteDeploymentManager = remoteDeploymentManagerFactory.CreateRemoteDeploymentManager(
 					metadata,

--- a/src/Tgstation.Server.Host/Components/Deployment/DmbFactory.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/DmbFactory.cs
@@ -429,7 +429,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 		/// </summary>
 		/// <param name="directory">The directory to cleanup.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for this <see cref="Task"/>.</param>
-		/// <returns>The deletion task</returns>
+		/// <returns>The deletion task.</returns>
 		async Task DeleteCompileJobContent(string directory, CancellationToken cancellationToken)
 		{
 			// Then call the cleanup event, waiting here first

--- a/src/Tgstation.Server.Host/Components/Deployment/DmbFactory.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/DmbFactory.cs
@@ -433,7 +433,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 		async Task DeleteCompileJobContent(string directory, CancellationToken cancellationToken)
 		{
 			// Then call the cleanup event, waiting here first
-			await eventConsumer.HandleEvent(EventType.DeploymentCleanup, new List<string> { directory }, cancellationToken);
+			await eventConsumer.HandleEvent(EventType.DeploymentCleanup, new List<string> { ioManager.ResolvePath(directory) }, cancellationToken);
 			await ioManager.DeleteDirectory(directory, cancellationToken);
 		}
 	}

--- a/src/Tgstation.Server.Host/Components/Deployment/DmbFactory.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/DmbFactory.cs
@@ -429,7 +429,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 		/// </summary>
 		/// <param name="directory">The directory to cleanup.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for this <see cref="Task"/>.</param>
-		/// <returns>The deletion task.</returns>
+		/// <returns>The deletion <see cref="Task"/>.</returns>
 		async Task DeleteCompileJobContent(string directory, CancellationToken cancellationToken)
 		{
 			// Then call the cleanup event, waiting here first

--- a/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
@@ -929,6 +929,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 				try
 				{
 					// DCT: None available
+					await eventConsumer.HandleEvent(EventType.DeploymentCleanup, new List<string> { jobPath }, default);
 					await ioManager.DeleteDirectory(jobPath, default);
 				}
 				catch (Exception e)

--- a/src/Tgstation.Server.Host/Components/Events/EventType.cs
+++ b/src/Tgstation.Server.Host/Components/Events/EventType.cs
@@ -159,7 +159,7 @@
 		/// <summary>
 		/// Whenever a deployment folder is deleted from disk. Parameters: Game directory path
 		/// </summary>
-		[EventScript("DeploymentCleanedUp")]
-		DeploymentCleanedUp,
+		[EventScript("DeploymentCleanup")]
+		DeploymentCleanup,
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Events/EventType.cs
+++ b/src/Tgstation.Server.Host/Components/Events/EventType.cs
@@ -155,5 +155,11 @@
 		/// </summary>
 		[EventScript("PreDreamMaker")]
 		PreDreamMaker,
+
+		/// <summary>
+		/// Whenever a deployment folder is deleted from disk. Parameters: Game directory path
+		/// </summary>
+		[EventScript("DeploymentCleanedUp")]
+		DeploymentCleanedUp,
 	}
 }

--- a/src/Tgstation.Server.Host/Components/InstanceFactory.cs
+++ b/src/Tgstation.Server.Host/Components/InstanceFactory.cs
@@ -286,8 +286,8 @@ namespace Tgstation.Server.Host.Components
 						databaseContextFactory,
 						gameIoManager,
 						remoteDeploymentManagerFactory,
-						loggerFactory.CreateLogger<DmbFactory>(),
 						eventConsumer,
+						loggerFactory.CreateLogger<DmbFactory>(),
 						metadata);
 					try
 					{

--- a/src/Tgstation.Server.Host/Components/InstanceFactory.cs
+++ b/src/Tgstation.Server.Host/Components/InstanceFactory.cs
@@ -287,6 +287,7 @@ namespace Tgstation.Server.Host.Components
 						gameIoManager,
 						remoteDeploymentManagerFactory,
 						loggerFactory.CreateLogger<DmbFactory>(),
+						eventConsumer,
 						metadata);
 					try
 					{


### PR DESCRIPTION
:cl: Core
Added `DeploymentClenaup` EventScript for when a deployment directory on disk is about to be removed.
/:cl:

Why? I am making a system where the server rsc is put onto a ramdisk to speed up icon operations, since some of them can take >100ms!!
![image](https://user-images.githubusercontent.com/25063394/210083973-5b0b0d08-a373-4b85-b2e0-5037b5c21873.png)

Icon ops are highly dependant on disk IO, and going through a VM + questionable storage threading can lead to issues, not to mention how the RSC writes can be somewhat random. 

The `CompileComplete` eventscript allows me to move the rsc to the ramdisk and make a symlink to the game dir, but I need a way to clear that up since deleting the symlink wouldnt delete the rsc from the ramdisk, causing issues. This EventScript would allow me to do that.

---

Sidenote, I dont know a good way to test this, so this is currently untested outside of a compile. If you have any good pointers please tell me. 