### PR TITLE
Detaching a deleted instance doesn't throw

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>5.3.2</TgsCoreVersion>
+    <TgsCoreVersion>5.3.3</TgsCoreVersion>
     <TgsConfigVersion>4.4.0</TgsConfigVersion>
     <TgsApiVersion>9.8.1</TgsApiVersion>
     <TgsApiLibraryVersion>10.2.0</TgsApiLibraryVersion>

--- a/src/Tgstation.Server.Host/Components/Deployment/Remote/GitHubRemoteDeploymentManager.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/Remote/GitHubRemoteDeploymentManager.cs
@@ -305,7 +305,7 @@ namespace Tgstation.Server.Host.Components.Deployment.Remote
 			compileJob.RevisionInformation.OriginCommitSha,
 			compileJob.RevisionInformation.CommitSha,
 			compileJob.GitHubDeploymentId.HasValue
-				? $"{Environment.NewLine}[GitHub Deployments](https://github.com/{remoteRepositoryOwner}/{remoteRepositoryName}/deployments/activity_log?environment=TGS%3A%20{Metadata.Name})"
+				? $"{Environment.NewLine}[GitHub Deployments](https://github.com/{remoteRepositoryOwner}/{remoteRepositoryName}/deployments/activity_log?environment=TGS%3A+{Metadata.Name.Replace(" ", "+", StringComparison.Ordinal)})"
 				: String.Empty);
 
 		/// <summary>

--- a/src/Tgstation.Server.Host/Controllers/InstanceController.cs
+++ b/src/Tgstation.Server.Host/Controllers/InstanceController.cs
@@ -303,7 +303,8 @@ namespace Tgstation.Server.Host.Controllers
 			var attachFileName = ioManager.ConcatPath(originalModel.Path, InstanceAttachFileName);
 			try
 			{
-				await ioManager.WriteAllBytes(attachFileName, Array.Empty<byte>(), cancellationToken);
+				if (await ioManager.DirectoryExists(originalModel.Path, cancellationToken))
+					await ioManager.WriteAllBytes(attachFileName, Array.Empty<byte>(), cancellationToken);
 			}
 			catch (OperationCanceledException)
 			{


### PR DESCRIPTION
:cl:
Fixed detaching an instance that did not exist on disk erroring.
Fixed a formatting error in GitHub test merge comments.
Removed delay between stage update notifications in deployment jobs.
/:cl: