### PR TITLE
Discord replies no longer mention the user.

### DIFF
--- a/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordProvider.cs
@@ -224,9 +224,20 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		public override async Task SendMessage(Message replyTo, MessageContent message, ulong channelId, CancellationToken cancellationToken)
 		{
 			Optional<IMessageReference> replyToReference = default;
+			Optional<IAllowedMentions> allowedMentions = default;
 			if (replyTo != null && replyTo is DiscordMessage discordMessage)
 			{
 				replyToReference = discordMessage.MessageReference;
+				allowedMentions = new AllowedMentions( 
+					//reset settings back to how discord acts if this is not passed (which is different than the default if empty)
+					Parse: [
+						MentionType.Everyone,
+						MentionType.Roles,
+						MentionType.Users
+					],
+					//disable reply mentions
+					MentionRepliedUser = false
+				);
 			}
 
 			var embeds = ConvertEmbed(message.Embed);
@@ -239,6 +250,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 					message.Text,
 					embeds: embeds,
 					messageReference: replyToReference,
+					allowedMentions: allowedMentions,
 					ct: cancellationToken);
 
 				if (!result.IsSuccess)


### PR DESCRIPTION
I don't want this clogging up my mentions inbox (which i check for things i forgot to do) every time i do !tgs. and it will once there are 7 bots on tgs 5 and all 7 of them mention me every time I use a command.

There is no need to mention or ping the user for a response to a message they sent less than a second ago. 

The goal of a mention is to alert the user there is a message they might want to see, but in this case, they kinda know, given they just sent the command.

I likey broke something given im using c# concepts i know nothing about 10 years after the last c# code i wrote.

