### PR TITLE
Add support for reading DreamDaemon output to file + other stuff

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -8,7 +8,7 @@
     <TgsApiVersion>9.9.0</TgsApiVersion>
     <TgsApiLibraryVersion>10.3.0</TgsApiLibraryVersion>
     <TgsClientVersion>11.3.0</TgsClientVersion>
-    <TgsDmapiVersion>6.1.0</TgsDmapiVersion>
+    <TgsDmapiVersion>6.2.0</TgsDmapiVersion>
     <TgsInteropVersion>5.4.0</TgsInteropVersion>
     <TgsHostWatchdogVersion>1.2.1</TgsHostWatchdogVersion>
     <TgsContainerScriptVersion>1.2.1</TgsContainerScriptVersion>

--- a/build/Version.props
+++ b/build/Version.props
@@ -3,11 +3,11 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>5.6.0</TgsCoreVersion>
+    <TgsCoreVersion>5.7.0</TgsCoreVersion>
     <TgsConfigVersion>4.4.0</TgsConfigVersion>
-    <TgsApiVersion>9.8.1</TgsApiVersion>
-    <TgsApiLibraryVersion>10.2.0</TgsApiLibraryVersion>
-    <TgsClientVersion>11.2.1</TgsClientVersion>
+    <TgsApiVersion>9.9.0</TgsApiVersion>
+    <TgsApiLibraryVersion>10.3.0</TgsApiLibraryVersion>
+    <TgsClientVersion>11.3.0</TgsClientVersion>
     <TgsDmapiVersion>6.1.0</TgsDmapiVersion>
     <TgsInteropVersion>5.4.0</TgsInteropVersion>
     <TgsHostWatchdogVersion>1.2.1</TgsHostWatchdogVersion>

--- a/src/DMAPI/tgs.dm
+++ b/src/DMAPI/tgs.dm
@@ -1,6 +1,6 @@
 // tgstation-server DMAPI
 
-#define TGS_DMAPI_VERSION "6.1.0"
+#define TGS_DMAPI_VERSION "6.2.0"
 
 // All functions and datums outside this document are subject to change with any version and should not be relied on.
 
@@ -258,6 +258,8 @@
 	var/help_text = ""
 	/// If this command should be available to game administrators only
 	var/admin_only = FALSE
+	/// A subtype of [/datum/tgs_chat_command] that is ignored when enumerating available commands. Use this to create shared base /datums for commands.
+	var/ignore_type
 
 /**
  * Process command activation. Should return a [/datum/tgs_message_content] to respond to the issuer with.

--- a/src/DMAPI/tgs/v3210/commands.dm
+++ b/src/DMAPI/tgs/v3210/commands.dm
@@ -10,9 +10,12 @@
 	var/warned_about_the_dangers_of_robutussin = !warnings_only
 	for(var/I in typesof(/datum/tgs_chat_command) - /datum/tgs_chat_command)
 		if(!warned_about_the_dangers_of_robutussin)
-			TGS_ERROR_LOG("Custom chat commands in [ApiVersion()] lacks the /datum/tgs_chat_user/sender.channel field!")
+			TGS_WARNING_LOG("Custom chat commands in [ApiVersion()] lacks the /datum/tgs_chat_user/sender.channel field!")
 			warned_about_the_dangers_of_robutussin = TRUE
 		var/datum/tgs_chat_command/stc = I
+		if(stc.ignore_type == I)
+			continue
+
 		var/command_name = initial(stc.name)
 		if(!command_name || findtext(command_name, " ") || findtext(command_name, "'") || findtext(command_name, "\""))
 			if(warnings_only && !warned_command_names[command_name])

--- a/src/DMAPI/tgs/v4/commands.dm
+++ b/src/DMAPI/tgs/v4/commands.dm
@@ -3,6 +3,9 @@
 	custom_commands = list()
 	for(var/I in typesof(/datum/tgs_chat_command) - /datum/tgs_chat_command)
 		var/datum/tgs_chat_command/stc = new I
+		if(stc.ignore_type == I)
+			continue
+
 		var/command_name = stc.name
 		if(!command_name || findtext(command_name, " ") || findtext(command_name, "'") || findtext(command_name, "\""))
 			TGS_ERROR_LOG("Custom command [command_name] ([I]) can't be used as it is empty or contains illegal characters!")

--- a/src/DMAPI/tgs/v5/commands.dm
+++ b/src/DMAPI/tgs/v5/commands.dm
@@ -3,14 +3,17 @@
 	custom_commands = list()
 	for(var/I in typesof(/datum/tgs_chat_command) - /datum/tgs_chat_command)
 		var/datum/tgs_chat_command/stc = new I
+		if(stc.ignore_type == I)
+			continue
+
 		var/command_name = stc.name
 		if(!command_name || findtext(command_name, " ") || findtext(command_name, "'") || findtext(command_name, "\""))
-			TGS_WARNING_LOG("Custom command [command_name] ([I]) can't be used as it is empty or contains illegal characters!")
+			TGS_ERROR_LOG("Custom command [command_name] ([I]) can't be used as it is empty or contains illegal characters!")
 			continue
 
 		if(results[command_name])
 			var/datum/other = custom_commands[command_name]
-			TGS_WARNING_LOG("Custom commands [other.type] and [I] have the same name (\"[command_name]\"), only [other.type] will be available!")
+			TGS_ERROR_LOG("Custom commands [other.type] and [I] have the same name (\"[command_name]\"), only [other.type] will be available!")
 			continue
 		results += list(list(DMAPI5_CUSTOM_CHAT_COMMAND_NAME = command_name, DMAPI5_CUSTOM_CHAT_COMMAND_HELP_TEXT = stc.help_text, DMAPI5_CUSTOM_CHAT_COMMAND_ADMIN_ONLY = stc.admin_only))
 		custom_commands[command_name] = stc

--- a/src/Tgstation.Server.Api/Models/Internal/DreamDaemonLaunchParameters.cs
+++ b/src/Tgstation.Server.Api/Models/Internal/DreamDaemonLaunchParameters.cs
@@ -85,6 +85,13 @@ namespace Tgstation.Server.Api.Models.Internal
 		public string? AdditionalParameters { get; set; }
 
 		/// <summary>
+		/// If process output/error text should be logged.
+		/// </summary>
+		[Required]
+		[ResponseOptions]
+		public bool? LogOutput { get; set; }
+
+		/// <summary>
 		/// Check if we match a given set of <paramref name="otherParameters"/>. <see cref="StartupTimeout"/> is excluded.
 		/// </summary>
 		/// <param name="otherParameters">The <see cref="DreamDaemonLaunchParameters"/> to compare against.</param>
@@ -100,7 +107,8 @@ namespace Tgstation.Server.Api.Models.Internal
 				&& Port == otherParameters.Port
 				&& TopicRequestTimeout == otherParameters.TopicRequestTimeout
 				&& AdditionalParameters == otherParameters.AdditionalParameters
-				&& StartProfiler == otherParameters.StartProfiler; // We intentionally don't check StartupTimeout, heartbeat seconds, or heartbeat dump as they don't matter in terms of the watchdog
+				&& StartProfiler == otherParameters.StartProfiler
+				&& LogOutput == otherParameters.LogOutput; // We intentionally don't check StartupTimeout, heartbeat seconds, or heartbeat dump as they don't matter in terms of the watchdog
 		}
 	}
 }

--- a/src/Tgstation.Server.Api/Rights/DreamDaemonRights.cs
+++ b/src/Tgstation.Server.Api/Rights/DreamDaemonRights.cs
@@ -102,5 +102,10 @@ namespace Tgstation.Server.Api.Rights
 		/// User can change <see cref="Models.Internal.DreamDaemonLaunchParameters.StartProfiler"/>
 		/// </summary>
 		SetProfiler = 131072,
+
+		/// <summary>
+		/// User can change <see cref="Models.Internal.DreamDaemonLaunchParameters.LogOutput"/>
+		/// </summary>
+		SetLogOutput = 262144,
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Byond/WindowsByondInstaller.cs
+++ b/src/Tgstation.Server.Host/Components/Byond/WindowsByondInstaller.cs
@@ -187,7 +187,7 @@ namespace Tgstation.Server.Host.Components.Byond
 			try
 			{
 				// noShellExecute because we aren't doing runas shennanigans
-				using var directXInstaller = processExecutor.LaunchProcess(
+				await using var directXInstaller = await processExecutor.LaunchProcess(
 					IOManager.ConcatPath(rbdx, "DXSETUP.exe"),
 					rbdx,
 					"/silent",
@@ -228,13 +228,12 @@ namespace Tgstation.Server.Host.Components.Byond
 			Logger.LogInformation("Adding Windows Firewall exception for {path}...", dreamDaemonPath);
 			try
 			{
-				using var netshProcess = processExecutor.LaunchProcess(
+				await using var netshProcess = await processExecutor.LaunchProcess(
 					"netsh.exe",
 					IOManager.ResolvePath(),
 					$"advfirewall firewall add rule name=\"TGS DreamDaemon\" program=\"{dreamDaemonPath}\" protocol=tcp dir=in enable=yes action=allow",
-					true,
-					true,
-					true);
+					readStandardHandles: true,
+					noShellExecute: true);
 
 				int exitCode;
 				using (cancellationToken.Register(() => netshProcess.Terminate()))

--- a/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
@@ -752,6 +752,8 @@ namespace Tgstation.Server.Host.Components.Deployment
 						}
 						while (DateTimeOffset.UtcNow < nextInterval);
 					}
+					else
+						await Task.Delay(minimumSleepInterval, cancellationToken);
 
 					progressReporter.StageName = currentStage;
 					lastReport = estimatedDuration.HasValue ? sleepInterval * (iteration + 1) / estimatedDuration.Value : null;

--- a/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
@@ -760,8 +760,9 @@ namespace Tgstation.Server.Host.Components.Deployment
 					progressReporter.ReportProgress(lastReport);
 				}
 			}
-			catch (OperationCanceledException)
+			catch (OperationCanceledException ex)
 			{
+				logger.LogTrace(ex, "ProgressTask aborted.");
 			}
 		}
 

--- a/src/Tgstation.Server.Host/Components/InstanceFactory.cs
+++ b/src/Tgstation.Server.Host/Components/InstanceFactory.cs
@@ -271,6 +271,7 @@ namespace Tgstation.Server.Host.Components
 						cryptographySuite,
 						assemblyInformationProvider,
 						gameIoManager,
+						diagnosticsIOManager,
 						chatManager,
 						networkPromptReaper,
 						platformIdentifier,
@@ -308,10 +309,11 @@ namespace Tgstation.Server.Host.Components
 							remoteDeploymentManagerFactory,
 							metadata,
 							metadata.DreamDaemonSettings);
-						eventConsumer.SetWatchdog(watchdog);
-						commandFactory.SetWatchdog(watchdog);
 						try
 						{
+							eventConsumer.SetWatchdog(watchdog);
+							commandFactory.SetWatchdog(watchdog);
+
 							Instance instance = null;
 							var dreamMaker = new DreamMaker(
 								byond,

--- a/src/Tgstation.Server.Host/Components/Session/SessionController.cs
+++ b/src/Tgstation.Server.Host/Components/Session/SessionController.cs
@@ -275,7 +275,7 @@ namespace Tgstation.Server.Host.Components.Session
 				byondLock.Dispose();
 			}
 
-			process.Dispose();
+			await process.DisposeAsync();
 			bridgeRegistration?.Dispose();
 			ReattachInformation.Dmb?.Dispose(); // will be null when released
 			chatTrackingContext.Dispose();
@@ -656,8 +656,8 @@ namespace Tgstation.Server.Host.Components.Session
 
 			var result = new LaunchResult
 			{
-				ExitCode = process.Lifetime.IsCompleted ? (int?)await process.Lifetime : null,
-				StartupTime = startupTask.IsCompleted ? (TimeSpan?)(DateTimeOffset.UtcNow - startTime) : null,
+				ExitCode = process.Lifetime.IsCompleted ? await process.Lifetime : null,
+				StartupTime = startupTask.IsCompleted ? (DateTimeOffset.UtcNow - startTime) : null,
 			};
 
 			logger.LogTrace("Launch result: {0}", result);

--- a/src/Tgstation.Server.Host/Components/Session/SessionPersistor.cs
+++ b/src/Tgstation.Server.Host/Components/Session/SessionPersistor.cs
@@ -99,7 +99,7 @@ namespace Tgstation.Server.Host.Components.Session
 			{
 				try
 				{
-					using var process = processExecutor.GetProcess(reattachInfo.ProcessId);
+					await using var process = processExecutor.GetProcess(reattachInfo.ProcessId);
 					if (process != null)
 					{
 						if (reattachInfo == result)

--- a/src/Tgstation.Server.Host/Components/StaticFiles/Configuration.cs
+++ b/src/Tgstation.Server.Host/Components/StaticFiles/Configuration.cs
@@ -562,7 +562,7 @@ namespace Tgstation.Server.Host.Components.StaticFiles
 				foreach (var scriptFile in scriptFiles)
 				{
 					logger.LogTrace("Running event script {scriptFile}...", scriptFile);
-					using (var script = processExecutor.LaunchProcess(
+					await using (var script = await processExecutor.LaunchProcess(
 						ioManager.ConcatPath(resolvedScriptsDir, scriptFile),
 						resolvedScriptsDir,
 						String.Join(
@@ -576,9 +576,8 @@ namespace Tgstation.Server.Host.Components.StaticFiles
 
 								return $"\"{arg}\"";
 							})),
-						true,
-						true,
-						true))
+						readStandardHandles: true,
+						noShellExecute: true))
 					using (cancellationToken.Register(() => script.Terminate()))
 					{
 						var exitCode = await script.Lifetime;

--- a/src/Tgstation.Server.Host/Controllers/DreamDaemonController.cs
+++ b/src/Tgstation.Server.Host/Controllers/DreamDaemonController.cs
@@ -150,7 +150,8 @@ namespace Tgstation.Server.Host.Controllers
 			| DreamDaemonRights.SetTopicTimeout
 			| DreamDaemonRights.SetAdditionalParameters
 			| DreamDaemonRights.SetVisibility
-			| DreamDaemonRights.SetProfiler)]
+			| DreamDaemonRights.SetProfiler
+			| DreamDaemonRights.SetLogOutput)]
 		[ProducesResponseType(typeof(DreamDaemonResponse), 200)]
 		[ProducesResponseType(typeof(ErrorMessageResponse), 410)]
 #pragma warning disable CA1502 // TODO: Decomplexify
@@ -224,7 +225,8 @@ namespace Tgstation.Server.Host.Controllers
 						|| CheckModified(x => x.DumpOnHeartbeatRestart, DreamDaemonRights.CreateDump)
 						|| CheckModified(x => x.TopicRequestTimeout, DreamDaemonRights.SetTopicTimeout)
 						|| CheckModified(x => x.AdditionalParameters, DreamDaemonRights.SetAdditionalParameters)
-						|| CheckModified(x => x.StartProfiler, DreamDaemonRights.SetProfiler))
+						|| CheckModified(x => x.StartProfiler, DreamDaemonRights.SetProfiler)
+						|| CheckModified(x => x.LogOutput, DreamDaemonRights.SetLogOutput))
 						return Forbid();
 
 					await DatabaseContext.Save(cancellationToken);
@@ -365,6 +367,7 @@ namespace Tgstation.Server.Host.Controllers
 					result.TopicRequestTimeout = settings.TopicRequestTimeout.Value;
 					result.AdditionalParameters = settings.AdditionalParameters;
 					result.StartProfiler = settings.StartProfiler;
+					result.LogOutput = settings.LogOutput;
 				}
 
 				if (revision)

--- a/src/Tgstation.Server.Host/Controllers/InstanceController.cs
+++ b/src/Tgstation.Server.Host/Controllers/InstanceController.cs
@@ -725,6 +725,7 @@ namespace Tgstation.Server.Host.Controllers
 					TopicRequestTimeout = generalConfiguration.ByondTopicTimeout,
 					AdditionalParameters = String.Empty,
 					StartProfiler = false,
+					LogOutput = false,
 				},
 				DreamMakerSettings = new DreamMakerSettings
 				{

--- a/src/Tgstation.Server.Host/Database/DatabaseContext.cs
+++ b/src/Tgstation.Server.Host/Database/DatabaseContext.cs
@@ -379,22 +379,22 @@ namespace Tgstation.Server.Host.Database
 		/// <summary>
 		/// Used by unit tests to remind us to setup the correct MSSQL migration downgrades.
 		/// </summary>
-		internal static readonly Type MSLatestMigration = typeof(MSAddProfiler);
+		internal static readonly Type MSLatestMigration = typeof(MSAddDreamDaemonLogOutput);
 
 		/// <summary>
 		/// Used by unit tests to remind us to setup the correct MYSQL migration downgrades.
 		/// </summary>
-		internal static readonly Type MYLatestMigration = typeof(MYAddProfiler);
+		internal static readonly Type MYLatestMigration = typeof(MYAddDreamDaemonLogOutput);
 
 		/// <summary>
 		/// Used by unit tests to remind us to setup the correct PostgresSQL migration downgrades.
 		/// </summary>
-		internal static readonly Type PGLatestMigration = typeof(PGAddProfiler);
+		internal static readonly Type PGLatestMigration = typeof(PGAddDreamDaemonLogOutput);
 
 		/// <summary>
 		/// Used by unit tests to remind us to setup the correct SQLite migration downgrades.
 		/// </summary>
-		internal static readonly Type SLLatestMigration = typeof(SLAddProfiler);
+		internal static readonly Type SLLatestMigration = typeof(SLAddDreamDaemonLogOutput);
 
 		/// <inheritdoc />
 #pragma warning disable CA1502 // Cyclomatic complexity
@@ -425,6 +425,15 @@ namespace Tgstation.Server.Host.Database
 
 			string BadDatabaseType() => throw new ArgumentException($"Invalid DatabaseType: {currentDatabaseType}", nameof(currentDatabaseType));
 
+			if (targetVersion < new Version(5, 7, 0))
+				targetMigration = currentDatabaseType switch
+				{
+					DatabaseType.MySql => nameof(MYAddProfiler),
+					DatabaseType.PostgresSql => nameof(PGAddProfiler),
+					DatabaseType.SqlServer => nameof(MSAddProfiler),
+					DatabaseType.Sqlite => nameof(SLAddProfiler),
+					_ => BadDatabaseType(),
+				};
 			if (targetVersion < new Version(4, 19, 0))
 				targetMigration = currentDatabaseType switch
 				{

--- a/src/Tgstation.Server.Host/Database/Migrations/20230331220749_MSAddDreamDaemonLogOutput.Designer.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20230331220749_MSAddDreamDaemonLogOutput.Designer.cs
@@ -3,23 +3,25 @@ using System;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
 namespace Tgstation.Server.Host.Database.Migrations
 {
-	[DbContext(typeof(PostgresSqlDatabaseContext))]
-	partial class PostgresSqlDatabaseContextModelSnapshot : ModelSnapshot
+	[DbContext(typeof(SqlServerDatabaseContext))]
+	[Migration("20230331220749_MSAddDreamDaemonLogOutput")]
+	partial class MSAddDreamDaemonLogOutput
 	{
 		/// <inheritdoc />
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder
 				.HasAnnotation("ProductVersion", "6.0.15")
-				.HasAnnotation("Relational:MaxIdentifierLength", 63);
+				.HasAnnotation("Relational:MaxIdentifierLength", 128);
 
-			NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
+			SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder, 1L, 1);
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.ChatBot", b =>
 			{
@@ -27,18 +29,18 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"), 1L, 1);
 
 				b.Property<int>("ChannelLimit")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<string>("ConnectionString")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<bool?>("Enabled")
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
@@ -46,10 +48,10 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("nvarchar(100)");
 
 				b.Property<int>("Provider")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<long>("ReconnectionInterval")
 					.HasColumnType("bigint");
@@ -68,41 +70,43 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"), 1L, 1);
 
 				b.Property<long>("ChatSettingsId")
 					.HasColumnType("bigint");
 
 				b.Property<decimal?>("DiscordChannelId")
-					.HasColumnType("numeric(20,0)");
+					.HasColumnType("decimal(20,0)");
 
 				b.Property<string>("IrcChannel")
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("nvarchar(100)");
 
 				b.Property<bool?>("IsAdminChannel")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<bool?>("IsUpdatesChannel")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<bool?>("IsWatchdogChannel")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<string>("Tag")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("nvarchar(max)");
 
 				b.HasKey("Id");
 
 				b.HasIndex("ChatSettingsId", "DiscordChannelId")
-					.IsUnique();
+					.IsUnique()
+					.HasFilter("[DiscordChannelId] IS NOT NULL");
 
 				b.HasIndex("ChatSettingsId", "IrcChannel")
-					.IsUnique();
+					.IsUnique()
+					.HasFilter("[IrcChannel] IS NOT NULL");
 
 				b.ToTable("ChatChannels");
 			});
@@ -113,31 +117,31 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"), 1L, 1);
 
 				b.Property<string>("ByondVersion")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<int?>("DMApiMajorVersion")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int?>("DMApiMinorVersion")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int?>("DMApiPatchVersion")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<Guid?>("DirectoryName")
 					.IsRequired()
-					.HasColumnType("uuid");
+					.HasColumnType("uniqueidentifier");
 
 				b.Property<string>("DmeName")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<int?>("GitHubDeploymentId")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<long?>("GitHubRepoId")
 					.HasColumnType("bigint");
@@ -146,14 +150,14 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasColumnType("bigint");
 
 				b.Property<int?>("MinimumSecurityLevel")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<string>("Output")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<string>("RepositoryOrigin")
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<long>("RevisionInformationId")
 					.HasColumnType("bigint");
@@ -176,24 +180,24 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"), 1L, 1);
 
 				b.Property<string>("AdditionalParameters")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<bool?>("AllowWebClient")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<bool?>("AutoStart")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<bool?>("DumpOnHeartbeatRestart")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<long>("HeartbeatSeconds")
 					.HasColumnType("bigint");
@@ -203,17 +207,17 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<bool?>("LogOutput")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<int>("Port")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int>("SecurityLevel")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<bool?>("StartProfiler")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<long>("StartupTimeout")
 					.HasColumnType("bigint");
@@ -222,7 +226,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasColumnType("bigint");
 
 				b.Property<int>("Visibility")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.HasKey("Id");
 
@@ -238,28 +242,28 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"), 1L, 1);
 
 				b.Property<int>("ApiValidationPort")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int>("ApiValidationSecurityLevel")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
 				b.Property<string>("ProjectName")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<bool?>("RequireDMApiValidation")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<TimeSpan?>("Timeout")
 					.IsRequired()
-					.HasColumnType("interval");
+					.HasColumnType("time");
 
 				b.HasKey("Id");
 
@@ -275,37 +279,38 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"), 1L, 1);
 
 				b.Property<long>("AutoUpdateInterval")
 					.HasColumnType("bigint");
 
 				b.Property<int>("ChatBotLimit")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int>("ConfigurationType")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("nvarchar(100)");
 
 				b.Property<bool?>("Online")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<string>("Path")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(450)");
 
 				b.Property<string>("SwarmIdentifer")
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(450)");
 
 				b.HasKey("Id");
 
 				b.HasIndex("Path", "SwarmIdentifer")
-					.IsUnique();
+					.IsUnique()
+					.HasFilter("[SwarmIdentifer] IS NOT NULL");
 
 				b.ToTable("Instances");
 			});
@@ -316,34 +321,34 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"), 1L, 1);
 
 				b.Property<decimal>("ByondRights")
-					.HasColumnType("numeric(20,0)");
+					.HasColumnType("decimal(20,0)");
 
 				b.Property<decimal>("ChatBotRights")
-					.HasColumnType("numeric(20,0)");
+					.HasColumnType("decimal(20,0)");
 
 				b.Property<decimal>("ConfigurationRights")
-					.HasColumnType("numeric(20,0)");
+					.HasColumnType("decimal(20,0)");
 
 				b.Property<decimal>("DreamDaemonRights")
-					.HasColumnType("numeric(20,0)");
+					.HasColumnType("decimal(20,0)");
 
 				b.Property<decimal>("DreamMakerRights")
-					.HasColumnType("numeric(20,0)");
+					.HasColumnType("decimal(20,0)");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
 				b.Property<decimal>("InstancePermissionSetRights")
-					.HasColumnType("numeric(20,0)");
+					.HasColumnType("decimal(20,0)");
 
 				b.Property<long>("PermissionSetId")
 					.HasColumnType("bigint");
 
 				b.Property<decimal>("RepositoryRights")
-					.HasColumnType("numeric(20,0)");
+					.HasColumnType("decimal(20,0)");
 
 				b.HasKey("Id");
 
@@ -361,43 +366,43 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"), 1L, 1);
 
 				b.Property<decimal?>("CancelRight")
-					.HasColumnType("numeric(20,0)");
+					.HasColumnType("decimal(20,0)");
 
 				b.Property<decimal?>("CancelRightsType")
-					.HasColumnType("numeric(20,0)");
+					.HasColumnType("decimal(20,0)");
 
 				b.Property<bool?>("Cancelled")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<long?>("CancelledById")
 					.HasColumnType("bigint");
 
 				b.Property<string>("Description")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<long?>("ErrorCode")
 					.HasColumnType("bigint");
 
 				b.Property<string>("ExceptionDetails")
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
 				b.Property<DateTimeOffset?>("StartedAt")
 					.IsRequired()
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("datetimeoffset");
 
 				b.Property<long>("StartedById")
 					.HasColumnType("bigint");
 
 				b.Property<DateTimeOffset?>("StoppedAt")
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("datetimeoffset");
 
 				b.HasKey("Id");
 
@@ -416,15 +421,15 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"), 1L, 1);
 
 				b.Property<string>("ExternalUserId")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("nvarchar(100)");
 
 				b.Property<int>("Provider")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<long?>("UserId")
 					.HasColumnType("bigint");
@@ -445,16 +450,16 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"), 1L, 1);
 
 				b.Property<decimal>("AdministrationRights")
-					.HasColumnType("numeric(20,0)");
+					.HasColumnType("decimal(20,0)");
 
 				b.Property<long?>("GroupId")
 					.HasColumnType("bigint");
 
 				b.Property<decimal>("InstanceManagerRights")
-					.HasColumnType("numeric(20,0)");
+					.HasColumnType("decimal(20,0)");
 
 				b.Property<long?>("UserId")
 					.HasColumnType("bigint");
@@ -462,10 +467,12 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.HasKey("Id");
 
 				b.HasIndex("GroupId")
-					.IsUnique();
+					.IsUnique()
+					.HasFilter("[GroupId] IS NOT NULL");
 
 				b.HasIndex("UserId")
-					.IsUnique();
+					.IsUnique()
+					.HasFilter("[UserId] IS NOT NULL");
 
 				b.ToTable("PermissionSets");
 			});
@@ -476,29 +483,29 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"), 1L, 1);
 
 				b.Property<string>("AccessIdentifier")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<long>("CompileJobId")
 					.HasColumnType("bigint");
 
 				b.Property<int>("LaunchSecurityLevel")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int>("LaunchVisibility")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int>("Port")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int>("ProcessId")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int>("RebootState")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.HasKey("Id");
 
@@ -513,56 +520,56 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"), 1L, 1);
 
 				b.Property<string>("AccessToken")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<string>("AccessUser")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<bool?>("AutoUpdatesKeepTestMerges")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<bool?>("AutoUpdatesSynchronize")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<string>("CommitterEmail")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<string>("CommitterName")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<bool?>("CreateGitHubDeployments")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
 				b.Property<bool?>("PostTestMergeComment")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<bool?>("PushTestMergeCommits")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<bool?>("ShowTestMergeCommitters")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<bool?>("UpdateSubmodules")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.HasKey("Id");
 
@@ -578,7 +585,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"), 1L, 1);
 
 				b.Property<long>("RevisionInformationId")
 					.HasColumnType("bigint");
@@ -601,12 +608,12 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"), 1L, 1);
 
 				b.Property<string>("CommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("character varying(40)");
+					.HasColumnType("nvarchar(40)");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
@@ -614,10 +621,10 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.Property<string>("OriginCommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("character varying(40)");
+					.HasColumnType("nvarchar(40)");
 
 				b.Property<DateTimeOffset>("Timestamp")
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("datetimeoffset");
 
 				b.HasKey("Id");
 
@@ -633,28 +640,28 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"), 1L, 1);
 
 				b.Property<string>("Author")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<string>("BodyAtMerge")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<string>("Comment")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<DateTimeOffset>("MergedAt")
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("datetimeoffset");
 
 				b.Property<long>("MergedById")
 					.HasColumnType("bigint");
 
 				b.Property<int>("Number")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<long?>("PrimaryRevisionInformationId")
 					.IsRequired()
@@ -663,15 +670,15 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.Property<string>("TargetCommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("character varying(40)");
+					.HasColumnType("nvarchar(40)");
 
 				b.Property<string>("TitleAtMerge")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<string>("Url")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(max)");
 
 				b.HasKey("Id");
 
@@ -689,41 +696,41 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"), 1L, 1);
 
 				b.Property<string>("CanonicalName")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("nvarchar(100)");
 
 				b.Property<DateTimeOffset?>("CreatedAt")
 					.IsRequired()
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("datetimeoffset");
 
 				b.Property<long?>("CreatedById")
 					.HasColumnType("bigint");
 
 				b.Property<bool?>("Enabled")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<long?>("GroupId")
 					.HasColumnType("bigint");
 
 				b.Property<DateTimeOffset?>("LastPasswordUpdate")
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("datetimeoffset");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("nvarchar(100)");
 
 				b.Property<string>("PasswordHash")
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<string>("SystemIdentifier")
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("nvarchar(100)");
 
 				b.HasKey("Id");
 
@@ -735,7 +742,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.HasIndex("GroupId");
 
 				b.HasIndex("SystemIdentifier")
-					.IsUnique();
+					.IsUnique()
+					.HasFilter("[SystemIdentifier] IS NOT NULL");
 
 				b.ToTable("Users");
 			});
@@ -746,12 +754,12 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"), 1L, 1);
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("nvarchar(100)");
 
 				b.HasKey("Id");
 
@@ -794,7 +802,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.HasOne("Tgstation.Server.Host.Models.RevisionInformation", "RevisionInformation")
 					.WithMany("CompileJobs")
 					.HasForeignKey("RevisionInformationId")
-					.OnDelete(DeleteBehavior.Cascade)
+					.OnDelete(DeleteBehavior.ClientNoAction)
 					.IsRequired();
 
 				b.Navigation("Job");

--- a/src/Tgstation.Server.Host/Database/Migrations/20230331220749_MSAddDreamDaemonLogOutput.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20230331220749_MSAddDreamDaemonLogOutput.cs
@@ -1,0 +1,39 @@
+﻿using System;
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tgstation.Server.Host.Database.Migrations
+{
+	/// <summary>
+	/// Adds the DreamDaemon LogOutput column for MSSQL.
+	/// </summary>
+	public partial class MSAddDreamDaemonLogOutput : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			if (migrationBuilder == null)
+				throw new ArgumentNullException(nameof(migrationBuilder));
+
+			migrationBuilder.AddColumn<bool>(
+				name: "LogOutput",
+				table: "DreamDaemonSettings",
+				type: "bit",
+				nullable: false,
+				defaultValue: false);
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			if (migrationBuilder == null)
+				throw new ArgumentNullException(nameof(migrationBuilder));
+
+			migrationBuilder.DropColumn(
+				name: "LogOutput",
+				table: "DreamDaemonSettings");
+		}
+	}
+}

--- a/src/Tgstation.Server.Host/Database/Migrations/20230331220938_MYAddDreamDaemonLogOutput.Designer.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20230331220938_MYAddDreamDaemonLogOutput.Designer.cs
@@ -3,23 +3,23 @@ using System;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
 namespace Tgstation.Server.Host.Database.Migrations
 {
-	[DbContext(typeof(PostgresSqlDatabaseContext))]
-	partial class PostgresSqlDatabaseContextModelSnapshot : ModelSnapshot
+	[DbContext(typeof(MySqlDatabaseContext))]
+	[Migration("20230331220938_MYAddDreamDaemonLogOutput")]
+	partial class MYAddDreamDaemonLogOutput
 	{
 		/// <inheritdoc />
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder
 				.HasAnnotation("ProductVersion", "6.0.15")
-				.HasAnnotation("Relational:MaxIdentifierLength", 63);
-
-			NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
+				.HasAnnotation("Relational:MaxIdentifierLength", 64);
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.ChatBot", b =>
 			{
@@ -27,18 +27,17 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
-
-				b.Property<int>("ChannelLimit")
-					.HasColumnType("integer");
+				b.Property<ushort?>("ChannelLimit")
+					.IsRequired()
+					.HasColumnType("smallint unsigned");
 
 				b.Property<string>("ConnectionString")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("varchar(10000)");
 
 				b.Property<bool?>("Enabled")
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
@@ -46,13 +45,14 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("varchar(100)");
 
 				b.Property<int>("Provider")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
-				b.Property<long>("ReconnectionInterval")
-					.HasColumnType("bigint");
+				b.Property<uint?>("ReconnectionInterval")
+					.IsRequired()
+					.HasColumnType("int unsigned");
 
 				b.HasKey("Id");
 
@@ -68,33 +68,31 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
-
 				b.Property<long>("ChatSettingsId")
 					.HasColumnType("bigint");
 
-				b.Property<decimal?>("DiscordChannelId")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong?>("DiscordChannelId")
+					.HasColumnType("bigint unsigned");
 
 				b.Property<string>("IrcChannel")
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("varchar(100)");
 
 				b.Property<bool?>("IsAdminChannel")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("IsUpdatesChannel")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("IsWatchdogChannel")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<string>("Tag")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("varchar(10000)");
 
 				b.HasKey("Id");
 
@@ -113,31 +111,29 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
-
 				b.Property<string>("ByondVersion")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("longtext");
 
 				b.Property<int?>("DMApiMajorVersion")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int?>("DMApiMinorVersion")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int?>("DMApiPatchVersion")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<Guid?>("DirectoryName")
 					.IsRequired()
-					.HasColumnType("uuid");
+					.HasColumnType("char(36)");
 
 				b.Property<string>("DmeName")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("longtext");
 
 				b.Property<int?>("GitHubDeploymentId")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<long?>("GitHubRepoId")
 					.HasColumnType("bigint");
@@ -146,14 +142,14 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasColumnType("bigint");
 
 				b.Property<int?>("MinimumSecurityLevel")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<string>("Output")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("longtext");
 
 				b.Property<string>("RepositoryOrigin")
-					.HasColumnType("text");
+					.HasColumnType("longtext");
 
 				b.Property<long>("RevisionInformationId")
 					.HasColumnType("bigint");
@@ -176,53 +172,55 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
-
 				b.Property<string>("AdditionalParameters")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("varchar(10000)");
 
 				b.Property<bool?>("AllowWebClient")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("AutoStart")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("DumpOnHeartbeatRestart")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
-				b.Property<long>("HeartbeatSeconds")
-					.HasColumnType("bigint");
+				b.Property<uint?>("HeartbeatSeconds")
+					.IsRequired()
+					.HasColumnType("int unsigned");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
 				b.Property<bool?>("LogOutput")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
-				b.Property<int>("Port")
-					.HasColumnType("integer");
+				b.Property<ushort?>("Port")
+					.IsRequired()
+					.HasColumnType("smallint unsigned");
 
 				b.Property<int>("SecurityLevel")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<bool?>("StartProfiler")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
-				b.Property<long>("StartupTimeout")
-					.HasColumnType("bigint");
+				b.Property<uint?>("StartupTimeout")
+					.IsRequired()
+					.HasColumnType("int unsigned");
 
-				b.Property<long>("TopicRequestTimeout")
-					.HasColumnType("bigint");
+				b.Property<uint?>("TopicRequestTimeout")
+					.IsRequired()
+					.HasColumnType("int unsigned");
 
 				b.Property<int>("Visibility")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.HasKey("Id");
 
@@ -238,28 +236,27 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
-
-				b.Property<int>("ApiValidationPort")
-					.HasColumnType("integer");
+				b.Property<ushort?>("ApiValidationPort")
+					.IsRequired()
+					.HasColumnType("smallint unsigned");
 
 				b.Property<int>("ApiValidationSecurityLevel")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
 				b.Property<string>("ProjectName")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("varchar(10000)");
 
 				b.Property<bool?>("RequireDMApiValidation")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<TimeSpan?>("Timeout")
 					.IsRequired()
-					.HasColumnType("interval");
+					.HasColumnType("time(6)");
 
 				b.HasKey("Id");
 
@@ -275,32 +272,32 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				b.Property<uint?>("AutoUpdateInterval")
+					.IsRequired()
+					.HasColumnType("int unsigned");
 
-				b.Property<long>("AutoUpdateInterval")
-					.HasColumnType("bigint");
-
-				b.Property<int>("ChatBotLimit")
-					.HasColumnType("integer");
+				b.Property<ushort?>("ChatBotLimit")
+					.IsRequired()
+					.HasColumnType("smallint unsigned");
 
 				b.Property<int>("ConfigurationType")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("varchar(100)");
 
 				b.Property<bool?>("Online")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<string>("Path")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("varchar(255)");
 
 				b.Property<string>("SwarmIdentifer")
-					.HasColumnType("text");
+					.HasColumnType("varchar(255)");
 
 				b.HasKey("Id");
 
@@ -316,34 +313,32 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				b.Property<ulong>("ByondRights")
+					.HasColumnType("bigint unsigned");
 
-				b.Property<decimal>("ByondRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("ChatBotRights")
+					.HasColumnType("bigint unsigned");
 
-				b.Property<decimal>("ChatBotRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("ConfigurationRights")
+					.HasColumnType("bigint unsigned");
 
-				b.Property<decimal>("ConfigurationRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("DreamDaemonRights")
+					.HasColumnType("bigint unsigned");
 
-				b.Property<decimal>("DreamDaemonRights")
-					.HasColumnType("numeric(20,0)");
-
-				b.Property<decimal>("DreamMakerRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("DreamMakerRights")
+					.HasColumnType("bigint unsigned");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
-				b.Property<decimal>("InstancePermissionSetRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("InstancePermissionSetRights")
+					.HasColumnType("bigint unsigned");
 
 				b.Property<long>("PermissionSetId")
 					.HasColumnType("bigint");
 
-				b.Property<decimal>("RepositoryRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("RepositoryRights")
+					.HasColumnType("bigint unsigned");
 
 				b.HasKey("Id");
 
@@ -361,43 +356,41 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				b.Property<ulong?>("CancelRight")
+					.HasColumnType("bigint unsigned");
 
-				b.Property<decimal?>("CancelRight")
-					.HasColumnType("numeric(20,0)");
-
-				b.Property<decimal?>("CancelRightsType")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong?>("CancelRightsType")
+					.HasColumnType("bigint unsigned");
 
 				b.Property<bool?>("Cancelled")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<long?>("CancelledById")
 					.HasColumnType("bigint");
 
 				b.Property<string>("Description")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("longtext");
 
-				b.Property<long?>("ErrorCode")
-					.HasColumnType("bigint");
+				b.Property<uint?>("ErrorCode")
+					.HasColumnType("int unsigned");
 
 				b.Property<string>("ExceptionDetails")
-					.HasColumnType("text");
+					.HasColumnType("longtext");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
 				b.Property<DateTimeOffset?>("StartedAt")
 					.IsRequired()
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("datetime(6)");
 
 				b.Property<long>("StartedById")
 					.HasColumnType("bigint");
 
 				b.Property<DateTimeOffset?>("StoppedAt")
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("datetime(6)");
 
 				b.HasKey("Id");
 
@@ -416,15 +409,13 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
-
 				b.Property<string>("ExternalUserId")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("varchar(100)");
 
 				b.Property<int>("Provider")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<long?>("UserId")
 					.HasColumnType("bigint");
@@ -445,16 +436,14 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
-
-				b.Property<decimal>("AdministrationRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("AdministrationRights")
+					.HasColumnType("bigint unsigned");
 
 				b.Property<long?>("GroupId")
 					.HasColumnType("bigint");
 
-				b.Property<decimal>("InstanceManagerRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("InstanceManagerRights")
+					.HasColumnType("bigint unsigned");
 
 				b.Property<long?>("UserId")
 					.HasColumnType("bigint");
@@ -476,29 +465,27 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
-
 				b.Property<string>("AccessIdentifier")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("longtext");
 
 				b.Property<long>("CompileJobId")
 					.HasColumnType("bigint");
 
 				b.Property<int>("LaunchSecurityLevel")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int>("LaunchVisibility")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
-				b.Property<int>("Port")
-					.HasColumnType("integer");
+				b.Property<ushort>("Port")
+					.HasColumnType("smallint unsigned");
 
 				b.Property<int>("ProcessId")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int>("RebootState")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.HasKey("Id");
 
@@ -513,56 +500,54 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
-
 				b.Property<string>("AccessToken")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("varchar(10000)");
 
 				b.Property<string>("AccessUser")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("varchar(10000)");
 
 				b.Property<bool?>("AutoUpdatesKeepTestMerges")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("AutoUpdatesSynchronize")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<string>("CommitterEmail")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("varchar(10000)");
 
 				b.Property<string>("CommitterName")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("varchar(10000)");
 
 				b.Property<bool?>("CreateGitHubDeployments")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
 				b.Property<bool?>("PostTestMergeComment")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("PushTestMergeCommits")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("ShowTestMergeCommitters")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("UpdateSubmodules")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.HasKey("Id");
 
@@ -577,8 +562,6 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
-
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
 
 				b.Property<long>("RevisionInformationId")
 					.HasColumnType("bigint");
@@ -601,12 +584,10 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
-
 				b.Property<string>("CommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("character varying(40)");
+					.HasColumnType("varchar(40)");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
@@ -614,10 +595,10 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.Property<string>("OriginCommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("character varying(40)");
+					.HasColumnType("varchar(40)");
 
 				b.Property<DateTimeOffset>("Timestamp")
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("datetime(6)");
 
 				b.HasKey("Id");
 
@@ -633,28 +614,26 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
-
 				b.Property<string>("Author")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("longtext");
 
 				b.Property<string>("BodyAtMerge")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("longtext");
 
 				b.Property<string>("Comment")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("varchar(10000)");
 
 				b.Property<DateTimeOffset>("MergedAt")
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("datetime(6)");
 
 				b.Property<long>("MergedById")
 					.HasColumnType("bigint");
 
 				b.Property<int>("Number")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<long?>("PrimaryRevisionInformationId")
 					.IsRequired()
@@ -663,15 +642,15 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.Property<string>("TargetCommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("character varying(40)");
+					.HasColumnType("varchar(40)");
 
 				b.Property<string>("TitleAtMerge")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("longtext");
 
 				b.Property<string>("Url")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("longtext");
 
 				b.HasKey("Id");
 
@@ -689,41 +668,39 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
-
 				b.Property<string>("CanonicalName")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("varchar(100)");
 
 				b.Property<DateTimeOffset?>("CreatedAt")
 					.IsRequired()
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("datetime(6)");
 
 				b.Property<long?>("CreatedById")
 					.HasColumnType("bigint");
 
 				b.Property<bool?>("Enabled")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<long?>("GroupId")
 					.HasColumnType("bigint");
 
 				b.Property<DateTimeOffset?>("LastPasswordUpdate")
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("datetime(6)");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("varchar(100)");
 
 				b.Property<string>("PasswordHash")
-					.HasColumnType("text");
+					.HasColumnType("longtext");
 
 				b.Property<string>("SystemIdentifier")
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("varchar(100)");
 
 				b.HasKey("Id");
 
@@ -746,12 +723,10 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
-
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("varchar(100)");
 
 				b.HasKey("Id");
 

--- a/src/Tgstation.Server.Host/Database/Migrations/20230331220938_MYAddDreamDaemonLogOutput.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20230331220938_MYAddDreamDaemonLogOutput.cs
@@ -1,0 +1,388 @@
+﻿using System;
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tgstation.Server.Host.Database.Migrations
+{
+	/// <summary>
+	/// Adds the DreamDaemon LogOutput column for MYSQL. Also corrects string column annotations.
+	/// </summary>
+	public partial class MYAddDreamDaemonLogOutput : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			if (migrationBuilder == null)
+				throw new ArgumentNullException(nameof(migrationBuilder));
+
+			migrationBuilder.AlterColumn<string>(
+				name: "Comment",
+				table: "TestMerges",
+				type: "varchar(10000)",
+				maxLength: 10000,
+				nullable: true,
+				oldClrType: typeof(string),
+				oldType: "longtext CHARACTER SET utf8mb4",
+				oldMaxLength: 10000,
+				oldNullable: true)
+				.Annotation("MySql:CharSet", "utf8mb4")
+				.OldAnnotation("MySql:CharSet", "utf8mb4");
+
+			migrationBuilder.AlterColumn<string>(
+				name: "CommitterName",
+				table: "RepositorySettings",
+				type: "varchar(10000)",
+				maxLength: 10000,
+				nullable: false,
+				oldClrType: typeof(string),
+				oldType: "longtext CHARACTER SET utf8mb4",
+				oldMaxLength: 10000)
+				.Annotation("MySql:CharSet", "utf8mb4")
+				.OldAnnotation("MySql:CharSet", "utf8mb4");
+
+			migrationBuilder.AlterColumn<string>(
+				name: "CommitterEmail",
+				table: "RepositorySettings",
+				type: "varchar(10000)",
+				maxLength: 10000,
+				nullable: false,
+				oldClrType: typeof(string),
+				oldType: "longtext CHARACTER SET utf8mb4",
+				oldMaxLength: 10000)
+				.Annotation("MySql:CharSet", "utf8mb4")
+				.OldAnnotation("MySql:CharSet", "utf8mb4");
+
+			migrationBuilder.AlterColumn<string>(
+				name: "AccessUser",
+				table: "RepositorySettings",
+				type: "varchar(10000)",
+				maxLength: 10000,
+				nullable: true,
+				oldClrType: typeof(string),
+				oldType: "longtext CHARACTER SET utf8mb4",
+				oldMaxLength: 10000,
+				oldNullable: true)
+				.Annotation("MySql:CharSet", "utf8mb4")
+				.OldAnnotation("MySql:CharSet", "utf8mb4");
+
+			migrationBuilder.AlterColumn<string>(
+				name: "AccessToken",
+				table: "RepositorySettings",
+				type: "varchar(10000)",
+				maxLength: 10000,
+				nullable: true,
+				oldClrType: typeof(string),
+				oldType: "longtext CHARACTER SET utf8mb4",
+				oldMaxLength: 10000,
+				oldNullable: true)
+				.Annotation("MySql:CharSet", "utf8mb4")
+				.OldAnnotation("MySql:CharSet", "utf8mb4");
+
+			migrationBuilder.AlterColumn<string>(
+				name: "ProjectName",
+				table: "DreamMakerSettings",
+				type: "varchar(10000)",
+				maxLength: 10000,
+				nullable: true,
+				oldClrType: typeof(string),
+				oldType: "longtext CHARACTER SET utf8mb4",
+				oldMaxLength: 10000,
+				oldNullable: true)
+				.Annotation("MySql:CharSet", "utf8mb4")
+				.OldAnnotation("MySql:CharSet", "utf8mb4");
+
+			migrationBuilder.AlterColumn<string>(
+				name: "AdditionalParameters",
+				table: "DreamDaemonSettings",
+				type: "varchar(10000)",
+				maxLength: 10000,
+				nullable: false,
+				oldClrType: typeof(string),
+				oldType: "longtext CHARACTER SET utf8mb4",
+				oldMaxLength: 10000)
+				.Annotation("MySql:CharSet", "utf8mb4")
+				.OldAnnotation("MySql:CharSet", "utf8mb4");
+
+			migrationBuilder.AddColumn<bool>(
+				name: "LogOutput",
+				table: "DreamDaemonSettings",
+				type: "tinyint(1)",
+				nullable: false,
+				defaultValue: false);
+
+			migrationBuilder.AlterColumn<string>(
+				name: "Tag",
+				table: "ChatChannels",
+				type: "varchar(10000)",
+				maxLength: 10000,
+				nullable: true,
+				oldClrType: typeof(string),
+				oldType: "longtext CHARACTER SET utf8mb4",
+				oldMaxLength: 10000,
+				oldNullable: true)
+				.Annotation("MySql:CharSet", "utf8mb4")
+				.OldAnnotation("MySql:CharSet", "utf8mb4");
+
+			migrationBuilder.AlterColumn<string>(
+				name: "ConnectionString",
+				table: "ChatBots",
+				type: "varchar(10000)",
+				maxLength: 10000,
+				nullable: false,
+				oldClrType: typeof(string),
+				oldType: "longtext CHARACTER SET utf8mb4",
+				oldMaxLength: 10000)
+				.Annotation("MySql:CharSet", "utf8mb4")
+				.OldAnnotation("MySql:CharSet", "utf8mb4");
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			if (migrationBuilder == null)
+				throw new ArgumentNullException(nameof(migrationBuilder));
+
+			migrationBuilder.DropColumn(
+				name: "LogOutput",
+				table: "DreamDaemonSettings");
+
+			migrationBuilder.AlterColumn<string>(
+				name: "PasswordHash",
+				table: "Users",
+				type: "longtext CHARACTER SET utf8mb4",
+				nullable: true,
+				oldClrType: typeof(string),
+				oldType: "longtext",
+				oldNullable: true)
+				.Annotation("MySql:CharSet", "utf8mb4")
+				.OldAnnotation("MySql:CharSet", "utf8mb4");
+
+			migrationBuilder.AlterColumn<string>(
+				name: "Url",
+				table: "TestMerges",
+				type: "longtext CHARACTER SET utf8mb4",
+				nullable: false,
+				oldClrType: typeof(string),
+				oldType: "longtext")
+				.Annotation("MySql:CharSet", "utf8mb4")
+				.OldAnnotation("MySql:CharSet", "utf8mb4");
+
+			migrationBuilder.AlterColumn<string>(
+				name: "TitleAtMerge",
+				table: "TestMerges",
+				type: "longtext CHARACTER SET utf8mb4",
+				nullable: false,
+				oldClrType: typeof(string),
+				oldType: "longtext")
+				.Annotation("MySql:CharSet", "utf8mb4")
+				.OldAnnotation("MySql:CharSet", "utf8mb4");
+
+			migrationBuilder.AlterColumn<string>(
+				name: "Comment",
+				table: "TestMerges",
+				type: "longtext CHARACTER SET utf8mb4",
+				maxLength: 10000,
+				nullable: true,
+				oldClrType: typeof(string),
+				oldType: "varchar(10000)",
+				oldMaxLength: 10000,
+				oldNullable: true)
+				.Annotation("MySql:CharSet", "utf8mb4")
+				.OldAnnotation("MySql:CharSet", "utf8mb4");
+
+			migrationBuilder.AlterColumn<string>(
+				name: "BodyAtMerge",
+				table: "TestMerges",
+				type: "longtext CHARACTER SET utf8mb4",
+				nullable: false,
+				oldClrType: typeof(string),
+				oldType: "longtext")
+				.Annotation("MySql:CharSet", "utf8mb4")
+				.OldAnnotation("MySql:CharSet", "utf8mb4");
+
+			migrationBuilder.AlterColumn<string>(
+				name: "Author",
+				table: "TestMerges",
+				type: "longtext CHARACTER SET utf8mb4",
+				nullable: false,
+				oldClrType: typeof(string),
+				oldType: "longtext")
+				.Annotation("MySql:CharSet", "utf8mb4")
+				.OldAnnotation("MySql:CharSet", "utf8mb4");
+
+			migrationBuilder.AlterColumn<string>(
+				name: "CommitterName",
+				table: "RepositorySettings",
+				type: "longtext CHARACTER SET utf8mb4",
+				maxLength: 10000,
+				nullable: false,
+				oldClrType: typeof(string),
+				oldType: "varchar(10000)",
+				oldMaxLength: 10000)
+				.Annotation("MySql:CharSet", "utf8mb4")
+				.OldAnnotation("MySql:CharSet", "utf8mb4");
+
+			migrationBuilder.AlterColumn<string>(
+				name: "CommitterEmail",
+				table: "RepositorySettings",
+				type: "longtext CHARACTER SET utf8mb4",
+				maxLength: 10000,
+				nullable: false,
+				oldClrType: typeof(string),
+				oldType: "varchar(10000)",
+				oldMaxLength: 10000)
+				.Annotation("MySql:CharSet", "utf8mb4")
+				.OldAnnotation("MySql:CharSet", "utf8mb4");
+
+			migrationBuilder.AlterColumn<string>(
+				name: "AccessUser",
+				table: "RepositorySettings",
+				type: "longtext CHARACTER SET utf8mb4",
+				maxLength: 10000,
+				nullable: true,
+				oldClrType: typeof(string),
+				oldType: "varchar(10000)",
+				oldMaxLength: 10000,
+				oldNullable: true)
+				.Annotation("MySql:CharSet", "utf8mb4")
+				.OldAnnotation("MySql:CharSet", "utf8mb4");
+
+			migrationBuilder.AlterColumn<string>(
+				name: "AccessToken",
+				table: "RepositorySettings",
+				type: "longtext CHARACTER SET utf8mb4",
+				maxLength: 10000,
+				nullable: true,
+				oldClrType: typeof(string),
+				oldType: "varchar(10000)",
+				oldMaxLength: 10000,
+				oldNullable: true)
+				.Annotation("MySql:CharSet", "utf8mb4")
+				.OldAnnotation("MySql:CharSet", "utf8mb4");
+
+			migrationBuilder.AlterColumn<string>(
+				name: "AccessIdentifier",
+				table: "ReattachInformations",
+				type: "longtext CHARACTER SET utf8mb4",
+				nullable: false,
+				oldClrType: typeof(string),
+				oldType: "longtext")
+				.Annotation("MySql:CharSet", "utf8mb4")
+				.OldAnnotation("MySql:CharSet", "utf8mb4");
+
+			migrationBuilder.AlterColumn<string>(
+				name: "ExceptionDetails",
+				table: "Jobs",
+				type: "longtext CHARACTER SET utf8mb4",
+				nullable: true,
+				oldClrType: typeof(string),
+				oldType: "longtext",
+				oldNullable: true)
+				.Annotation("MySql:CharSet", "utf8mb4")
+				.OldAnnotation("MySql:CharSet", "utf8mb4");
+
+			migrationBuilder.AlterColumn<string>(
+				name: "Description",
+				table: "Jobs",
+				type: "longtext CHARACTER SET utf8mb4",
+				nullable: false,
+				oldClrType: typeof(string),
+				oldType: "longtext")
+				.Annotation("MySql:CharSet", "utf8mb4")
+				.OldAnnotation("MySql:CharSet", "utf8mb4");
+
+			migrationBuilder.AlterColumn<string>(
+				name: "ProjectName",
+				table: "DreamMakerSettings",
+				type: "longtext CHARACTER SET utf8mb4",
+				maxLength: 10000,
+				nullable: true,
+				oldClrType: typeof(string),
+				oldType: "varchar(10000)",
+				oldMaxLength: 10000,
+				oldNullable: true)
+				.Annotation("MySql:CharSet", "utf8mb4")
+				.OldAnnotation("MySql:CharSet", "utf8mb4");
+
+			migrationBuilder.AlterColumn<string>(
+				name: "AdditionalParameters",
+				table: "DreamDaemonSettings",
+				type: "longtext CHARACTER SET utf8mb4",
+				maxLength: 10000,
+				nullable: false,
+				oldClrType: typeof(string),
+				oldType: "varchar(10000)",
+				oldMaxLength: 10000)
+				.Annotation("MySql:CharSet", "utf8mb4")
+				.OldAnnotation("MySql:CharSet", "utf8mb4");
+
+			migrationBuilder.AlterColumn<string>(
+				name: "RepositoryOrigin",
+				table: "CompileJobs",
+				type: "longtext CHARACTER SET utf8mb4",
+				nullable: true,
+				oldClrType: typeof(string),
+				oldType: "longtext",
+				oldNullable: true)
+				.Annotation("MySql:CharSet", "utf8mb4")
+				.OldAnnotation("MySql:CharSet", "utf8mb4");
+
+			migrationBuilder.AlterColumn<string>(
+				name: "Output",
+				table: "CompileJobs",
+				type: "longtext CHARACTER SET utf8mb4",
+				nullable: false,
+				oldClrType: typeof(string),
+				oldType: "longtext")
+				.Annotation("MySql:CharSet", "utf8mb4")
+				.OldAnnotation("MySql:CharSet", "utf8mb4");
+
+			migrationBuilder.AlterColumn<string>(
+				name: "DmeName",
+				table: "CompileJobs",
+				type: "longtext CHARACTER SET utf8mb4",
+				nullable: false,
+				oldClrType: typeof(string),
+				oldType: "longtext")
+				.Annotation("MySql:CharSet", "utf8mb4")
+				.OldAnnotation("MySql:CharSet", "utf8mb4");
+
+			migrationBuilder.AlterColumn<string>(
+				name: "ByondVersion",
+				table: "CompileJobs",
+				type: "longtext CHARACTER SET utf8mb4",
+				nullable: false,
+				oldClrType: typeof(string),
+				oldType: "longtext")
+				.Annotation("MySql:CharSet", "utf8mb4")
+				.OldAnnotation("MySql:CharSet", "utf8mb4");
+
+			migrationBuilder.AlterColumn<string>(
+				name: "Tag",
+				table: "ChatChannels",
+				type: "longtext CHARACTER SET utf8mb4",
+				maxLength: 10000,
+				nullable: true,
+				oldClrType: typeof(string),
+				oldType: "varchar(10000)",
+				oldMaxLength: 10000,
+				oldNullable: true)
+				.Annotation("MySql:CharSet", "utf8mb4")
+				.OldAnnotation("MySql:CharSet", "utf8mb4");
+
+			migrationBuilder.AlterColumn<string>(
+				name: "ConnectionString",
+				table: "ChatBots",
+				type: "longtext CHARACTER SET utf8mb4",
+				maxLength: 10000,
+				nullable: false,
+				oldClrType: typeof(string),
+				oldType: "varchar(10000)",
+				oldMaxLength: 10000)
+				.Annotation("MySql:CharSet", "utf8mb4")
+				.OldAnnotation("MySql:CharSet", "utf8mb4");
+		}
+	}
+}

--- a/src/Tgstation.Server.Host/Database/Migrations/20230331221032_PGAddDreamDaemonLogOutput.Designer.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20230331221032_PGAddDreamDaemonLogOutput.Designer.cs
@@ -3,16 +3,18 @@ using System;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
 namespace Tgstation.Server.Host.Database.Migrations
 {
 	[DbContext(typeof(PostgresSqlDatabaseContext))]
-	partial class PostgresSqlDatabaseContextModelSnapshot : ModelSnapshot
+	[Migration("20230331221032_PGAddDreamDaemonLogOutput")]
+	partial class PGAddDreamDaemonLogOutput
 	{
 		/// <inheritdoc />
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder

--- a/src/Tgstation.Server.Host/Database/Migrations/20230331221032_PGAddDreamDaemonLogOutput.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20230331221032_PGAddDreamDaemonLogOutput.cs
@@ -1,0 +1,39 @@
+﻿using System;
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tgstation.Server.Host.Database.Migrations
+{
+	/// <summary>
+	/// Adds the DreamDaemon LogOutput column for PostgresSQL.
+	/// </summary>
+	public partial class PGAddDreamDaemonLogOutput : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			if (migrationBuilder == null)
+				throw new ArgumentNullException(nameof(migrationBuilder));
+
+			migrationBuilder.AddColumn<bool>(
+				name: "LogOutput",
+				table: "DreamDaemonSettings",
+				type: "boolean",
+				nullable: false,
+				defaultValue: false);
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			if (migrationBuilder == null)
+				throw new ArgumentNullException(nameof(migrationBuilder));
+
+			migrationBuilder.DropColumn(
+				name: "LogOutput",
+				table: "DreamDaemonSettings");
+		}
+	}
+}

--- a/src/Tgstation.Server.Host/Database/Migrations/20230331221156_SLAddDreamDaemonLogOutput.Designer.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20230331221156_SLAddDreamDaemonLogOutput.Designer.cs
@@ -3,56 +3,54 @@ using System;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
 namespace Tgstation.Server.Host.Database.Migrations
 {
-	[DbContext(typeof(PostgresSqlDatabaseContext))]
-	partial class PostgresSqlDatabaseContextModelSnapshot : ModelSnapshot
+	[DbContext(typeof(SqliteDatabaseContext))]
+	[Migration("20230331221156_SLAddDreamDaemonLogOutput")]
+	partial class SLAddDreamDaemonLogOutput
 	{
 		/// <inheritdoc />
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
-			modelBuilder
-				.HasAnnotation("ProductVersion", "6.0.15")
-				.HasAnnotation("Relational:MaxIdentifierLength", 63);
-
-			NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
+			modelBuilder.HasAnnotation("ProductVersion", "6.0.15");
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.ChatBot", b =>
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
-
-				b.Property<int>("ChannelLimit")
-					.HasColumnType("integer");
+				b.Property<ushort?>("ChannelLimit")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("ConnectionString")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("TEXT");
 
 				b.Property<bool?>("Enabled")
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("TEXT");
 
 				b.Property<int>("Provider")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
-				b.Property<long>("ReconnectionInterval")
-					.HasColumnType("bigint");
+				b.Property<uint?>("ReconnectionInterval")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
 				b.HasKey("Id");
 
@@ -66,35 +64,33 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("ChatSettingsId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
-				b.Property<decimal?>("DiscordChannelId")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong?>("DiscordChannelId")
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("IrcChannel")
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("TEXT");
 
 				b.Property<bool?>("IsAdminChannel")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("IsUpdatesChannel")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("IsWatchdogChannel")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("Tag")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("TEXT");
 
 				b.HasKey("Id");
 
@@ -111,52 +107,50 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("ByondVersion")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
 				b.Property<int?>("DMApiMajorVersion")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
 				b.Property<int?>("DMApiMinorVersion")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
 				b.Property<int?>("DMApiPatchVersion")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
 				b.Property<Guid?>("DirectoryName")
 					.IsRequired()
-					.HasColumnType("uuid");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("DmeName")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
 				b.Property<int?>("GitHubDeploymentId")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
 				b.Property<long?>("GitHubRepoId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("JobId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<int?>("MinimumSecurityLevel")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("Output")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("RepositoryOrigin")
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
 				b.Property<long>("RevisionInformationId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.HasKey("Id");
 
@@ -174,55 +168,57 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("AdditionalParameters")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("TEXT");
 
 				b.Property<bool?>("AllowWebClient")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("AutoStart")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("DumpOnHeartbeatRestart")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
-				b.Property<long>("HeartbeatSeconds")
-					.HasColumnType("bigint");
+				b.Property<uint?>("HeartbeatSeconds")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("LogOutput")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
-				b.Property<int>("Port")
-					.HasColumnType("integer");
+				b.Property<ushort?>("Port")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
 				b.Property<int>("SecurityLevel")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("StartProfiler")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
-				b.Property<long>("StartupTimeout")
-					.HasColumnType("bigint");
+				b.Property<uint?>("StartupTimeout")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
-				b.Property<long>("TopicRequestTimeout")
-					.HasColumnType("bigint");
+				b.Property<uint?>("TopicRequestTimeout")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
 				b.Property<int>("Visibility")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
 				b.HasKey("Id");
 
@@ -236,30 +232,29 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
-
-				b.Property<int>("ApiValidationPort")
-					.HasColumnType("integer");
+				b.Property<ushort?>("ApiValidationPort")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
 				b.Property<int>("ApiValidationSecurityLevel")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("ProjectName")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("TEXT");
 
 				b.Property<bool?>("RequireDMApiValidation")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<TimeSpan?>("Timeout")
 					.IsRequired()
-					.HasColumnType("interval");
+					.HasColumnType("TEXT");
 
 				b.HasKey("Id");
 
@@ -273,34 +268,34 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				b.Property<uint?>("AutoUpdateInterval")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
-				b.Property<long>("AutoUpdateInterval")
-					.HasColumnType("bigint");
-
-				b.Property<int>("ChatBotLimit")
-					.HasColumnType("integer");
+				b.Property<ushort?>("ChatBotLimit")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
 				b.Property<int>("ConfigurationType")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("TEXT");
 
 				b.Property<bool?>("Online")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("Path")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("SwarmIdentifer")
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
 				b.HasKey("Id");
 
@@ -314,36 +309,34 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				b.Property<ulong>("ByondRights")
+					.HasColumnType("INTEGER");
 
-				b.Property<decimal>("ByondRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("ChatBotRights")
+					.HasColumnType("INTEGER");
 
-				b.Property<decimal>("ChatBotRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("ConfigurationRights")
+					.HasColumnType("INTEGER");
 
-				b.Property<decimal>("ConfigurationRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("DreamDaemonRights")
+					.HasColumnType("INTEGER");
 
-				b.Property<decimal>("DreamDaemonRights")
-					.HasColumnType("numeric(20,0)");
-
-				b.Property<decimal>("DreamMakerRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("DreamMakerRights")
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
-				b.Property<decimal>("InstancePermissionSetRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("InstancePermissionSetRights")
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("PermissionSetId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
-				b.Property<decimal>("RepositoryRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("RepositoryRights")
+					.HasColumnType("INTEGER");
 
 				b.HasKey("Id");
 
@@ -359,45 +352,43 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				b.Property<ulong?>("CancelRight")
+					.HasColumnType("INTEGER");
 
-				b.Property<decimal?>("CancelRight")
-					.HasColumnType("numeric(20,0)");
-
-				b.Property<decimal?>("CancelRightsType")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong?>("CancelRightsType")
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("Cancelled")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<long?>("CancelledById")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("Description")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
-				b.Property<long?>("ErrorCode")
-					.HasColumnType("bigint");
+				b.Property<uint?>("ErrorCode")
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("ExceptionDetails")
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<DateTimeOffset?>("StartedAt")
 					.IsRequired()
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("TEXT");
 
 				b.Property<long>("StartedById")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<DateTimeOffset?>("StoppedAt")
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("TEXT");
 
 				b.HasKey("Id");
 
@@ -414,20 +405,18 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("ExternalUserId")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("TEXT");
 
 				b.Property<int>("Provider")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
 				b.Property<long?>("UserId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.HasKey("Id");
 
@@ -443,21 +432,19 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
-
-				b.Property<decimal>("AdministrationRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("AdministrationRights")
+					.HasColumnType("INTEGER");
 
 				b.Property<long?>("GroupId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
-				b.Property<decimal>("InstanceManagerRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("InstanceManagerRights")
+					.HasColumnType("INTEGER");
 
 				b.Property<long?>("UserId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.HasKey("Id");
 
@@ -474,31 +461,29 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("AccessIdentifier")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
 				b.Property<long>("CompileJobId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<int>("LaunchSecurityLevel")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
 				b.Property<int>("LaunchVisibility")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
-				b.Property<int>("Port")
-					.HasColumnType("integer");
+				b.Property<ushort>("Port")
+					.HasColumnType("INTEGER");
 
 				b.Property<int>("ProcessId")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
 				b.Property<int>("RebootState")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
 				b.HasKey("Id");
 
@@ -511,58 +496,56 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("AccessToken")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("AccessUser")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("TEXT");
 
 				b.Property<bool?>("AutoUpdatesKeepTestMerges")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("AutoUpdatesSynchronize")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("CommitterEmail")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("CommitterName")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("TEXT");
 
 				b.Property<bool?>("CreateGitHubDeployments")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("PostTestMergeComment")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("PushTestMergeCommits")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("ShowTestMergeCommitters")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("UpdateSubmodules")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.HasKey("Id");
 
@@ -576,15 +559,13 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("RevisionInformationId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("TestMergeId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.HasKey("Id");
 
@@ -599,25 +580,23 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("CommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("character varying(40)");
+					.HasColumnType("TEXT");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("OriginCommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("character varying(40)");
+					.HasColumnType("TEXT");
 
 				b.Property<DateTimeOffset>("Timestamp")
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("TEXT");
 
 				b.HasKey("Id");
 
@@ -631,47 +610,45 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("Author")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("BodyAtMerge")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("Comment")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("TEXT");
 
 				b.Property<DateTimeOffset>("MergedAt")
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("TEXT");
 
 				b.Property<long>("MergedById")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<int>("Number")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
 				b.Property<long?>("PrimaryRevisionInformationId")
 					.IsRequired()
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("TargetCommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("character varying(40)");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("TitleAtMerge")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("Url")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
 				b.HasKey("Id");
 
@@ -687,43 +664,41 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("CanonicalName")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("TEXT");
 
 				b.Property<DateTimeOffset?>("CreatedAt")
 					.IsRequired()
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("TEXT");
 
 				b.Property<long?>("CreatedById")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("Enabled")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<long?>("GroupId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<DateTimeOffset?>("LastPasswordUpdate")
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("PasswordHash")
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("SystemIdentifier")
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("TEXT");
 
 				b.HasKey("Id");
 
@@ -744,14 +719,12 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("TEXT");
 
 				b.HasKey("Id");
 
@@ -794,7 +767,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.HasOne("Tgstation.Server.Host.Models.RevisionInformation", "RevisionInformation")
 					.WithMany("CompileJobs")
 					.HasForeignKey("RevisionInformationId")
-					.OnDelete(DeleteBehavior.Cascade)
+					.OnDelete(DeleteBehavior.ClientNoAction)
 					.IsRequired();
 
 				b.Navigation("Job");

--- a/src/Tgstation.Server.Host/Database/Migrations/20230331221156_SLAddDreamDaemonLogOutput.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20230331221156_SLAddDreamDaemonLogOutput.cs
@@ -1,0 +1,39 @@
+﻿using System;
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tgstation.Server.Host.Database.Migrations
+{
+	/// <summary>
+	/// Adds the DreamDaemon LogOutput column for SQLite.
+	/// </summary>
+	public partial class SLAddDreamDaemonLogOutput : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			if (migrationBuilder == null)
+				throw new ArgumentNullException(nameof(migrationBuilder));
+
+			migrationBuilder.AddColumn<bool>(
+				name: "LogOutput",
+				table: "DreamDaemonSettings",
+				type: "INTEGER",
+				nullable: false,
+				defaultValue: false);
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			if (migrationBuilder == null)
+				throw new ArgumentNullException(nameof(migrationBuilder));
+
+			migrationBuilder.DropColumn(
+				name: "LogOutput",
+				table: "DreamDaemonSettings");
+		}
+	}
+}

--- a/src/Tgstation.Server.Host/Database/Migrations/20230401210715_MYAddDreamDaemonLogOutput.Designer.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20230401210715_MYAddDreamDaemonLogOutput.Designer.cs
@@ -10,7 +10,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 namespace Tgstation.Server.Host.Database.Migrations
 {
 	[DbContext(typeof(MySqlDatabaseContext))]
-	[Migration("20230331220938_MYAddDreamDaemonLogOutput")]
+	[Migration("20230401210715_MYAddDreamDaemonLogOutput")]
 	partial class MYAddDreamDaemonLogOutput
 	{
 		/// <inheritdoc />
@@ -34,7 +34,9 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.Property<string>("ConnectionString")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("varchar(10000)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("ConnectionString"), "utf8mb4");
 
 				b.Property<bool?>("Enabled")
 					.HasColumnType("tinyint(1)");
@@ -78,6 +80,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasMaxLength(100)
 					.HasColumnType("varchar(100)");
 
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("IrcChannel"), "utf8mb4");
+
 				b.Property<bool?>("IsAdminChannel")
 					.IsRequired()
 					.HasColumnType("tinyint(1)");
@@ -92,7 +96,9 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("Tag")
 					.HasMaxLength(10000)
-					.HasColumnType("varchar(10000)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Tag"), "utf8mb4");
 
 				b.HasKey("Id");
 
@@ -115,6 +121,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.IsRequired()
 					.HasColumnType("longtext");
 
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("ByondVersion"), "utf8mb4");
+
 				b.Property<int?>("DMApiMajorVersion")
 					.HasColumnType("int");
 
@@ -132,6 +140,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.IsRequired()
 					.HasColumnType("longtext");
 
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("DmeName"), "utf8mb4");
+
 				b.Property<int?>("GitHubDeploymentId")
 					.HasColumnType("int");
 
@@ -148,8 +158,12 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.IsRequired()
 					.HasColumnType("longtext");
 
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Output"), "utf8mb4");
+
 				b.Property<string>("RepositoryOrigin")
 					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("RepositoryOrigin"), "utf8mb4");
 
 				b.Property<long>("RevisionInformationId")
 					.HasColumnType("bigint");
@@ -175,7 +189,9 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.Property<string>("AdditionalParameters")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("varchar(10000)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("AdditionalParameters"), "utf8mb4");
 
 				b.Property<bool?>("AllowWebClient")
 					.IsRequired()
@@ -248,7 +264,9 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("ProjectName")
 					.HasMaxLength(10000)
-					.HasColumnType("varchar(10000)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("ProjectName"), "utf8mb4");
 
 				b.Property<bool?>("RequireDMApiValidation")
 					.IsRequired()
@@ -288,6 +306,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasMaxLength(100)
 					.HasColumnType("varchar(100)");
 
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Name"), "utf8mb4");
+
 				b.Property<bool?>("Online")
 					.IsRequired()
 					.HasColumnType("tinyint(1)");
@@ -296,8 +316,12 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.IsRequired()
 					.HasColumnType("varchar(255)");
 
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Path"), "utf8mb4");
+
 				b.Property<string>("SwarmIdentifer")
 					.HasColumnType("varchar(255)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("SwarmIdentifer"), "utf8mb4");
 
 				b.HasKey("Id");
 
@@ -373,11 +397,15 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.IsRequired()
 					.HasColumnType("longtext");
 
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Description"), "utf8mb4");
+
 				b.Property<uint?>("ErrorCode")
 					.HasColumnType("int unsigned");
 
 				b.Property<string>("ExceptionDetails")
 					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("ExceptionDetails"), "utf8mb4");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
@@ -413,6 +441,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.IsRequired()
 					.HasMaxLength(100)
 					.HasColumnType("varchar(100)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("ExternalUserId"), "utf8mb4");
 
 				b.Property<int>("Provider")
 					.HasColumnType("int");
@@ -469,6 +499,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.IsRequired()
 					.HasColumnType("longtext");
 
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("AccessIdentifier"), "utf8mb4");
+
 				b.Property<long>("CompileJobId")
 					.HasColumnType("bigint");
 
@@ -502,11 +534,15 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("AccessToken")
 					.HasMaxLength(10000)
-					.HasColumnType("varchar(10000)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("AccessToken"), "utf8mb4");
 
 				b.Property<string>("AccessUser")
 					.HasMaxLength(10000)
-					.HasColumnType("varchar(10000)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("AccessUser"), "utf8mb4");
 
 				b.Property<bool?>("AutoUpdatesKeepTestMerges")
 					.IsRequired()
@@ -519,12 +555,16 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.Property<string>("CommitterEmail")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("varchar(10000)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("CommitterEmail"), "utf8mb4");
 
 				b.Property<string>("CommitterName")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("varchar(10000)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("CommitterName"), "utf8mb4");
 
 				b.Property<bool?>("CreateGitHubDeployments")
 					.IsRequired()
@@ -589,6 +629,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasMaxLength(40)
 					.HasColumnType("varchar(40)");
 
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("CommitSha"), "utf8mb4");
+
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
@@ -596,6 +638,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.IsRequired()
 					.HasMaxLength(40)
 					.HasColumnType("varchar(40)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("OriginCommitSha"), "utf8mb4");
 
 				b.Property<DateTimeOffset>("Timestamp")
 					.HasColumnType("datetime(6)");
@@ -618,13 +662,19 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.IsRequired()
 					.HasColumnType("longtext");
 
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Author"), "utf8mb4");
+
 				b.Property<string>("BodyAtMerge")
 					.IsRequired()
 					.HasColumnType("longtext");
 
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("BodyAtMerge"), "utf8mb4");
+
 				b.Property<string>("Comment")
 					.HasMaxLength(10000)
-					.HasColumnType("varchar(10000)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Comment"), "utf8mb4");
 
 				b.Property<DateTimeOffset>("MergedAt")
 					.HasColumnType("datetime(6)");
@@ -644,13 +694,19 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasMaxLength(40)
 					.HasColumnType("varchar(40)");
 
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("TargetCommitSha"), "utf8mb4");
+
 				b.Property<string>("TitleAtMerge")
 					.IsRequired()
 					.HasColumnType("longtext");
 
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("TitleAtMerge"), "utf8mb4");
+
 				b.Property<string>("Url")
 					.IsRequired()
 					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Url"), "utf8mb4");
 
 				b.HasKey("Id");
 
@@ -672,6 +728,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.IsRequired()
 					.HasMaxLength(100)
 					.HasColumnType("varchar(100)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("CanonicalName"), "utf8mb4");
 
 				b.Property<DateTimeOffset?>("CreatedAt")
 					.IsRequired()
@@ -695,12 +753,18 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasMaxLength(100)
 					.HasColumnType("varchar(100)");
 
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Name"), "utf8mb4");
+
 				b.Property<string>("PasswordHash")
 					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("PasswordHash"), "utf8mb4");
 
 				b.Property<string>("SystemIdentifier")
 					.HasMaxLength(100)
 					.HasColumnType("varchar(100)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("SystemIdentifier"), "utf8mb4");
 
 				b.HasKey("Id");
 
@@ -727,6 +791,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.IsRequired()
 					.HasMaxLength(100)
 					.HasColumnType("varchar(100)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Name"), "utf8mb4");
 
 				b.HasKey("Id");
 

--- a/src/Tgstation.Server.Host/Database/Migrations/20230401210715_MYAddDreamDaemonLogOutput.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20230401210715_MYAddDreamDaemonLogOutput.cs
@@ -7,8 +7,9 @@ using Microsoft.EntityFrameworkCore.Migrations;
 namespace Tgstation.Server.Host.Database.Migrations
 {
 	/// <summary>
-	/// Adds the DreamDaemon LogOutput column for MYSQL. Also corrects string column annotations.
+	/// Adds the DreamDaemon LogOutput column for MYSQL.
 	/// </summary>
+	/// <remarks>Note the version upgrade of Pomelo caused some freakyness. The down migrations should be harmless here.</remarks>
 	public partial class MYAddDreamDaemonLogOutput : Migration
 	{
 		/// <inheritdoc />
@@ -17,125 +18,12 @@ namespace Tgstation.Server.Host.Database.Migrations
 			if (migrationBuilder == null)
 				throw new ArgumentNullException(nameof(migrationBuilder));
 
-			migrationBuilder.AlterColumn<string>(
-				name: "Comment",
-				table: "TestMerges",
-				type: "varchar(10000)",
-				maxLength: 10000,
-				nullable: true,
-				oldClrType: typeof(string),
-				oldType: "longtext CHARACTER SET utf8mb4",
-				oldMaxLength: 10000,
-				oldNullable: true)
-				.Annotation("MySql:CharSet", "utf8mb4")
-				.OldAnnotation("MySql:CharSet", "utf8mb4");
-
-			migrationBuilder.AlterColumn<string>(
-				name: "CommitterName",
-				table: "RepositorySettings",
-				type: "varchar(10000)",
-				maxLength: 10000,
-				nullable: false,
-				oldClrType: typeof(string),
-				oldType: "longtext CHARACTER SET utf8mb4",
-				oldMaxLength: 10000)
-				.Annotation("MySql:CharSet", "utf8mb4")
-				.OldAnnotation("MySql:CharSet", "utf8mb4");
-
-			migrationBuilder.AlterColumn<string>(
-				name: "CommitterEmail",
-				table: "RepositorySettings",
-				type: "varchar(10000)",
-				maxLength: 10000,
-				nullable: false,
-				oldClrType: typeof(string),
-				oldType: "longtext CHARACTER SET utf8mb4",
-				oldMaxLength: 10000)
-				.Annotation("MySql:CharSet", "utf8mb4")
-				.OldAnnotation("MySql:CharSet", "utf8mb4");
-
-			migrationBuilder.AlterColumn<string>(
-				name: "AccessUser",
-				table: "RepositorySettings",
-				type: "varchar(10000)",
-				maxLength: 10000,
-				nullable: true,
-				oldClrType: typeof(string),
-				oldType: "longtext CHARACTER SET utf8mb4",
-				oldMaxLength: 10000,
-				oldNullable: true)
-				.Annotation("MySql:CharSet", "utf8mb4")
-				.OldAnnotation("MySql:CharSet", "utf8mb4");
-
-			migrationBuilder.AlterColumn<string>(
-				name: "AccessToken",
-				table: "RepositorySettings",
-				type: "varchar(10000)",
-				maxLength: 10000,
-				nullable: true,
-				oldClrType: typeof(string),
-				oldType: "longtext CHARACTER SET utf8mb4",
-				oldMaxLength: 10000,
-				oldNullable: true)
-				.Annotation("MySql:CharSet", "utf8mb4")
-				.OldAnnotation("MySql:CharSet", "utf8mb4");
-
-			migrationBuilder.AlterColumn<string>(
-				name: "ProjectName",
-				table: "DreamMakerSettings",
-				type: "varchar(10000)",
-				maxLength: 10000,
-				nullable: true,
-				oldClrType: typeof(string),
-				oldType: "longtext CHARACTER SET utf8mb4",
-				oldMaxLength: 10000,
-				oldNullable: true)
-				.Annotation("MySql:CharSet", "utf8mb4")
-				.OldAnnotation("MySql:CharSet", "utf8mb4");
-
-			migrationBuilder.AlterColumn<string>(
-				name: "AdditionalParameters",
-				table: "DreamDaemonSettings",
-				type: "varchar(10000)",
-				maxLength: 10000,
-				nullable: false,
-				oldClrType: typeof(string),
-				oldType: "longtext CHARACTER SET utf8mb4",
-				oldMaxLength: 10000)
-				.Annotation("MySql:CharSet", "utf8mb4")
-				.OldAnnotation("MySql:CharSet", "utf8mb4");
-
 			migrationBuilder.AddColumn<bool>(
 				name: "LogOutput",
 				table: "DreamDaemonSettings",
 				type: "tinyint(1)",
 				nullable: false,
 				defaultValue: false);
-
-			migrationBuilder.AlterColumn<string>(
-				name: "Tag",
-				table: "ChatChannels",
-				type: "varchar(10000)",
-				maxLength: 10000,
-				nullable: true,
-				oldClrType: typeof(string),
-				oldType: "longtext CHARACTER SET utf8mb4",
-				oldMaxLength: 10000,
-				oldNullable: true)
-				.Annotation("MySql:CharSet", "utf8mb4")
-				.OldAnnotation("MySql:CharSet", "utf8mb4");
-
-			migrationBuilder.AlterColumn<string>(
-				name: "ConnectionString",
-				table: "ChatBots",
-				type: "varchar(10000)",
-				maxLength: 10000,
-				nullable: false,
-				oldClrType: typeof(string),
-				oldType: "longtext CHARACTER SET utf8mb4",
-				oldMaxLength: 10000)
-				.Annotation("MySql:CharSet", "utf8mb4")
-				.OldAnnotation("MySql:CharSet", "utf8mb4");
 		}
 
 		/// <inheritdoc />
@@ -186,7 +74,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 				maxLength: 10000,
 				nullable: true,
 				oldClrType: typeof(string),
-				oldType: "varchar(10000)",
+				oldType: "longtext",
 				oldMaxLength: 10000,
 				oldNullable: true)
 				.Annotation("MySql:CharSet", "utf8mb4")
@@ -219,7 +107,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 				maxLength: 10000,
 				nullable: false,
 				oldClrType: typeof(string),
-				oldType: "varchar(10000)",
+				oldType: "longtext",
 				oldMaxLength: 10000)
 				.Annotation("MySql:CharSet", "utf8mb4")
 				.OldAnnotation("MySql:CharSet", "utf8mb4");
@@ -231,7 +119,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 				maxLength: 10000,
 				nullable: false,
 				oldClrType: typeof(string),
-				oldType: "varchar(10000)",
+				oldType: "longtext",
 				oldMaxLength: 10000)
 				.Annotation("MySql:CharSet", "utf8mb4")
 				.OldAnnotation("MySql:CharSet", "utf8mb4");
@@ -243,7 +131,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 				maxLength: 10000,
 				nullable: true,
 				oldClrType: typeof(string),
-				oldType: "varchar(10000)",
+				oldType: "longtext",
 				oldMaxLength: 10000,
 				oldNullable: true)
 				.Annotation("MySql:CharSet", "utf8mb4")
@@ -256,7 +144,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 				maxLength: 10000,
 				nullable: true,
 				oldClrType: typeof(string),
-				oldType: "varchar(10000)",
+				oldType: "longtext",
 				oldMaxLength: 10000,
 				oldNullable: true)
 				.Annotation("MySql:CharSet", "utf8mb4")
@@ -300,7 +188,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 				maxLength: 10000,
 				nullable: true,
 				oldClrType: typeof(string),
-				oldType: "varchar(10000)",
+				oldType: "longtext",
 				oldMaxLength: 10000,
 				oldNullable: true)
 				.Annotation("MySql:CharSet", "utf8mb4")
@@ -313,7 +201,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 				maxLength: 10000,
 				nullable: false,
 				oldClrType: typeof(string),
-				oldType: "varchar(10000)",
+				oldType: "longtext",
 				oldMaxLength: 10000)
 				.Annotation("MySql:CharSet", "utf8mb4")
 				.OldAnnotation("MySql:CharSet", "utf8mb4");
@@ -366,7 +254,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 				maxLength: 10000,
 				nullable: true,
 				oldClrType: typeof(string),
-				oldType: "varchar(10000)",
+				oldType: "longtext",
 				oldMaxLength: 10000,
 				oldNullable: true)
 				.Annotation("MySql:CharSet", "utf8mb4")
@@ -379,7 +267,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 				maxLength: 10000,
 				nullable: false,
 				oldClrType: typeof(string),
-				oldType: "varchar(10000)",
+				oldType: "longtext",
 				oldMaxLength: 10000)
 				.Annotation("MySql:CharSet", "utf8mb4")
 				.OldAnnotation("MySql:CharSet", "utf8mb4");

--- a/src/Tgstation.Server.Host/Database/Migrations/MySqlDatabaseContextModelSnapshot.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/MySqlDatabaseContextModelSnapshot.cs
@@ -32,7 +32,9 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.Property<string>("ConnectionString")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("varchar(10000)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("ConnectionString"), "utf8mb4");
 
 				b.Property<bool?>("Enabled")
 					.HasColumnType("tinyint(1)");
@@ -76,6 +78,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasMaxLength(100)
 					.HasColumnType("varchar(100)");
 
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("IrcChannel"), "utf8mb4");
+
 				b.Property<bool?>("IsAdminChannel")
 					.IsRequired()
 					.HasColumnType("tinyint(1)");
@@ -90,7 +94,9 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("Tag")
 					.HasMaxLength(10000)
-					.HasColumnType("varchar(10000)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Tag"), "utf8mb4");
 
 				b.HasKey("Id");
 
@@ -113,6 +119,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.IsRequired()
 					.HasColumnType("longtext");
 
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("ByondVersion"), "utf8mb4");
+
 				b.Property<int?>("DMApiMajorVersion")
 					.HasColumnType("int");
 
@@ -130,6 +138,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.IsRequired()
 					.HasColumnType("longtext");
 
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("DmeName"), "utf8mb4");
+
 				b.Property<int?>("GitHubDeploymentId")
 					.HasColumnType("int");
 
@@ -146,8 +156,12 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.IsRequired()
 					.HasColumnType("longtext");
 
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Output"), "utf8mb4");
+
 				b.Property<string>("RepositoryOrigin")
 					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("RepositoryOrigin"), "utf8mb4");
 
 				b.Property<long>("RevisionInformationId")
 					.HasColumnType("bigint");
@@ -173,7 +187,9 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.Property<string>("AdditionalParameters")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("varchar(10000)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("AdditionalParameters"), "utf8mb4");
 
 				b.Property<bool?>("AllowWebClient")
 					.IsRequired()
@@ -246,7 +262,9 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("ProjectName")
 					.HasMaxLength(10000)
-					.HasColumnType("varchar(10000)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("ProjectName"), "utf8mb4");
 
 				b.Property<bool?>("RequireDMApiValidation")
 					.IsRequired()
@@ -286,6 +304,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasMaxLength(100)
 					.HasColumnType("varchar(100)");
 
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Name"), "utf8mb4");
+
 				b.Property<bool?>("Online")
 					.IsRequired()
 					.HasColumnType("tinyint(1)");
@@ -294,8 +314,12 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.IsRequired()
 					.HasColumnType("varchar(255)");
 
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Path"), "utf8mb4");
+
 				b.Property<string>("SwarmIdentifer")
 					.HasColumnType("varchar(255)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("SwarmIdentifer"), "utf8mb4");
 
 				b.HasKey("Id");
 
@@ -371,11 +395,15 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.IsRequired()
 					.HasColumnType("longtext");
 
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Description"), "utf8mb4");
+
 				b.Property<uint?>("ErrorCode")
 					.HasColumnType("int unsigned");
 
 				b.Property<string>("ExceptionDetails")
 					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("ExceptionDetails"), "utf8mb4");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
@@ -411,6 +439,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.IsRequired()
 					.HasMaxLength(100)
 					.HasColumnType("varchar(100)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("ExternalUserId"), "utf8mb4");
 
 				b.Property<int>("Provider")
 					.HasColumnType("int");
@@ -467,6 +497,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.IsRequired()
 					.HasColumnType("longtext");
 
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("AccessIdentifier"), "utf8mb4");
+
 				b.Property<long>("CompileJobId")
 					.HasColumnType("bigint");
 
@@ -500,11 +532,15 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("AccessToken")
 					.HasMaxLength(10000)
-					.HasColumnType("varchar(10000)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("AccessToken"), "utf8mb4");
 
 				b.Property<string>("AccessUser")
 					.HasMaxLength(10000)
-					.HasColumnType("varchar(10000)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("AccessUser"), "utf8mb4");
 
 				b.Property<bool?>("AutoUpdatesKeepTestMerges")
 					.IsRequired()
@@ -517,12 +553,16 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.Property<string>("CommitterEmail")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("varchar(10000)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("CommitterEmail"), "utf8mb4");
 
 				b.Property<string>("CommitterName")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("varchar(10000)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("CommitterName"), "utf8mb4");
 
 				b.Property<bool?>("CreateGitHubDeployments")
 					.IsRequired()
@@ -587,6 +627,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasMaxLength(40)
 					.HasColumnType("varchar(40)");
 
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("CommitSha"), "utf8mb4");
+
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
@@ -594,6 +636,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.IsRequired()
 					.HasMaxLength(40)
 					.HasColumnType("varchar(40)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("OriginCommitSha"), "utf8mb4");
 
 				b.Property<DateTimeOffset>("Timestamp")
 					.HasColumnType("datetime(6)");
@@ -616,13 +660,19 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.IsRequired()
 					.HasColumnType("longtext");
 
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Author"), "utf8mb4");
+
 				b.Property<string>("BodyAtMerge")
 					.IsRequired()
 					.HasColumnType("longtext");
 
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("BodyAtMerge"), "utf8mb4");
+
 				b.Property<string>("Comment")
 					.HasMaxLength(10000)
-					.HasColumnType("varchar(10000)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Comment"), "utf8mb4");
 
 				b.Property<DateTimeOffset>("MergedAt")
 					.HasColumnType("datetime(6)");
@@ -642,13 +692,19 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasMaxLength(40)
 					.HasColumnType("varchar(40)");
 
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("TargetCommitSha"), "utf8mb4");
+
 				b.Property<string>("TitleAtMerge")
 					.IsRequired()
 					.HasColumnType("longtext");
 
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("TitleAtMerge"), "utf8mb4");
+
 				b.Property<string>("Url")
 					.IsRequired()
 					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Url"), "utf8mb4");
 
 				b.HasKey("Id");
 
@@ -670,6 +726,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.IsRequired()
 					.HasMaxLength(100)
 					.HasColumnType("varchar(100)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("CanonicalName"), "utf8mb4");
 
 				b.Property<DateTimeOffset?>("CreatedAt")
 					.IsRequired()
@@ -693,12 +751,18 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasMaxLength(100)
 					.HasColumnType("varchar(100)");
 
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Name"), "utf8mb4");
+
 				b.Property<string>("PasswordHash")
 					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("PasswordHash"), "utf8mb4");
 
 				b.Property<string>("SystemIdentifier")
 					.HasMaxLength(100)
 					.HasColumnType("varchar(100)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("SystemIdentifier"), "utf8mb4");
 
 				b.HasKey("Id");
 
@@ -725,6 +789,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.IsRequired()
 					.HasMaxLength(100)
 					.HasColumnType("varchar(100)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Name"), "utf8mb4");
 
 				b.HasKey("Id");
 

--- a/src/Tgstation.Server.Host/Database/Migrations/MySqlDatabaseContextModelSnapshot.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/MySqlDatabaseContextModelSnapshot.cs
@@ -4,16 +4,19 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable disable
+
 namespace Tgstation.Server.Host.Database.Migrations
 {
 	[DbContext(typeof(MySqlDatabaseContext))]
 	partial class MySqlDatabaseContextModelSnapshot : ModelSnapshot
 	{
+		/// <inheritdoc />
 		protected override void BuildModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder
-				.HasAnnotation("ProductVersion", "3.1.20")
+				.HasAnnotation("ProductVersion", "6.0.15")
 				.HasAnnotation("Relational:MaxIdentifierLength", 64);
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.ChatBot", b =>
@@ -28,8 +31,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("ConnectionString")
 					.IsRequired()
-					.HasColumnType("longtext CHARACTER SET utf8mb4")
-					.HasMaxLength(10000);
+					.HasMaxLength(10000)
+					.HasColumnType("varchar(10000)");
 
 				b.Property<bool?>("Enabled")
 					.HasColumnType("tinyint(1)");
@@ -39,8 +42,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("Name")
 					.IsRequired()
-					.HasColumnType("varchar(100) CHARACTER SET utf8mb4")
-					.HasMaxLength(100);
+					.HasMaxLength(100)
+					.HasColumnType("varchar(100)");
 
 				b.Property<int>("Provider")
 					.HasColumnType("int");
@@ -70,8 +73,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasColumnType("bigint unsigned");
 
 				b.Property<string>("IrcChannel")
-					.HasColumnType("varchar(100) CHARACTER SET utf8mb4")
-					.HasMaxLength(100);
+					.HasMaxLength(100)
+					.HasColumnType("varchar(100)");
 
 				b.Property<bool?>("IsAdminChannel")
 					.IsRequired()
@@ -86,8 +89,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasColumnType("tinyint(1)");
 
 				b.Property<string>("Tag")
-					.HasColumnType("longtext CHARACTER SET utf8mb4")
-					.HasMaxLength(10000);
+					.HasMaxLength(10000)
+					.HasColumnType("varchar(10000)");
 
 				b.HasKey("Id");
 
@@ -108,7 +111,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("ByondVersion")
 					.IsRequired()
-					.HasColumnType("longtext CHARACTER SET utf8mb4");
+					.HasColumnType("longtext");
 
 				b.Property<int?>("DMApiMajorVersion")
 					.HasColumnType("int");
@@ -125,7 +128,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("DmeName")
 					.IsRequired()
-					.HasColumnType("longtext CHARACTER SET utf8mb4");
+					.HasColumnType("longtext");
 
 				b.Property<int?>("GitHubDeploymentId")
 					.HasColumnType("int");
@@ -141,10 +144,10 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("Output")
 					.IsRequired()
-					.HasColumnType("longtext CHARACTER SET utf8mb4");
+					.HasColumnType("longtext");
 
 				b.Property<string>("RepositoryOrigin")
-					.HasColumnType("longtext CHARACTER SET utf8mb4");
+					.HasColumnType("longtext");
 
 				b.Property<long>("RevisionInformationId")
 					.HasColumnType("bigint");
@@ -169,8 +172,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("AdditionalParameters")
 					.IsRequired()
-					.HasColumnType("longtext CHARACTER SET utf8mb4")
-					.HasMaxLength(10000);
+					.HasMaxLength(10000)
+					.HasColumnType("varchar(10000)");
 
 				b.Property<bool?>("AllowWebClient")
 					.IsRequired()
@@ -190,6 +193,10 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
+
+				b.Property<bool?>("LogOutput")
+					.IsRequired()
+					.HasColumnType("tinyint(1)");
 
 				b.Property<ushort?>("Port")
 					.IsRequired()
@@ -238,8 +245,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasColumnType("bigint");
 
 				b.Property<string>("ProjectName")
-					.HasColumnType("longtext CHARACTER SET utf8mb4")
-					.HasMaxLength(10000);
+					.HasMaxLength(10000)
+					.HasColumnType("varchar(10000)");
 
 				b.Property<bool?>("RequireDMApiValidation")
 					.IsRequired()
@@ -276,8 +283,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("Name")
 					.IsRequired()
-					.HasColumnType("varchar(100) CHARACTER SET utf8mb4")
-					.HasMaxLength(100);
+					.HasMaxLength(100)
+					.HasColumnType("varchar(100)");
 
 				b.Property<bool?>("Online")
 					.IsRequired()
@@ -285,10 +292,10 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("Path")
 					.IsRequired()
-					.HasColumnType("varchar(255) CHARACTER SET utf8mb4");
+					.HasColumnType("varchar(255)");
 
 				b.Property<string>("SwarmIdentifer")
-					.HasColumnType("varchar(255) CHARACTER SET utf8mb4");
+					.HasColumnType("varchar(255)");
 
 				b.HasKey("Id");
 
@@ -362,13 +369,13 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("Description")
 					.IsRequired()
-					.HasColumnType("longtext CHARACTER SET utf8mb4");
+					.HasColumnType("longtext");
 
 				b.Property<uint?>("ErrorCode")
 					.HasColumnType("int unsigned");
 
 				b.Property<string>("ExceptionDetails")
-					.HasColumnType("longtext CHARACTER SET utf8mb4");
+					.HasColumnType("longtext");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
@@ -402,8 +409,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("ExternalUserId")
 					.IsRequired()
-					.HasColumnType("varchar(100) CHARACTER SET utf8mb4")
-					.HasMaxLength(100);
+					.HasMaxLength(100)
+					.HasColumnType("varchar(100)");
 
 				b.Property<int>("Provider")
 					.HasColumnType("int");
@@ -458,7 +465,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("AccessIdentifier")
 					.IsRequired()
-					.HasColumnType("longtext CHARACTER SET utf8mb4");
+					.HasColumnType("longtext");
 
 				b.Property<long>("CompileJobId")
 					.HasColumnType("bigint");
@@ -492,12 +499,12 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasColumnType("bigint");
 
 				b.Property<string>("AccessToken")
-					.HasColumnType("longtext CHARACTER SET utf8mb4")
-					.HasMaxLength(10000);
+					.HasMaxLength(10000)
+					.HasColumnType("varchar(10000)");
 
 				b.Property<string>("AccessUser")
-					.HasColumnType("longtext CHARACTER SET utf8mb4")
-					.HasMaxLength(10000);
+					.HasMaxLength(10000)
+					.HasColumnType("varchar(10000)");
 
 				b.Property<bool?>("AutoUpdatesKeepTestMerges")
 					.IsRequired()
@@ -509,13 +516,13 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("CommitterEmail")
 					.IsRequired()
-					.HasColumnType("longtext CHARACTER SET utf8mb4")
-					.HasMaxLength(10000);
+					.HasMaxLength(10000)
+					.HasColumnType("varchar(10000)");
 
 				b.Property<string>("CommitterName")
 					.IsRequired()
-					.HasColumnType("longtext CHARACTER SET utf8mb4")
-					.HasMaxLength(10000);
+					.HasMaxLength(10000)
+					.HasColumnType("varchar(10000)");
 
 				b.Property<bool?>("CreateGitHubDeployments")
 					.IsRequired()
@@ -577,16 +584,16 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("CommitSha")
 					.IsRequired()
-					.HasColumnType("varchar(40) CHARACTER SET utf8mb4")
-					.HasMaxLength(40);
+					.HasMaxLength(40)
+					.HasColumnType("varchar(40)");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
 				b.Property<string>("OriginCommitSha")
 					.IsRequired()
-					.HasColumnType("varchar(40) CHARACTER SET utf8mb4")
-					.HasMaxLength(40);
+					.HasMaxLength(40)
+					.HasColumnType("varchar(40)");
 
 				b.Property<DateTimeOffset>("Timestamp")
 					.HasColumnType("datetime(6)");
@@ -607,15 +614,15 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("Author")
 					.IsRequired()
-					.HasColumnType("longtext CHARACTER SET utf8mb4");
+					.HasColumnType("longtext");
 
 				b.Property<string>("BodyAtMerge")
 					.IsRequired()
-					.HasColumnType("longtext CHARACTER SET utf8mb4");
+					.HasColumnType("longtext");
 
 				b.Property<string>("Comment")
-					.HasColumnType("longtext CHARACTER SET utf8mb4")
-					.HasMaxLength(10000);
+					.HasMaxLength(10000)
+					.HasColumnType("varchar(10000)");
 
 				b.Property<DateTimeOffset>("MergedAt")
 					.HasColumnType("datetime(6)");
@@ -632,16 +639,16 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("TargetCommitSha")
 					.IsRequired()
-					.HasColumnType("varchar(40) CHARACTER SET utf8mb4")
-					.HasMaxLength(40);
+					.HasMaxLength(40)
+					.HasColumnType("varchar(40)");
 
 				b.Property<string>("TitleAtMerge")
 					.IsRequired()
-					.HasColumnType("longtext CHARACTER SET utf8mb4");
+					.HasColumnType("longtext");
 
 				b.Property<string>("Url")
 					.IsRequired()
-					.HasColumnType("longtext CHARACTER SET utf8mb4");
+					.HasColumnType("longtext");
 
 				b.HasKey("Id");
 
@@ -661,8 +668,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("CanonicalName")
 					.IsRequired()
-					.HasColumnType("varchar(100) CHARACTER SET utf8mb4")
-					.HasMaxLength(100);
+					.HasMaxLength(100)
+					.HasColumnType("varchar(100)");
 
 				b.Property<DateTimeOffset?>("CreatedAt")
 					.IsRequired()
@@ -683,15 +690,15 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("Name")
 					.IsRequired()
-					.HasColumnType("varchar(100) CHARACTER SET utf8mb4")
-					.HasMaxLength(100);
+					.HasMaxLength(100)
+					.HasColumnType("varchar(100)");
 
 				b.Property<string>("PasswordHash")
-					.HasColumnType("longtext CHARACTER SET utf8mb4");
+					.HasColumnType("longtext");
 
 				b.Property<string>("SystemIdentifier")
-					.HasColumnType("varchar(100) CHARACTER SET utf8mb4")
-					.HasMaxLength(100);
+					.HasMaxLength(100)
+					.HasColumnType("varchar(100)");
 
 				b.HasKey("Id");
 
@@ -716,8 +723,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("Name")
 					.IsRequired()
-					.HasColumnType("varchar(100) CHARACTER SET utf8mb4")
-					.HasMaxLength(100);
+					.HasMaxLength(100)
+					.HasColumnType("varchar(100)");
 
 				b.HasKey("Id");
 
@@ -734,6 +741,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasForeignKey("InstanceId")
 					.OnDelete(DeleteBehavior.Cascade)
 					.IsRequired();
+
+				b.Navigation("Instance");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.ChatChannel", b =>
@@ -743,6 +752,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasForeignKey("ChatSettingsId")
 					.OnDelete(DeleteBehavior.Cascade)
 					.IsRequired();
+
+				b.Navigation("ChatSettings");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.CompileJob", b =>
@@ -758,6 +769,10 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasForeignKey("RevisionInformationId")
 					.OnDelete(DeleteBehavior.Cascade)
 					.IsRequired();
+
+				b.Navigation("Job");
+
+				b.Navigation("RevisionInformation");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.DreamDaemonSettings", b =>
@@ -767,6 +782,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasForeignKey("Tgstation.Server.Host.Models.DreamDaemonSettings", "InstanceId")
 					.OnDelete(DeleteBehavior.Cascade)
 					.IsRequired();
+
+				b.Navigation("Instance");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.DreamMakerSettings", b =>
@@ -776,6 +793,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasForeignKey("Tgstation.Server.Host.Models.DreamMakerSettings", "InstanceId")
 					.OnDelete(DeleteBehavior.Cascade)
 					.IsRequired();
+
+				b.Navigation("Instance");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.InstancePermissionSet", b =>
@@ -791,6 +810,10 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasForeignKey("PermissionSetId")
 					.OnDelete(DeleteBehavior.Cascade)
 					.IsRequired();
+
+				b.Navigation("Instance");
+
+				b.Navigation("PermissionSet");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.Job", b =>
@@ -810,6 +833,12 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasForeignKey("StartedById")
 					.OnDelete(DeleteBehavior.Cascade)
 					.IsRequired();
+
+				b.Navigation("CancelledBy");
+
+				b.Navigation("Instance");
+
+				b.Navigation("StartedBy");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.OAuthConnection", b =>
@@ -818,6 +847,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.WithMany("OAuthConnections")
 					.HasForeignKey("UserId")
 					.OnDelete(DeleteBehavior.Cascade);
+
+				b.Navigation("User");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.PermissionSet", b =>
@@ -831,6 +862,10 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.WithOne("PermissionSet")
 					.HasForeignKey("Tgstation.Server.Host.Models.PermissionSet", "UserId")
 					.OnDelete(DeleteBehavior.Cascade);
+
+				b.Navigation("Group");
+
+				b.Navigation("User");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.ReattachInformation", b =>
@@ -840,6 +875,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasForeignKey("CompileJobId")
 					.OnDelete(DeleteBehavior.Cascade)
 					.IsRequired();
+
+				b.Navigation("CompileJob");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.RepositorySettings", b =>
@@ -849,6 +886,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasForeignKey("Tgstation.Server.Host.Models.RepositorySettings", "InstanceId")
 					.OnDelete(DeleteBehavior.Cascade)
 					.IsRequired();
+
+				b.Navigation("Instance");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.RevInfoTestMerge", b =>
@@ -864,6 +903,10 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasForeignKey("TestMergeId")
 					.OnDelete(DeleteBehavior.ClientNoAction)
 					.IsRequired();
+
+				b.Navigation("RevisionInformation");
+
+				b.Navigation("TestMerge");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.RevisionInformation", b =>
@@ -873,6 +916,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasForeignKey("InstanceId")
 					.OnDelete(DeleteBehavior.Cascade)
 					.IsRequired();
+
+				b.Navigation("Instance");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.TestMerge", b =>
@@ -888,6 +933,10 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasForeignKey("Tgstation.Server.Host.Models.TestMerge", "PrimaryRevisionInformationId")
 					.OnDelete(DeleteBehavior.Cascade)
 					.IsRequired();
+
+				b.Navigation("MergedBy");
+
+				b.Navigation("PrimaryRevisionInformation");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.User", b =>
@@ -899,6 +948,70 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.HasOne("Tgstation.Server.Host.Models.UserGroup", "Group")
 					.WithMany("Users")
 					.HasForeignKey("GroupId");
+
+				b.Navigation("CreatedBy");
+
+				b.Navigation("Group");
+			});
+
+			modelBuilder.Entity("Tgstation.Server.Host.Models.ChatBot", b =>
+			{
+				b.Navigation("Channels");
+			});
+
+			modelBuilder.Entity("Tgstation.Server.Host.Models.Instance", b =>
+			{
+				b.Navigation("ChatSettings");
+
+				b.Navigation("DreamDaemonSettings");
+
+				b.Navigation("DreamMakerSettings");
+
+				b.Navigation("InstancePermissionSets");
+
+				b.Navigation("Jobs");
+
+				b.Navigation("RepositorySettings");
+
+				b.Navigation("RevisionInformations");
+			});
+
+			modelBuilder.Entity("Tgstation.Server.Host.Models.PermissionSet", b =>
+			{
+				b.Navigation("InstancePermissionSets");
+			});
+
+			modelBuilder.Entity("Tgstation.Server.Host.Models.RevisionInformation", b =>
+			{
+				b.Navigation("ActiveTestMerges");
+
+				b.Navigation("CompileJobs");
+
+				b.Navigation("PrimaryTestMerge");
+			});
+
+			modelBuilder.Entity("Tgstation.Server.Host.Models.TestMerge", b =>
+			{
+				b.Navigation("RevisonInformations");
+			});
+
+			modelBuilder.Entity("Tgstation.Server.Host.Models.User", b =>
+			{
+				b.Navigation("CreatedUsers");
+
+				b.Navigation("OAuthConnections");
+
+				b.Navigation("PermissionSet");
+
+				b.Navigation("TestMerges");
+			});
+
+			modelBuilder.Entity("Tgstation.Server.Host.Models.UserGroup", b =>
+			{
+				b.Navigation("PermissionSet")
+					.IsRequired();
+
+				b.Navigation("Users");
 			});
 #pragma warning restore 612, 618
 		}

--- a/src/Tgstation.Server.Host/Database/Migrations/SqlServerDatabaseContextModelSnapshot.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/SqlServerDatabaseContextModelSnapshot.cs
@@ -3,35 +3,39 @@ using System;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata;
+
+#nullable disable
 
 namespace Tgstation.Server.Host.Database.Migrations
 {
 	[DbContext(typeof(SqlServerDatabaseContext))]
 	partial class SqlServerDatabaseContextModelSnapshot : ModelSnapshot
 	{
+		/// <inheritdoc />
 		protected override void BuildModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder
-				.HasAnnotation("ProductVersion", "3.1.20")
-				.HasAnnotation("Relational:MaxIdentifierLength", 128)
-				.HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+				.HasAnnotation("ProductVersion", "6.0.15")
+				.HasAnnotation("Relational:MaxIdentifierLength", 128);
+
+			SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder, 1L, 1);
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.ChatBot", b =>
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint")
-					.HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+					.HasColumnType("bigint");
+
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"), 1L, 1);
 
 				b.Property<int>("ChannelLimit")
 					.HasColumnType("int");
 
 				b.Property<string>("ConnectionString")
 					.IsRequired()
-					.HasColumnType("nvarchar(max)")
-					.HasMaxLength(10000);
+					.HasMaxLength(10000)
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<bool?>("Enabled")
 					.HasColumnType("bit");
@@ -41,8 +45,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("Name")
 					.IsRequired()
-					.HasColumnType("nvarchar(100)")
-					.HasMaxLength(100);
+					.HasMaxLength(100)
+					.HasColumnType("nvarchar(100)");
 
 				b.Property<int>("Provider")
 					.HasColumnType("int");
@@ -62,8 +66,9 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint")
-					.HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+					.HasColumnType("bigint");
+
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"), 1L, 1);
 
 				b.Property<long>("ChatSettingsId")
 					.HasColumnType("bigint");
@@ -72,8 +77,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasColumnType("decimal(20,0)");
 
 				b.Property<string>("IrcChannel")
-					.HasColumnType("nvarchar(100)")
-					.HasMaxLength(100);
+					.HasMaxLength(100)
+					.HasColumnType("nvarchar(100)");
 
 				b.Property<bool?>("IsAdminChannel")
 					.IsRequired()
@@ -88,8 +93,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasColumnType("bit");
 
 				b.Property<string>("Tag")
-					.HasColumnType("nvarchar(max)")
-					.HasMaxLength(10000);
+					.HasMaxLength(10000)
+					.HasColumnType("nvarchar(max)");
 
 				b.HasKey("Id");
 
@@ -108,8 +113,9 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint")
-					.HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+					.HasColumnType("bigint");
+
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"), 1L, 1);
 
 				b.Property<string>("ByondVersion")
 					.IsRequired()
@@ -170,13 +176,14 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint")
-					.HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+					.HasColumnType("bigint");
+
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"), 1L, 1);
 
 				b.Property<string>("AdditionalParameters")
 					.IsRequired()
-					.HasColumnType("nvarchar(max)")
-					.HasMaxLength(10000);
+					.HasMaxLength(10000)
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<bool?>("AllowWebClient")
 					.IsRequired()
@@ -195,6 +202,10 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
+
+				b.Property<bool?>("LogOutput")
+					.IsRequired()
+					.HasColumnType("bit");
 
 				b.Property<int>("Port")
 					.HasColumnType("int");
@@ -227,8 +238,9 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint")
-					.HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+					.HasColumnType("bigint");
+
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"), 1L, 1);
 
 				b.Property<int>("ApiValidationPort")
 					.HasColumnType("int");
@@ -240,8 +252,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasColumnType("bigint");
 
 				b.Property<string>("ProjectName")
-					.HasColumnType("nvarchar(max)")
-					.HasMaxLength(10000);
+					.HasMaxLength(10000)
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<bool?>("RequireDMApiValidation")
 					.IsRequired()
@@ -263,8 +275,9 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint")
-					.HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+					.HasColumnType("bigint");
+
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"), 1L, 1);
 
 				b.Property<long>("AutoUpdateInterval")
 					.HasColumnType("bigint");
@@ -277,8 +290,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("Name")
 					.IsRequired()
-					.HasColumnType("nvarchar(100)")
-					.HasMaxLength(100);
+					.HasMaxLength(100)
+					.HasColumnType("nvarchar(100)");
 
 				b.Property<bool?>("Online")
 					.IsRequired()
@@ -304,8 +317,9 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint")
-					.HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+					.HasColumnType("bigint");
+
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"), 1L, 1);
 
 				b.Property<decimal>("ByondRights")
 					.HasColumnType("decimal(20,0)");
@@ -348,8 +362,9 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint")
-					.HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+					.HasColumnType("bigint");
+
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"), 1L, 1);
 
 				b.Property<decimal?>("CancelRight")
 					.HasColumnType("decimal(20,0)");
@@ -402,13 +417,14 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint")
-					.HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+					.HasColumnType("bigint");
+
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"), 1L, 1);
 
 				b.Property<string>("ExternalUserId")
 					.IsRequired()
-					.HasColumnType("nvarchar(100)")
-					.HasMaxLength(100);
+					.HasMaxLength(100)
+					.HasColumnType("nvarchar(100)");
 
 				b.Property<int>("Provider")
 					.HasColumnType("int");
@@ -430,8 +446,9 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint")
-					.HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+					.HasColumnType("bigint");
+
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"), 1L, 1);
 
 				b.Property<decimal>("AdministrationRights")
 					.HasColumnType("decimal(20,0)");
@@ -462,8 +479,9 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint")
-					.HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+					.HasColumnType("bigint");
+
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"), 1L, 1);
 
 				b.Property<string>("AccessIdentifier")
 					.IsRequired()
@@ -498,16 +516,17 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint")
-					.HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+					.HasColumnType("bigint");
+
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"), 1L, 1);
 
 				b.Property<string>("AccessToken")
-					.HasColumnType("nvarchar(max)")
-					.HasMaxLength(10000);
+					.HasMaxLength(10000)
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<string>("AccessUser")
-					.HasColumnType("nvarchar(max)")
-					.HasMaxLength(10000);
+					.HasMaxLength(10000)
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<bool?>("AutoUpdatesKeepTestMerges")
 					.IsRequired()
@@ -519,13 +538,13 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("CommitterEmail")
 					.IsRequired()
-					.HasColumnType("nvarchar(max)")
-					.HasMaxLength(10000);
+					.HasMaxLength(10000)
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<string>("CommitterName")
 					.IsRequired()
-					.HasColumnType("nvarchar(max)")
-					.HasMaxLength(10000);
+					.HasMaxLength(10000)
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<bool?>("CreateGitHubDeployments")
 					.IsRequired()
@@ -562,8 +581,9 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint")
-					.HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+					.HasColumnType("bigint");
+
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"), 1L, 1);
 
 				b.Property<long>("RevisionInformationId")
 					.HasColumnType("bigint");
@@ -584,21 +604,22 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint")
-					.HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+					.HasColumnType("bigint");
+
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"), 1L, 1);
 
 				b.Property<string>("CommitSha")
 					.IsRequired()
-					.HasColumnType("nvarchar(40)")
-					.HasMaxLength(40);
+					.HasMaxLength(40)
+					.HasColumnType("nvarchar(40)");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
 				b.Property<string>("OriginCommitSha")
 					.IsRequired()
-					.HasColumnType("nvarchar(40)")
-					.HasMaxLength(40);
+					.HasMaxLength(40)
+					.HasColumnType("nvarchar(40)");
 
 				b.Property<DateTimeOffset>("Timestamp")
 					.HasColumnType("datetimeoffset");
@@ -615,8 +636,9 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint")
-					.HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+					.HasColumnType("bigint");
+
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"), 1L, 1);
 
 				b.Property<string>("Author")
 					.IsRequired()
@@ -627,8 +649,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasColumnType("nvarchar(max)");
 
 				b.Property<string>("Comment")
-					.HasColumnType("nvarchar(max)")
-					.HasMaxLength(10000);
+					.HasMaxLength(10000)
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<DateTimeOffset>("MergedAt")
 					.HasColumnType("datetimeoffset");
@@ -645,8 +667,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("TargetCommitSha")
 					.IsRequired()
-					.HasColumnType("nvarchar(40)")
-					.HasMaxLength(40);
+					.HasMaxLength(40)
+					.HasColumnType("nvarchar(40)");
 
 				b.Property<string>("TitleAtMerge")
 					.IsRequired()
@@ -670,13 +692,14 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint")
-					.HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+					.HasColumnType("bigint");
+
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"), 1L, 1);
 
 				b.Property<string>("CanonicalName")
 					.IsRequired()
-					.HasColumnType("nvarchar(100)")
-					.HasMaxLength(100);
+					.HasMaxLength(100)
+					.HasColumnType("nvarchar(100)");
 
 				b.Property<DateTimeOffset?>("CreatedAt")
 					.IsRequired()
@@ -697,15 +720,15 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("Name")
 					.IsRequired()
-					.HasColumnType("nvarchar(100)")
-					.HasMaxLength(100);
+					.HasMaxLength(100)
+					.HasColumnType("nvarchar(100)");
 
 				b.Property<string>("PasswordHash")
 					.HasColumnType("nvarchar(max)");
 
 				b.Property<string>("SystemIdentifier")
-					.HasColumnType("nvarchar(100)")
-					.HasMaxLength(100);
+					.HasMaxLength(100)
+					.HasColumnType("nvarchar(100)");
 
 				b.HasKey("Id");
 
@@ -727,13 +750,14 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint")
-					.HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+					.HasColumnType("bigint");
+
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"), 1L, 1);
 
 				b.Property<string>("Name")
 					.IsRequired()
-					.HasColumnType("nvarchar(100)")
-					.HasMaxLength(100);
+					.HasMaxLength(100)
+					.HasColumnType("nvarchar(100)");
 
 				b.HasKey("Id");
 
@@ -750,6 +774,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasForeignKey("InstanceId")
 					.OnDelete(DeleteBehavior.Cascade)
 					.IsRequired();
+
+				b.Navigation("Instance");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.ChatChannel", b =>
@@ -759,6 +785,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasForeignKey("ChatSettingsId")
 					.OnDelete(DeleteBehavior.Cascade)
 					.IsRequired();
+
+				b.Navigation("ChatSettings");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.CompileJob", b =>
@@ -774,6 +802,10 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasForeignKey("RevisionInformationId")
 					.OnDelete(DeleteBehavior.ClientNoAction)
 					.IsRequired();
+
+				b.Navigation("Job");
+
+				b.Navigation("RevisionInformation");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.DreamDaemonSettings", b =>
@@ -783,6 +815,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasForeignKey("Tgstation.Server.Host.Models.DreamDaemonSettings", "InstanceId")
 					.OnDelete(DeleteBehavior.Cascade)
 					.IsRequired();
+
+				b.Navigation("Instance");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.DreamMakerSettings", b =>
@@ -792,6 +826,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasForeignKey("Tgstation.Server.Host.Models.DreamMakerSettings", "InstanceId")
 					.OnDelete(DeleteBehavior.Cascade)
 					.IsRequired();
+
+				b.Navigation("Instance");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.InstancePermissionSet", b =>
@@ -807,6 +843,10 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasForeignKey("PermissionSetId")
 					.OnDelete(DeleteBehavior.Cascade)
 					.IsRequired();
+
+				b.Navigation("Instance");
+
+				b.Navigation("PermissionSet");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.Job", b =>
@@ -826,6 +866,12 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasForeignKey("StartedById")
 					.OnDelete(DeleteBehavior.Cascade)
 					.IsRequired();
+
+				b.Navigation("CancelledBy");
+
+				b.Navigation("Instance");
+
+				b.Navigation("StartedBy");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.OAuthConnection", b =>
@@ -834,6 +880,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.WithMany("OAuthConnections")
 					.HasForeignKey("UserId")
 					.OnDelete(DeleteBehavior.Cascade);
+
+				b.Navigation("User");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.PermissionSet", b =>
@@ -847,6 +895,10 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.WithOne("PermissionSet")
 					.HasForeignKey("Tgstation.Server.Host.Models.PermissionSet", "UserId")
 					.OnDelete(DeleteBehavior.Cascade);
+
+				b.Navigation("Group");
+
+				b.Navigation("User");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.ReattachInformation", b =>
@@ -856,6 +908,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasForeignKey("CompileJobId")
 					.OnDelete(DeleteBehavior.Cascade)
 					.IsRequired();
+
+				b.Navigation("CompileJob");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.RepositorySettings", b =>
@@ -865,6 +919,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasForeignKey("Tgstation.Server.Host.Models.RepositorySettings", "InstanceId")
 					.OnDelete(DeleteBehavior.Cascade)
 					.IsRequired();
+
+				b.Navigation("Instance");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.RevInfoTestMerge", b =>
@@ -880,6 +936,10 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasForeignKey("TestMergeId")
 					.OnDelete(DeleteBehavior.ClientNoAction)
 					.IsRequired();
+
+				b.Navigation("RevisionInformation");
+
+				b.Navigation("TestMerge");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.RevisionInformation", b =>
@@ -889,6 +949,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasForeignKey("InstanceId")
 					.OnDelete(DeleteBehavior.Cascade)
 					.IsRequired();
+
+				b.Navigation("Instance");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.TestMerge", b =>
@@ -904,6 +966,10 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasForeignKey("Tgstation.Server.Host.Models.TestMerge", "PrimaryRevisionInformationId")
 					.OnDelete(DeleteBehavior.Cascade)
 					.IsRequired();
+
+				b.Navigation("MergedBy");
+
+				b.Navigation("PrimaryRevisionInformation");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.User", b =>
@@ -915,6 +981,70 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.HasOne("Tgstation.Server.Host.Models.UserGroup", "Group")
 					.WithMany("Users")
 					.HasForeignKey("GroupId");
+
+				b.Navigation("CreatedBy");
+
+				b.Navigation("Group");
+			});
+
+			modelBuilder.Entity("Tgstation.Server.Host.Models.ChatBot", b =>
+			{
+				b.Navigation("Channels");
+			});
+
+			modelBuilder.Entity("Tgstation.Server.Host.Models.Instance", b =>
+			{
+				b.Navigation("ChatSettings");
+
+				b.Navigation("DreamDaemonSettings");
+
+				b.Navigation("DreamMakerSettings");
+
+				b.Navigation("InstancePermissionSets");
+
+				b.Navigation("Jobs");
+
+				b.Navigation("RepositorySettings");
+
+				b.Navigation("RevisionInformations");
+			});
+
+			modelBuilder.Entity("Tgstation.Server.Host.Models.PermissionSet", b =>
+			{
+				b.Navigation("InstancePermissionSets");
+			});
+
+			modelBuilder.Entity("Tgstation.Server.Host.Models.RevisionInformation", b =>
+			{
+				b.Navigation("ActiveTestMerges");
+
+				b.Navigation("CompileJobs");
+
+				b.Navigation("PrimaryTestMerge");
+			});
+
+			modelBuilder.Entity("Tgstation.Server.Host.Models.TestMerge", b =>
+			{
+				b.Navigation("RevisonInformations");
+			});
+
+			modelBuilder.Entity("Tgstation.Server.Host.Models.User", b =>
+			{
+				b.Navigation("CreatedUsers");
+
+				b.Navigation("OAuthConnections");
+
+				b.Navigation("PermissionSet");
+
+				b.Navigation("TestMerges");
+			});
+
+			modelBuilder.Entity("Tgstation.Server.Host.Models.UserGroup", b =>
+			{
+				b.Navigation("PermissionSet")
+					.IsRequired();
+
+				b.Navigation("Users");
 			});
 #pragma warning restore 612, 618
 		}

--- a/src/Tgstation.Server.Host/Database/Migrations/SqliteDatabaseContextModelSnapshot.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/SqliteDatabaseContextModelSnapshot.cs
@@ -4,16 +4,18 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+#nullable disable
+
 namespace Tgstation.Server.Host.Database.Migrations
 {
 	[DbContext(typeof(SqliteDatabaseContext))]
 	partial class SqliteDatabaseContextModelSnapshot : ModelSnapshot
 	{
+		/// <inheritdoc />
 		protected override void BuildModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
-			modelBuilder
-				.HasAnnotation("ProductVersion", "3.1.20");
+			modelBuilder.HasAnnotation("ProductVersion", "6.0.15");
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.ChatBot", b =>
 			{
@@ -27,8 +29,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("ConnectionString")
 					.IsRequired()
-					.HasColumnType("TEXT")
-					.HasMaxLength(10000);
+					.HasMaxLength(10000)
+					.HasColumnType("TEXT");
 
 				b.Property<bool?>("Enabled")
 					.HasColumnType("INTEGER");
@@ -38,8 +40,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("Name")
 					.IsRequired()
-					.HasColumnType("TEXT")
-					.HasMaxLength(100);
+					.HasMaxLength(100)
+					.HasColumnType("TEXT");
 
 				b.Property<int>("Provider")
 					.HasColumnType("INTEGER");
@@ -69,8 +71,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasColumnType("INTEGER");
 
 				b.Property<string>("IrcChannel")
-					.HasColumnType("TEXT")
-					.HasMaxLength(100);
+					.HasMaxLength(100)
+					.HasColumnType("TEXT");
 
 				b.Property<bool?>("IsAdminChannel")
 					.IsRequired()
@@ -85,8 +87,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasColumnType("INTEGER");
 
 				b.Property<string>("Tag")
-					.HasColumnType("TEXT")
-					.HasMaxLength(10000);
+					.HasMaxLength(10000)
+					.HasColumnType("TEXT");
 
 				b.HasKey("Id");
 
@@ -168,8 +170,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("AdditionalParameters")
 					.IsRequired()
-					.HasColumnType("TEXT")
-					.HasMaxLength(10000);
+					.HasMaxLength(10000)
+					.HasColumnType("TEXT");
 
 				b.Property<bool?>("AllowWebClient")
 					.IsRequired()
@@ -188,6 +190,10 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasColumnType("INTEGER");
 
 				b.Property<long>("InstanceId")
+					.HasColumnType("INTEGER");
+
+				b.Property<bool?>("LogOutput")
+					.IsRequired()
 					.HasColumnType("INTEGER");
 
 				b.Property<ushort?>("Port")
@@ -237,8 +243,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasColumnType("INTEGER");
 
 				b.Property<string>("ProjectName")
-					.HasColumnType("TEXT")
-					.HasMaxLength(10000);
+					.HasMaxLength(10000)
+					.HasColumnType("TEXT");
 
 				b.Property<bool?>("RequireDMApiValidation")
 					.IsRequired()
@@ -275,8 +281,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("Name")
 					.IsRequired()
-					.HasColumnType("TEXT")
-					.HasMaxLength(100);
+					.HasMaxLength(100)
+					.HasColumnType("TEXT");
 
 				b.Property<bool?>("Online")
 					.IsRequired()
@@ -401,8 +407,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("ExternalUserId")
 					.IsRequired()
-					.HasColumnType("TEXT")
-					.HasMaxLength(100);
+					.HasMaxLength(100)
+					.HasColumnType("TEXT");
 
 				b.Property<int>("Provider")
 					.HasColumnType("INTEGER");
@@ -491,12 +497,12 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasColumnType("INTEGER");
 
 				b.Property<string>("AccessToken")
-					.HasColumnType("TEXT")
-					.HasMaxLength(10000);
+					.HasMaxLength(10000)
+					.HasColumnType("TEXT");
 
 				b.Property<string>("AccessUser")
-					.HasColumnType("TEXT")
-					.HasMaxLength(10000);
+					.HasMaxLength(10000)
+					.HasColumnType("TEXT");
 
 				b.Property<bool?>("AutoUpdatesKeepTestMerges")
 					.IsRequired()
@@ -508,13 +514,13 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("CommitterEmail")
 					.IsRequired()
-					.HasColumnType("TEXT")
-					.HasMaxLength(10000);
+					.HasMaxLength(10000)
+					.HasColumnType("TEXT");
 
 				b.Property<string>("CommitterName")
 					.IsRequired()
-					.HasColumnType("TEXT")
-					.HasMaxLength(10000);
+					.HasMaxLength(10000)
+					.HasColumnType("TEXT");
 
 				b.Property<bool?>("CreateGitHubDeployments")
 					.IsRequired()
@@ -576,16 +582,16 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("CommitSha")
 					.IsRequired()
-					.HasColumnType("TEXT")
-					.HasMaxLength(40);
+					.HasMaxLength(40)
+					.HasColumnType("TEXT");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("INTEGER");
 
 				b.Property<string>("OriginCommitSha")
 					.IsRequired()
-					.HasColumnType("TEXT")
-					.HasMaxLength(40);
+					.HasMaxLength(40)
+					.HasColumnType("TEXT");
 
 				b.Property<DateTimeOffset>("Timestamp")
 					.HasColumnType("TEXT");
@@ -613,8 +619,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasColumnType("TEXT");
 
 				b.Property<string>("Comment")
-					.HasColumnType("TEXT")
-					.HasMaxLength(10000);
+					.HasMaxLength(10000)
+					.HasColumnType("TEXT");
 
 				b.Property<DateTimeOffset>("MergedAt")
 					.HasColumnType("TEXT");
@@ -631,8 +637,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("TargetCommitSha")
 					.IsRequired()
-					.HasColumnType("TEXT")
-					.HasMaxLength(40);
+					.HasMaxLength(40)
+					.HasColumnType("TEXT");
 
 				b.Property<string>("TitleAtMerge")
 					.IsRequired()
@@ -660,8 +666,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("CanonicalName")
 					.IsRequired()
-					.HasColumnType("TEXT")
-					.HasMaxLength(100);
+					.HasMaxLength(100)
+					.HasColumnType("TEXT");
 
 				b.Property<DateTimeOffset?>("CreatedAt")
 					.IsRequired()
@@ -682,15 +688,15 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("Name")
 					.IsRequired()
-					.HasColumnType("TEXT")
-					.HasMaxLength(100);
+					.HasMaxLength(100)
+					.HasColumnType("TEXT");
 
 				b.Property<string>("PasswordHash")
 					.HasColumnType("TEXT");
 
 				b.Property<string>("SystemIdentifier")
-					.HasColumnType("TEXT")
-					.HasMaxLength(100);
+					.HasMaxLength(100)
+					.HasColumnType("TEXT");
 
 				b.HasKey("Id");
 
@@ -715,8 +721,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("Name")
 					.IsRequired()
-					.HasColumnType("TEXT")
-					.HasMaxLength(100);
+					.HasMaxLength(100)
+					.HasColumnType("TEXT");
 
 				b.HasKey("Id");
 
@@ -733,6 +739,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasForeignKey("InstanceId")
 					.OnDelete(DeleteBehavior.Cascade)
 					.IsRequired();
+
+				b.Navigation("Instance");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.ChatChannel", b =>
@@ -742,6 +750,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasForeignKey("ChatSettingsId")
 					.OnDelete(DeleteBehavior.Cascade)
 					.IsRequired();
+
+				b.Navigation("ChatSettings");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.CompileJob", b =>
@@ -757,6 +767,10 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasForeignKey("RevisionInformationId")
 					.OnDelete(DeleteBehavior.ClientNoAction)
 					.IsRequired();
+
+				b.Navigation("Job");
+
+				b.Navigation("RevisionInformation");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.DreamDaemonSettings", b =>
@@ -766,6 +780,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasForeignKey("Tgstation.Server.Host.Models.DreamDaemonSettings", "InstanceId")
 					.OnDelete(DeleteBehavior.Cascade)
 					.IsRequired();
+
+				b.Navigation("Instance");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.DreamMakerSettings", b =>
@@ -775,6 +791,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasForeignKey("Tgstation.Server.Host.Models.DreamMakerSettings", "InstanceId")
 					.OnDelete(DeleteBehavior.Cascade)
 					.IsRequired();
+
+				b.Navigation("Instance");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.InstancePermissionSet", b =>
@@ -790,6 +808,10 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasForeignKey("PermissionSetId")
 					.OnDelete(DeleteBehavior.Cascade)
 					.IsRequired();
+
+				b.Navigation("Instance");
+
+				b.Navigation("PermissionSet");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.Job", b =>
@@ -809,6 +831,12 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasForeignKey("StartedById")
 					.OnDelete(DeleteBehavior.Cascade)
 					.IsRequired();
+
+				b.Navigation("CancelledBy");
+
+				b.Navigation("Instance");
+
+				b.Navigation("StartedBy");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.OAuthConnection", b =>
@@ -817,6 +845,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.WithMany("OAuthConnections")
 					.HasForeignKey("UserId")
 					.OnDelete(DeleteBehavior.Cascade);
+
+				b.Navigation("User");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.PermissionSet", b =>
@@ -830,6 +860,10 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.WithOne("PermissionSet")
 					.HasForeignKey("Tgstation.Server.Host.Models.PermissionSet", "UserId")
 					.OnDelete(DeleteBehavior.Cascade);
+
+				b.Navigation("Group");
+
+				b.Navigation("User");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.ReattachInformation", b =>
@@ -839,6 +873,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasForeignKey("CompileJobId")
 					.OnDelete(DeleteBehavior.Cascade)
 					.IsRequired();
+
+				b.Navigation("CompileJob");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.RepositorySettings", b =>
@@ -848,6 +884,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasForeignKey("Tgstation.Server.Host.Models.RepositorySettings", "InstanceId")
 					.OnDelete(DeleteBehavior.Cascade)
 					.IsRequired();
+
+				b.Navigation("Instance");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.RevInfoTestMerge", b =>
@@ -863,6 +901,10 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasForeignKey("TestMergeId")
 					.OnDelete(DeleteBehavior.ClientNoAction)
 					.IsRequired();
+
+				b.Navigation("RevisionInformation");
+
+				b.Navigation("TestMerge");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.RevisionInformation", b =>
@@ -872,6 +914,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasForeignKey("InstanceId")
 					.OnDelete(DeleteBehavior.Cascade)
 					.IsRequired();
+
+				b.Navigation("Instance");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.TestMerge", b =>
@@ -887,6 +931,10 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasForeignKey("Tgstation.Server.Host.Models.TestMerge", "PrimaryRevisionInformationId")
 					.OnDelete(DeleteBehavior.Cascade)
 					.IsRequired();
+
+				b.Navigation("MergedBy");
+
+				b.Navigation("PrimaryRevisionInformation");
 			});
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.User", b =>
@@ -898,6 +946,70 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.HasOne("Tgstation.Server.Host.Models.UserGroup", "Group")
 					.WithMany("Users")
 					.HasForeignKey("GroupId");
+
+				b.Navigation("CreatedBy");
+
+				b.Navigation("Group");
+			});
+
+			modelBuilder.Entity("Tgstation.Server.Host.Models.ChatBot", b =>
+			{
+				b.Navigation("Channels");
+			});
+
+			modelBuilder.Entity("Tgstation.Server.Host.Models.Instance", b =>
+			{
+				b.Navigation("ChatSettings");
+
+				b.Navigation("DreamDaemonSettings");
+
+				b.Navigation("DreamMakerSettings");
+
+				b.Navigation("InstancePermissionSets");
+
+				b.Navigation("Jobs");
+
+				b.Navigation("RepositorySettings");
+
+				b.Navigation("RevisionInformations");
+			});
+
+			modelBuilder.Entity("Tgstation.Server.Host.Models.PermissionSet", b =>
+			{
+				b.Navigation("InstancePermissionSets");
+			});
+
+			modelBuilder.Entity("Tgstation.Server.Host.Models.RevisionInformation", b =>
+			{
+				b.Navigation("ActiveTestMerges");
+
+				b.Navigation("CompileJobs");
+
+				b.Navigation("PrimaryTestMerge");
+			});
+
+			modelBuilder.Entity("Tgstation.Server.Host.Models.TestMerge", b =>
+			{
+				b.Navigation("RevisonInformations");
+			});
+
+			modelBuilder.Entity("Tgstation.Server.Host.Models.User", b =>
+			{
+				b.Navigation("CreatedUsers");
+
+				b.Navigation("OAuthConnections");
+
+				b.Navigation("PermissionSet");
+
+				b.Navigation("TestMerges");
+			});
+
+			modelBuilder.Entity("Tgstation.Server.Host.Models.UserGroup", b =>
+			{
+				b.Navigation("PermissionSet")
+					.IsRequired();
+
+				b.Navigation("Users");
 			});
 #pragma warning restore 612, 618
 		}

--- a/src/Tgstation.Server.Host/Database/MySqlDatabaseContext.cs
+++ b/src/Tgstation.Server.Host/Database/MySqlDatabaseContext.cs
@@ -5,6 +5,8 @@ using Microsoft.EntityFrameworkCore;
 using Pomelo.EntityFrameworkCore.MySql.Infrastructure;
 
 using Tgstation.Server.Host.Configuration;
+using Tgstation.Server.Host.Extensions;
+using Tgstation.Server.Host.Models;
 
 namespace Tgstation.Server.Host.Database
 {
@@ -59,6 +61,49 @@ namespace Tgstation.Server.Host.Database
 					mySqlOptions.EnableRetryOnFailure();
 					mySqlOptions.UseQuerySplittingBehavior(QuerySplittingBehavior.SingleQuery);
 				});
+		}
+
+		/// <inheritdoc />
+		protected override void OnModelCreating(ModelBuilder modelBuilder)
+		{
+			base.OnModelCreating(modelBuilder);
+
+			// Added to prevent a column type change after upgrading Pomelo.Mysql
+			// Related: https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/issues/1606
+			modelBuilder
+				.MapMySqlTextField<ChatBot>(x => x.ConnectionString)
+				.MapMySqlTextField<ChatChannel>(x => x.Tag)
+				.MapMySqlTextField<ChatChannel>(x => x.IrcChannel)
+				.MapMySqlTextField<CompileJob>(x => x.ByondVersion)
+				.MapMySqlTextField<CompileJob>(x => x.DmeName)
+				.MapMySqlTextField<CompileJob>(x => x.Output)
+				.MapMySqlTextField<CompileJob>(x => x.RepositoryOrigin)
+				.MapMySqlTextField<DreamDaemonSettings>(x => x.AdditionalParameters)
+				.MapMySqlTextField<DreamMakerSettings>(x => x.ProjectName)
+				.MapMySqlTextField<Instance>(x => x.Name)
+				.MapMySqlTextField<Instance>(x => x.Path)
+				.MapMySqlTextField<Instance>(x => x.SwarmIdentifer)
+				.MapMySqlTextField<Job>(x => x.Description)
+				.MapMySqlTextField<Job>(x => x.ExceptionDetails)
+				.MapMySqlTextField<OAuthConnection>(x => x.ExternalUserId)
+				.MapMySqlTextField<ReattachInformation>(x => x.AccessIdentifier)
+				.MapMySqlTextField<RepositorySettings>(x => x.AccessToken)
+				.MapMySqlTextField<RepositorySettings>(x => x.AccessUser)
+				.MapMySqlTextField<RepositorySettings>(x => x.CommitterEmail)
+				.MapMySqlTextField<RepositorySettings>(x => x.CommitterName)
+				.MapMySqlTextField<RevisionInformation>(x => x.CommitSha)
+				.MapMySqlTextField<RevisionInformation>(x => x.OriginCommitSha)
+				.MapMySqlTextField<TestMerge>(x => x.Author)
+				.MapMySqlTextField<TestMerge>(x => x.BodyAtMerge)
+				.MapMySqlTextField<TestMerge>(x => x.Comment)
+				.MapMySqlTextField<TestMerge>(x => x.TargetCommitSha)
+				.MapMySqlTextField<TestMerge>(x => x.TitleAtMerge)
+				.MapMySqlTextField<TestMerge>(x => x.Url)
+				.MapMySqlTextField<User>(x => x.CanonicalName)
+				.MapMySqlTextField<User>(x => x.Name)
+				.MapMySqlTextField<User>(x => x.PasswordHash)
+				.MapMySqlTextField<User>(x => x.SystemIdentifier)
+				.MapMySqlTextField<UserGroup>(x => x.Name);
 		}
 	}
 }

--- a/src/Tgstation.Server.Host/Extensions/ModelBuilderExtensions.cs
+++ b/src/Tgstation.Server.Host/Extensions/ModelBuilderExtensions.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using System.Linq.Expressions;
+using System.Reflection;
+
+using Microsoft.EntityFrameworkCore;
+
+using Tgstation.Server.Api.Models;
+
+namespace Tgstation.Server.Host.Extensions
+{
+	/// <summary>
+	/// Extension methods for the <see cref="ModelBuilder"/> <see langword="class"/>.
+	/// </summary>
+	static class ModelBuilderExtensions
+	{
+		/// <summary>
+		/// Set a given <typeparamref name="TEntity"/>'s property's column charset to "utf8mb4". Only for use with the MySQL/MariaDB provider.
+		/// </summary>
+		/// <typeparam name="TEntity">The entity.</typeparam>
+		/// <param name="modelBuilder">The <see cref="ModelBuilder"/>.</param>
+		/// <param name="expression">The <see cref="Expression"/> accessing the relevant property.</param>
+		/// <returns><paramref name="modelBuilder"/>.</returns>
+		public static ModelBuilder MapMySqlTextField<TEntity>(
+			this ModelBuilder modelBuilder,
+			Expression<Func<TEntity, string>> expression)
+			where TEntity : class
+		{
+			var property = modelBuilder
+				.Entity<TEntity>()
+				.Property(expression);
+			property
+				.HasCharSet("utf8mb4");
+
+			var propertyInfo = GetPropertyFromExpression(expression);
+			var stringLengthAttribute = propertyInfo.GetCustomAttribute<StringLengthAttribute>();
+
+			if (stringLengthAttribute?.MaximumLength == Limits.MaximumStringLength)
+				property.HasColumnType("longtext");
+
+			return modelBuilder;
+		}
+
+		/// <summary>
+		/// Get the <see cref="PropertyInfo"/> pointed to by an <paramref name="expression"/>.
+		/// </summary>
+		/// <typeparam name="TEntity">The entity.</typeparam>
+		/// <param name="expression">The <see cref="Expression"/> accessing the relevant property.</param>
+		/// <returns>The <see cref="PropertyInfo"/> pointed to by <paramref name="expression"/>.</returns>
+		static PropertyInfo GetPropertyFromExpression<TEntity>(Expression<Func<TEntity, string>> expression)
+		{
+			MemberExpression memberExpression;
+
+			// this line is necessary, because sometimes the expression comes in as Convert(originalexpression)
+			if (expression.Body is UnaryExpression unaryExpression)
+				if (unaryExpression.Operand is MemberExpression unaryAsMember)
+					memberExpression = unaryAsMember;
+				else
+					throw new ArgumentException("Cannot get property from expression!", nameof(expression));
+			else if (expression.Body is MemberExpression)
+				memberExpression = (MemberExpression)expression.Body;
+			else
+				throw new ArgumentException("Cannot get property from expression!", nameof(expression));
+
+			return (PropertyInfo)memberExpression.Member;
+		}
+	}
+}

--- a/src/Tgstation.Server.Host/IO/DefaultIOManager.cs
+++ b/src/Tgstation.Server.Host/IO/DefaultIOManager.cs
@@ -44,10 +44,6 @@ namespace Tgstation.Server.Host.IO
 		/// <returns>A <see cref="Task"/> representing the running operation.</returns>
 		static async Task NormalizeAndDelete(DirectoryInfo dir, CancellationToken cancellationToken)
 		{
-			var tasks = new List<Task>();
-
-			await Task.Yield();
-
 			// check if we are a symbolic link
 			if (!dir.Attributes.HasFlag(FileAttributes.Directory) || dir.Attributes.HasFlag(FileAttributes.ReparsePoint))
 			{
@@ -55,6 +51,9 @@ namespace Tgstation.Server.Host.IO
 				return;
 			}
 
+			await Task.Yield();
+
+			var tasks = new List<Task>();
 			foreach (var subDir in dir.EnumerateDirectories())
 			{
 				cancellationToken.ThrowIfCancellationRequested();

--- a/src/Tgstation.Server.Host/IO/DefaultIOManager.cs
+++ b/src/Tgstation.Server.Host/IO/DefaultIOManager.cs
@@ -247,15 +247,21 @@ namespace Tgstation.Server.Host.IO
 		/// <inheritdoc />
 		public async Task WriteAllBytes(string path, byte[] contents, CancellationToken cancellationToken)
 		{
+			using var file = CreateAsyncWriteStream(path);
+			await file.WriteAsync(contents, cancellationToken);
+		}
+
+		/// <inheritdoc />
+		public FileStream CreateAsyncWriteStream(string path)
+		{
 			path = ResolvePath(path);
-			using var file = new FileStream(
+			return new FileStream(
 				path,
 				FileMode.Create,
 				FileAccess.Write,
-				FileShare.ReadWrite,
+				FileShare.Read,
 				DefaultBufferSize,
 				FileOptions.Asynchronous | FileOptions.SequentialScan);
-			await file.WriteAsync(contents, cancellationToken);
 		}
 
 		/// <inheritdoc />

--- a/src/Tgstation.Server.Host/IO/IIOManager.cs
+++ b/src/Tgstation.Server.Host/IO/IIOManager.cs
@@ -102,6 +102,13 @@ namespace Tgstation.Server.Host.IO
 		Task<IReadOnlyList<string>> GetFiles(string path, CancellationToken cancellationToken);
 
 		/// <summary>
+		/// Creates a <see cref="FileStream"/> for writing.
+		/// </summary>
+		/// <param name="path">The path of the file to write, will be truncated.</param>
+		/// <returns>The open <see cref="FileStream"/>.</returns>
+		FileStream CreateAsyncWriteStream(string path);
+
+		/// <summary>
 		/// Writes some <paramref name="contents"/> to a file at <paramref name="path"/> overwriting previous content.
 		/// </summary>
 		/// <param name="path">The path of the file to write.</param>

--- a/src/Tgstation.Server.Host/Server.cs
+++ b/src/Tgstation.Server.Host/Server.cs
@@ -112,8 +112,7 @@ namespace Tgstation.Server.Host
 					{
 						if (b.FullPath == updatePath && File.Exists(b.FullPath))
 						{
-							if (logger != null)
-								logger.LogInformation("Host watchdog appears to be requesting server termination!");
+							logger?.LogInformation("Host watchdog appears to be requesting server termination!");
 							cancellationTokenSource.Cancel();
 						}
 					};
@@ -134,8 +133,7 @@ namespace Tgstation.Server.Host
 				}
 				catch (OperationCanceledException ex)
 				{
-					if (logger != null)
-						logger.LogDebug(ex, "Server run cancelled!");
+					logger?.LogDebug(ex, "Server run cancelled!");
 				}
 				catch (Exception ex)
 				{

--- a/src/Tgstation.Server.Host/System/IProcess.cs
+++ b/src/Tgstation.Server.Host/System/IProcess.cs
@@ -7,7 +7,7 @@ namespace Tgstation.Server.Host.System
 	/// <summary>
 	/// Abstraction over a <see cref="global::System.Diagnostics.Process"/>.
 	/// </summary>
-	interface IProcess : IProcessBase, IDisposable
+	interface IProcess : IProcessBase, IAsyncDisposable
 	{
 		/// <summary>
 		/// The <see cref="IProcess"/>' ID.
@@ -18,20 +18,6 @@ namespace Tgstation.Server.Host.System
 		/// The <see cref="Task"/> representing the time until the <see cref="IProcess"/> becomes "idle".
 		/// </summary>
 		Task Startup { get; }
-
-		/// <summary>
-		/// Get the stderr output of the <see cref="IProcess"/>.
-		/// </summary>
-		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
-		/// <returns>A <see cref="Task{TResult}"/> resulting in the stderr output of the <see cref="IProcess"/>.</returns>
-		Task<string> GetErrorOutput(CancellationToken cancellationToken);
-
-		/// <summary>
-		/// Get the stdout output of the <see cref="IProcess"/>.
-		/// </summary>
-		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
-		/// <returns>A <see cref="Task{TResult}"/> resulting in the stdout output of the <see cref="IProcess"/>.</returns>
-		Task<string> GetStandardOutput(CancellationToken cancellationToken);
 
 		/// <summary>
 		/// Get the stderr and stdout output of the <see cref="IProcess"/>.

--- a/src/Tgstation.Server.Host/System/IProcessExecutor.cs
+++ b/src/Tgstation.Server.Host/System/IProcessExecutor.cs
@@ -1,4 +1,6 @@
-﻿namespace Tgstation.Server.Host.System
+﻿using System.Threading.Tasks;
+
+namespace Tgstation.Server.Host.System
 {
 	/// <summary>
 	/// For launching <see cref="IProcess"/>'.
@@ -11,16 +13,16 @@
 		/// <param name="fileName">The full path to the executable file.</param>
 		/// <param name="workingDirectory">The working directory for the <see cref="IProcess"/>.</param>
 		/// <param name="arguments">The arguments for the <see cref="IProcess"/>.</param>
-		/// <param name="readOutput">If standard output should be read.</param>
-		/// <param name="readError">If standard error should be read.</param>
-		/// <param name="noShellExecute">If shell execute should not be used. Must be set if <paramref name="readError"/> or <paramref name="readOutput"/> are set.</param>
-		/// <returns>A new <see cref="IProcess"/>.</returns>
-		IProcess LaunchProcess(
+		/// <param name="fileRedirect">File to write process output and error streams to. Requires <paramref name="readStandardHandles"/> to be <see langword="true"/>.</param>
+		/// <param name="readStandardHandles">If the process output and error streams should be read.</param>
+		/// <param name="noShellExecute">If shell execute should not be used. Must be set if <paramref name="readStandardHandles"/> is set.</param>
+		/// <returns>A <see cref="Task"/> resulting in the new <see cref="IProcess"/>.</returns>
+		Task<IProcess> LaunchProcess(
 			string fileName,
 			string workingDirectory,
 			string arguments = null,
-			bool readOutput = false,
-			bool readError = false,
+			string fileRedirect = null,
+			bool readStandardHandles = false,
 			bool noShellExecute = false);
 
 		/// <summary>

--- a/src/Tgstation.Server.Host/System/PosixProcessFeatures.cs
+++ b/src/Tgstation.Server.Host/System/PosixProcessFeatures.cs
@@ -90,13 +90,12 @@ namespace Tgstation.Server.Host.System
 
 			string output;
 			int exitCode;
-			using (var gcoreProc = lazyLoadedProcessExecutor.Value.LaunchProcess(
+			await using (var gcoreProc = await lazyLoadedProcessExecutor.Value.LaunchProcess(
 				GCorePath,
 				Environment.CurrentDirectory,
 				$"-o {outputFile} {process.Id}",
-				true,
-				true,
-				true))
+				readStandardHandles: true,
+				noShellExecute: true))
 			{
 				using (cancellationToken.Register(() => gcoreProc.Terminate()))
 					exitCode = await gcoreProc.Lifetime;

--- a/src/Tgstation.Server.Host/System/ProcessExecutor.cs
+++ b/src/Tgstation.Server.Host/System/ProcessExecutor.cs
@@ -1,9 +1,13 @@
 ﻿using System;
 using System.IO;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
+
+using Tgstation.Server.Host.Extensions;
+using Tgstation.Server.Host.IO;
 
 namespace Tgstation.Server.Host.System
 {
@@ -16,6 +20,11 @@ namespace Tgstation.Server.Host.System
 		readonly IProcessFeatures processFeatures;
 
 		/// <summary>
+		/// The <see cref="IIOManager"/> for the <see cref="ProcessExecutor"/>.
+		/// </summary>
+		readonly IIOManager ioManager;
+
+		/// <summary>
 		/// The <see cref="ILogger"/> for the <see cref="ProcessExecutor"/>.
 		/// </summary>
 		readonly ILogger<ProcessExecutor> logger;
@@ -24,6 +33,150 @@ namespace Tgstation.Server.Host.System
 		/// The <see cref="ILoggerFactory"/> for the <see cref="ProcessExecutor"/>.
 		/// </summary>
 		readonly ILoggerFactory loggerFactory;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ProcessExecutor"/> class.
+		/// </summary>
+		/// <param name="processFeatures">The value of <see cref="processFeatures"/>.</param>
+		/// <param name="ioManager">The value of <see cref="ioManager"/>.</param>
+		/// <param name="logger">The value of <see cref="logger"/>.</param>
+		/// <param name="loggerFactory">The value of <see cref="loggerFactory"/>.</param>
+		public ProcessExecutor(
+			IProcessFeatures processFeatures,
+			IIOManager ioManager,
+			ILogger<ProcessExecutor> logger,
+			ILoggerFactory loggerFactory)
+		{
+			this.processFeatures = processFeatures ?? throw new ArgumentNullException(nameof(processFeatures));
+			this.ioManager = ioManager ?? throw new ArgumentNullException(nameof(ioManager));
+			this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+			this.loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
+		}
+
+		/// <inheritdoc />
+		public IProcess GetProcess(int id)
+		{
+			logger.LogDebug("Attaching to process {0}...", id);
+			global::System.Diagnostics.Process handle;
+			try
+			{
+				handle = global::System.Diagnostics.Process.GetProcessById(id);
+			}
+			catch (Exception e)
+			{
+				logger.LogDebug(e, "Unable to get process {0}!", id);
+				return null;
+			}
+
+			return CreateFromExistingHandle(handle);
+		}
+
+		/// <inheritdoc />
+		public IProcess GetCurrentProcess()
+		{
+			logger.LogTrace("Getting current process...");
+			var handle = global::System.Diagnostics.Process.GetCurrentProcess();
+			return CreateFromExistingHandle(handle);
+		}
+
+		/// <inheritdoc />
+		public async Task<IProcess> LaunchProcess(
+			string fileName,
+			string workingDirectory,
+			string arguments,
+			string fileRedirect,
+			bool readStandardHandles,
+			bool noShellExecute)
+		{
+			if (fileName == null)
+				throw new ArgumentNullException(nameof(fileName));
+			if (workingDirectory == null)
+				throw new ArgumentNullException(nameof(workingDirectory));
+			if (arguments == null)
+				throw new ArgumentNullException(nameof(arguments));
+
+			if (!noShellExecute && readStandardHandles)
+				throw new InvalidOperationException("Requesting output/error reading requires noShellExecute to be true!");
+
+			logger.LogDebug(
+				"{0}aunching process in {1}: {2} {3}",
+				noShellExecute ? "L" : "Shell l",
+				workingDirectory,
+				fileName,
+				arguments);
+			var handle = new global::System.Diagnostics.Process();
+			try
+			{
+				handle.StartInfo.FileName = fileName;
+				handle.StartInfo.Arguments = arguments;
+				handle.StartInfo.WorkingDirectory = workingDirectory;
+
+				handle.StartInfo.UseShellExecute = !noShellExecute;
+
+				var processStartTcs = new TaskCompletionSource();
+				var lifetimeTaskTask = AttachExitHandlerBeforeLaunch(handle, processStartTcs.Task);
+
+				Task<string> readTask = null;
+				CancellationTokenSource disposeCts = null;
+				if (readStandardHandles)
+				{
+					handle.StartInfo.RedirectStandardOutput = true;
+					handle.StartInfo.RedirectStandardError = true;
+
+					disposeCts = new CancellationTokenSource();
+					readTask = ConsumeReaders(handle, processStartTcs.Task, fileRedirect, disposeCts.Token);
+				}
+
+				try
+				{
+					handle.Start();
+
+					processStartTcs.SetResult();
+				}
+				catch (Exception ex)
+				{
+					processStartTcs.SetException(ex);
+					throw;
+				}
+
+				var process = new Process(
+					processFeatures,
+					handle,
+					disposeCts,
+					await lifetimeTaskTask, // won't block
+					readTask,
+					loggerFactory.CreateLogger<Process>(),
+					false);
+
+				return process;
+			}
+			catch
+			{
+				handle.Dispose();
+				throw;
+			}
+		}
+
+		/// <inheritdoc />
+		public IProcess GetProcessByName(string name)
+		{
+			logger.LogTrace("GetProcessByName: {processName}...", name ?? throw new ArgumentNullException(nameof(name)));
+			var procs = global::System.Diagnostics.Process.GetProcessesByName(name);
+			global::System.Diagnostics.Process handle = null;
+			foreach (var proc in procs)
+				if (handle == null)
+					handle = proc;
+				else
+				{
+					logger.LogTrace("Disposing extra found PID: {pid}...", proc.Id);
+					proc.Dispose();
+				}
+
+			if (handle == null)
+				return null;
+
+			return CreateFromExistingHandle(handle);
+		}
 
 		/// <summary>
 		/// Wrapper for <see cref="AttachExitHandler(global::System.Diagnostics.Process, Func{int})"/> to safely provide the process ID.
@@ -92,180 +245,81 @@ namespace Tgstation.Server.Host.System
 		}
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="ProcessExecutor"/> class.
+		/// Consume the stdout/stderr streams into a <see cref="Task"/>.
 		/// </summary>
-		/// <param name="processFeatures">The value of <see cref="processFeatures"/>.</param>
-		/// <param name="logger">The value of <see cref="logger"/>.</param>
-		/// <param name="loggerFactory">The value of <see cref="loggerFactory"/>.</param>
-		public ProcessExecutor(
-			IProcessFeatures processFeatures,
-			ILogger<ProcessExecutor> logger,
-			ILoggerFactory loggerFactory)
+		/// <param name="handle">The <see cref="global::System.Diagnostics.Process"/>.</param>
+		/// <param name="startTask">The <see cref="Task"/> that completes when <paramref name="handle"/> starts.</param>
+		/// <param name="fileRedirect">The optional path to redirect the streams to.</param>
+		/// <param name="disposeToken">The <see cref="CancellationToken"/> that triggers when the <see cref="Process"/> is disposed.</param>
+		/// <returns>A <see cref="Task{TResult}"/> resulting in the program's output/error text if <paramref name="fileRedirect"/> is <see langword="null"/>, <see langword="null"/> otherwise.</returns>
+		async Task<string> ConsumeReaders(global::System.Diagnostics.Process handle, Task startTask, string fileRedirect, CancellationToken disposeToken)
 		{
-			this.processFeatures = processFeatures ?? throw new ArgumentNullException(nameof(processFeatures));
-			this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
-			this.loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
-		}
+			await startTask;
 
-		/// <inheritdoc />
-		public IProcess GetProcess(int id)
-		{
-			logger.LogDebug("Attaching to process {0}...", id);
-			global::System.Diagnostics.Process handle;
-			try
+			var pid = handle.Id;
+			logger.LogTrace("Starting read for PID {pid}...", pid);
+
+			var stdOutHandle = handle.StandardOutput;
+			var stdErrHandle = handle.StandardError;
+			Task<string> outputReadTask = null, errorReadTask = null;
+			bool outputOpen = true, errorOpen = true;
+			async Task<string> GetNextLine()
 			{
-				handle = global::System.Diagnostics.Process.GetProcessById(id);
-			}
-			catch (Exception e)
-			{
-				logger.LogDebug(e, "Unable to get process {0}!", id);
-				return null;
-			}
+				if (outputOpen && outputReadTask == null)
+					outputReadTask = stdOutHandle.ReadLineAsync();
 
-			return CreateFromExistingHandle(handle);
-		}
+				if (errorOpen && errorReadTask == null)
+					errorReadTask = stdErrHandle.ReadLineAsync();
 
-		/// <inheritdoc />
-		public IProcess GetCurrentProcess()
-		{
-			logger.LogTrace("Getting current process...");
-			var handle = global::System.Diagnostics.Process.GetCurrentProcess();
-			return CreateFromExistingHandle(handle);
-		}
-
-		/// <inheritdoc />
-		public IProcess LaunchProcess(
-			string fileName,
-			string workingDirectory,
-			string arguments,
-			bool readOutput,
-			bool readError,
-			bool noShellExecute)
-		{
-			if (fileName == null)
-				throw new ArgumentNullException(nameof(fileName));
-			if (workingDirectory == null)
-				throw new ArgumentNullException(nameof(workingDirectory));
-			if (arguments == null)
-				throw new ArgumentNullException(nameof(arguments));
-
-			if (!noShellExecute && (readOutput || readError))
-				throw new InvalidOperationException("Requesting output/error reading requires noShellExecute to be true!");
-
-			logger.LogDebug(
-				"{0}aunching process in {1}: {2} {3}",
-				noShellExecute ? "L" : "Shell l",
-				workingDirectory,
-				fileName,
-				arguments);
-			var handle = new global::System.Diagnostics.Process();
-			try
-			{
-				handle.StartInfo.FileName = fileName;
-				handle.StartInfo.Arguments = arguments;
-				handle.StartInfo.WorkingDirectory = workingDirectory;
-
-				handle.StartInfo.UseShellExecute = !noShellExecute;
-
-				StringBuilder combinedStringBuilder = null;
-
-				Task<string> outputTask = null;
-				Task<string> errorTask = null;
-				var processStartTcs = new TaskCompletionSource<object>();
-				if (readOutput || readError)
+				var completedTask = await Task.WhenAny(outputReadTask ?? errorReadTask, errorReadTask ?? outputReadTask).WithToken(disposeToken);
+				var line = await completedTask;
+				if (completedTask == outputReadTask)
 				{
-					combinedStringBuilder = new StringBuilder();
-
-					async Task<string> ConsumeReader(Func<TextReader> readerFunc, bool isOutputStream)
-					{
-						var stringBuilder = new StringBuilder();
-						string text;
-
-						await processStartTcs.Task;
-
-						var pid = handle.Id;
-						var streamType = isOutputStream ? "out" : "err";
-						logger.LogTrace("Starting std{0} read for PID {1}...", streamType, pid);
-
-						var reader = readerFunc();
-						while ((text = await reader.ReadLineAsync()) != null)
-						{
-							combinedStringBuilder.AppendLine();
-							combinedStringBuilder.Append(text);
-							stringBuilder.AppendLine();
-							stringBuilder.Append(text);
-						}
-
-						logger.LogTrace("Finished std{0} read for PID {1}", streamType, pid);
-
-						return stringBuilder.ToString();
-					}
-
-					if (readOutput)
-					{
-						outputTask = ConsumeReader(() => handle.StandardOutput, true);
-						handle.StartInfo.RedirectStandardOutput = true;
-					}
-
-					if (readError)
-					{
-						errorTask = ConsumeReader(() => handle.StandardError, false);
-						handle.StartInfo.RedirectStandardError = true;
-					}
+					outputReadTask = null;
+					if (line == null)
+						outputOpen = false;
 				}
-
-				var lifetimeTaskTask = AttachExitHandlerBeforeLaunch(handle, processStartTcs.Task);
-
-				try
-				{
-					handle.Start();
-
-					processStartTcs.SetResult(null);
-				}
-				catch (Exception ex)
-				{
-					processStartTcs.SetException(ex);
-					throw;
-				}
-
-				var process = new Process(
-					processFeatures,
-					handle,
-					lifetimeTaskTask.GetAwaiter().GetResult(), // won't block
-					outputTask,
-					errorTask,
-					combinedStringBuilder,
-					loggerFactory.CreateLogger<Process>(),
-					false);
-
-				return process;
-			}
-			catch
-			{
-				handle.Dispose();
-				throw;
-			}
-		}
-
-		/// <inheritdoc />
-		public IProcess GetProcessByName(string name)
-		{
-			logger.LogTrace("GetProcessByName: {processName}...", name ?? throw new ArgumentNullException(nameof(name)));
-			var procs = global::System.Diagnostics.Process.GetProcessesByName(name);
-			global::System.Diagnostics.Process handle = null;
-			foreach (var proc in procs)
-				if (handle == null)
-					handle = proc;
 				else
 				{
-					logger.LogTrace("Disposing extra found PID: {pid}...", proc.Id);
-					proc.Dispose();
+					errorReadTask = null;
+					if (line == null)
+						errorOpen = false;
 				}
 
-			if (handle == null)
-				return null;
+				if (line == null && (errorOpen || outputOpen))
+					return await GetNextLine();
 
-			return CreateFromExistingHandle(handle);
+				return line;
+			}
+
+			using var fileStream = fileRedirect != null ? ioManager.CreateAsyncWriteStream(fileRedirect) : null;
+			using var writer = fileStream != null ? new StreamWriter(fileStream) : null;
+
+			string text;
+			var stringBuilder = fileStream == null ? new StringBuilder() : null;
+			try
+			{
+				while ((text = await GetNextLine()) != null)
+				{
+					if (fileStream != null)
+					{
+						await writer.WriteLineAsync(text);
+						await writer.FlushAsync();
+					}
+					else
+						stringBuilder.AppendLine(text);
+				}
+
+				logger.LogTrace("Finished read for PID {pid}", pid);
+			}
+			catch (OperationCanceledException ex)
+			{
+				logger.LogWarning(ex, "PID {pid} stream reading interrupted!", pid);
+				if (fileStream != null)
+					await writer.WriteLineAsync("-- Process detached, log truncated. This is likely due a to TGS restart --");
+			}
+
+			return stringBuilder?.ToString();
 		}
 
 		/// <summary>
@@ -273,7 +327,7 @@ namespace Tgstation.Server.Host.System
 		/// </summary>
 		/// <param name="handle">The <see cref="global::System.Diagnostics.Process"/> to create a <see cref="IProcess"/> from.</param>
 		/// <returns>The <see cref="IProcess"/> based on <paramref name="handle"/>.</returns>
-		private IProcess CreateFromExistingHandle(global::System.Diagnostics.Process handle)
+		IProcess CreateFromExistingHandle(global::System.Diagnostics.Process handle)
 		{
 			try
 			{
@@ -281,9 +335,8 @@ namespace Tgstation.Server.Host.System
 				return new Process(
 					processFeatures,
 					handle,
+					null,
 					AttachExitHandler(handle, () => pid),
-					null,
-					null,
 					null,
 					loggerFactory.CreateLogger<Process>(),
 					true);

--- a/tests/Tgstation.Server.Host.Tests/System/TestPosixSignalHandler.cs
+++ b/tests/Tgstation.Server.Host.Tests/System/TestPosixSignalHandler.cs
@@ -59,14 +59,15 @@ namespace Tgstation.Server.Host.System.Tests
 					new Lazy<IProcessExecutor>(() => processExecutor),
 					new DefaultIOManager(new AssemblyInformationProvider()),
 					loggerFactory.CreateLogger<PosixProcessFeatures>()),
+				Mock.Of<IIOManager>(),
 				loggerFactory.CreateLogger<ProcessExecutor>(),
 				loggerFactory);
-			using var subProc = processExecutor
+			await using var subProc = await processExecutor
 				.LaunchProcess(
 					"dotnet",
 					pathToSignalTestApp,
 					$"run -c {CurrentConfig} --no-build",
-					true,
+					null,
 					true,
 					true);
 

--- a/tests/Tgstation.Server.Tests/Instance/WatchdogTest.cs
+++ b/tests/Tgstation.Server.Tests/Instance/WatchdogTest.cs
@@ -230,11 +230,12 @@ namespace Tgstation.Server.Tests.Instance
 			IProcessExecutor executor = null;
 			executor = new ProcessExecutor(
 				RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-					? (IProcessFeatures)new WindowsProcessFeatures(Mock.Of<ILogger<WindowsProcessFeatures>>())
+					? new WindowsProcessFeatures(Mock.Of<ILogger<WindowsProcessFeatures>>())
 					: new PosixProcessFeatures(new Lazy<IProcessExecutor>(() => executor), Mock.Of<IIOManager>(), Mock.Of<ILogger<PosixProcessFeatures>>()),
+				Mock.Of<IIOManager>(),
 				Mock.Of<ILogger<ProcessExecutor>>(),
 				LoggerFactory.Create(x => { }));
-			using var ourProcessHandler = executor
+			await using var ourProcessHandler = executor
 				.GetProcess(ddProc.Id);
 
 			// Ensure it's responding to heartbeats

--- a/tests/Tgstation.Server.Tests/IntegrationTest.cs
+++ b/tests/Tgstation.Server.Tests/IntegrationTest.cs
@@ -754,6 +754,7 @@ namespace Tgstation.Server.Tests
 					TopicRequestTimeout = 1000,
 					AdditionalParameters = String.Empty,
 					StartProfiler =	false,
+					LogOutput = true,
 				},
 				DreamMakerSettings = new Host.Models.DreamMakerSettings
 				{


### PR DESCRIPTION
:cl:
Add support for streaming DreamDaemon output to file. Restarting TGS while this is happening will result in a truncated log.
Fixed potential errors in deployment process.
/:cl:

:cl: HTTP API
Added `logOutput` boolean field to DreamDaemon model. Defaults to `false` for new and migrated instances.
Added DreamDaemon right 262144 for modifying this field.
/:cl:

:cl: DreamMaker API
Added `/datum/tgs_chat_command/var/ignore_type` to allow for abstract base /datums without triggering a DMAPI error log.
/:cl:

Merge with `[APIDeploy][DMDeploy]`