### PR TITLE
Fix Directory Deletion

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>5.7.1</TgsCoreVersion>
+    <TgsCoreVersion>5.7.2</TgsCoreVersion>
     <TgsConfigVersion>4.4.0</TgsConfigVersion>
     <TgsApiVersion>9.9.0</TgsApiVersion>
     <TgsApiLibraryVersion>10.3.0</TgsApiLibraryVersion>

--- a/tests/Tgstation.Server.Host.Tests/IO/TestIOManager.cs
+++ b/tests/Tgstation.Server.Host.Tests/IO/TestIOManager.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using System.IO;
+using System.Threading.Tasks;
+
+using Tgstation.Server.Host.System;
+
+namespace Tgstation.Server.Host.IO.Tests
+{
+	[TestClass]
+	public sealed class TestIOManager
+	{
+		readonly IIOManager ioManager = new DefaultIOManager(new AssemblyInformationProvider());
+
+		[TestMethod]
+		public async Task TestDeleteDirectory()
+		{
+			var tempPath = Path.GetTempFileName();
+			File.Delete(tempPath);
+			Directory.CreateDirectory(tempPath);
+			try
+			{
+				await ioManager.DeleteDirectory(tempPath, default);
+
+				Assert.IsFalse(Directory.Exists(tempPath));
+			}
+			catch
+			{
+				Directory.Delete(tempPath);
+				throw;
+			}
+		}
+
+		[TestMethod]
+		public async Task TestDirectoryExists()
+		{
+			var tempPath = Path.GetTempFileName();
+			File.Delete(tempPath);
+
+			Assert.IsFalse(await ioManager.DirectoryExists(tempPath, default));
+
+			Directory.CreateDirectory(tempPath);
+
+			try
+			{
+				Assert.IsTrue(await ioManager.DirectoryExists(tempPath, default));
+			}
+			catch
+			{
+				Directory.Delete(tempPath);
+				throw;
+			}
+		}
+	}
+}

--- a/tests/Tgstation.Server.Tests/Instance/ConfigurationTest.cs
+++ b/tests/Tgstation.Server.Tests/Instance/ConfigurationTest.cs
@@ -87,6 +87,14 @@ namespace Tgstation.Server.Tests.Instance
 			var tmp = (TestDir.Path?.StartsWith('/') ?? false) ? '.' + TestDir.Path : TestDir.Path;
 			var path = Path.Combine(instance.Path, "Configuration", tmp);
 			Assert.IsFalse(Directory.Exists(path));
+
+			// leave a directory there to test the deployment process
+			var staticDir = new ConfigurationFileRequest
+			{
+				Path = "/GameStaticFiles/data"
+			};
+
+			await configurationClient.CreateDirectory(staticDir, cancellationToken);
 		}
 
 		public async Task Run(CancellationToken cancellationToken)

--- a/tests/Tgstation.Server.Tests/Instance/ConfigurationTest.cs
+++ b/tests/Tgstation.Server.Tests/Instance/ConfigurationTest.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Net.Http;
 using System.Net.Mime;


### PR DESCRIPTION
:cl:
Fix directory deletion not working as intended.
/:cl:

TL;DR Task (Thread) to delete the directory was created, not awaited. Caused issues b/c creating the config/data folders need to delete the old ones in the deployment directory first.