### PR TITLE
Disable delayed autostart for Windows Service

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -10,7 +10,7 @@
     <TgsClientVersion>11.2.1</TgsClientVersion>
     <TgsDmapiVersion>6.0.6</TgsDmapiVersion>
     <TgsInteropVersion>5.3.0</TgsInteropVersion>
-    <TgsHostWatchdogVersion>1.2.0</TgsHostWatchdogVersion>
+    <TgsHostWatchdogVersion>1.2.1</TgsHostWatchdogVersion>
     <TgsContainerScriptVersion>1.2.1</TgsContainerScriptVersion>
     <TgsMigratorVersion>1.0.1</TgsMigratorVersion>
     <TgsNetVersion>net6.0</TgsNetVersion>

--- a/src/Tgstation.Server.Host.Service/Program.cs
+++ b/src/Tgstation.Server.Host.Service/Program.cs
@@ -152,7 +152,6 @@ namespace Tgstation.Server.Host.Service
 						installer.Context = new InstallContext("tgs-install.log", new string[] { String.Format(CultureInfo.InvariantCulture, "/assemblypath={0}", Assembly.GetEntryAssembly().Location) });
 						installer.Description = "/tg/station 13 server running as a windows service";
 						installer.DisplayName = "/tg/station server";
-						installer.DelayedAutoStart = true;
 						installer.StartType = ServiceStartMode.Automatic;
 						installer.ServicesDependedOn = new string[] { "Tcpip", "Dhcp", "Dnscache" };
 						installer.ServiceName = ServerService.Name;

--- a/tools/Tgstation.Server.Migrator/Program.cs
+++ b/tools/Tgstation.Server.Migrator/Program.cs
@@ -417,7 +417,6 @@ try
 			});
 		installer.Description = "/tg/station 13 server running as a windows service";
 		installer.DisplayName = "/tg/station server";
-		installer.DelayedAutoStart = true;
 		installer.StartType = ServiceStartMode.Automatic;
 		installer.ServicesDependedOn = new string[] { "Tcpip", "Dhcp", "Dnscache" };
 		installer.ServiceName = "tgstation-server";


### PR DESCRIPTION
:cl: Host Watchdog
Windows service is now installed as `Automatic` instead of `Automatic (Delayed Start)` to ensure faster startups. While not mandatory, you will have to change this manually for existing service installations in the Windows Service Control Panel.
/:cl: