### PR TITLE
Add's a UserInformationUrlOverride configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Security:
       ClientSecret: "..."
       RedirectUrl: "..."
       ServerUrl: "..."
+	  UserInformationUrlOverride: "..." # For power users, leave out of configuration for most cases. Not supported by GitHub provider.
 ```
 The following providers use the `RedirectUrl` setting:
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Security:
       ClientSecret: "..."
       RedirectUrl: "..."
       ServerUrl: "..."
-	  UserInformationUrlOverride: "..." # For power users, leave out of configuration for most cases. Not supported by GitHub provider.
+      UserInformationUrlOverride: "..." # For power users, leave out of configuration for most cases. Not supported by GitHub provider.
 ```
 The following providers use the `RedirectUrl` setting:
 

--- a/build/ControlPanelVersion.props
+++ b/build/ControlPanelVersion.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <!-- This is in it's own file to help incremental building, changing it causes a complete rebuild of the web panel -->
-    <TgsControlPanelVersion>4.17.0</TgsControlPanelVersion>
+    <TgsControlPanelVersion>4.18.0</TgsControlPanelVersion>
   </PropertyGroup>
 </Project>

--- a/build/Version.props
+++ b/build/Version.props
@@ -4,7 +4,7 @@
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
     <TgsCoreVersion>5.7.3</TgsCoreVersion>
-    <TgsConfigVersion>4.4.0</TgsConfigVersion>
+    <TgsConfigVersion>4.5.0</TgsConfigVersion>
     <TgsApiVersion>9.9.0</TgsApiVersion>
     <TgsApiLibraryVersion>10.3.0</TgsApiLibraryVersion>
     <TgsClientVersion>11.3.0</TgsClientVersion>

--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>5.7.3</TgsCoreVersion>
+    <TgsCoreVersion>5.8.0</TgsCoreVersion>
     <TgsConfigVersion>4.5.0</TgsConfigVersion>
     <TgsApiVersion>9.9.0</TgsApiVersion>
     <TgsApiLibraryVersion>10.3.0</TgsApiLibraryVersion>

--- a/src/Tgstation.Server.Host/Configuration/OAuthConfiguration.cs
+++ b/src/Tgstation.Server.Host/Configuration/OAuthConfiguration.cs
@@ -16,5 +16,10 @@ namespace Tgstation.Server.Host.Configuration
 		/// The authentication server URL. Not used by all providers.
 		/// </summary>
 		public Uri RedirectUrl { get; set; }
+
+		/// <summary>
+		/// User information URL override. Not supported by the <see cref="Api.Models.OAuthProvider.GitHub"/> provider.
+		/// </summary>
+		public Uri UserInformationUrlOverride { get; set; }
 	}
 }

--- a/src/Tgstation.Server.Host/Security/OAuth/GenericOAuthValidator.cs
+++ b/src/Tgstation.Server.Host/Security/OAuth/GenericOAuthValidator.cs
@@ -121,7 +121,9 @@ namespace Tgstation.Server.Host.Security.OAuth
 				}
 
 				Logger.LogTrace("Getting user details...");
-				using var userInformationRequest = new HttpRequestMessage(HttpMethod.Get, UserInformationUrl);
+
+				var userInfoUrl = OAuthConfiguration?.UserInformationUrlOverride ?? UserInformationUrl;
+				using var userInformationRequest = new HttpRequestMessage(HttpMethod.Get, userInfoUrl);
 				userInformationRequest.Headers.Authorization = new AuthenticationHeaderValue(
 					ApiHeaders.BearerAuthenticationScheme,
 					accessToken);


### PR DESCRIPTION
:cl: **Configuration**
**The new configuration version is 4.4.0.**
Added `UserInformationUrlOverride` option to OAuth configuration items. For power users only. Does not work with the GitHub provider.
/:cl:

:cl:
Fixed logging exception when a Discord guild failed to be retrieved.
/:cl:

55a015bf310f65d96ee4608a5101bab175961564 ^