### PR TITLE
Fix some events getting relayed to DreamDaemon unintentionally

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>5.8.0</TgsCoreVersion>
+    <TgsCoreVersion>5.9.0</TgsCoreVersion>
     <TgsConfigVersion>4.5.0</TgsConfigVersion>
     <TgsApiVersion>9.9.0</TgsApiVersion>
     <TgsApiLibraryVersion>10.3.0</TgsApiLibraryVersion>

--- a/src/DMAPI/tgs/v5/commands.dm
+++ b/src/DMAPI/tgs/v5/commands.dm
@@ -36,10 +36,10 @@
 		var/datum/tgs_message_content/response = sc.Run(u, params)
 		response = UpgradeDeprecatedCommandResponse(response, command)
 		
-		var/list/topic_response = list()
+		var/list/topic_response = TopicResponse()
 		topic_response[DMAPI5_TOPIC_RESPONSE_COMMAND_RESPONSE_MESSAGE] = response?.text
 		topic_response[DMAPI5_TOPIC_RESPONSE_COMMAND_RESPONSE] = response?._interop_serialize()
-		return json_encode(topic_response)
+		return topic_response
 	return TopicResponse("Unknown custom chat command: [command]!")
 
 // Common proc b/c it's used by the V3/V4 APIs

--- a/src/Tgstation.Server.Api/Tgstation.Server.Api.csproj
+++ b/src/Tgstation.Server.Api/Tgstation.Server.Api.csproj
@@ -46,12 +46,16 @@
   </Target>
 
   <ItemGroup>
+    <!-- Usage: HTTP constants reference -->
     <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.2.0" />
+    <!-- Usage: Primary JSON library -->
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <!-- Usage: Linting -->
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <!-- Usage: Data model annotating -->
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/Tgstation.Server.Client/Tgstation.Server.Client.csproj
+++ b/src/Tgstation.Server.Client/Tgstation.Server.Client.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../../build/Version.props" />
 
   <PropertyGroup>
@@ -32,6 +32,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Usage: Linting -->
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Tgstation.Server.Host.Console/Tgstation.Server.Host.Console.csproj
+++ b/src/Tgstation.Server.Host.Console/Tgstation.Server.Host.Console.csproj
@@ -24,8 +24,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- DO NOT UPDATE UNLESS YOU WANT TO DEAL WITH THE LOGGERFACTORY REFACTOR -->
+    <!-- Usage: Console logging plugin -->
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <!-- Usage: Linting -->
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Tgstation.Server.Host.Service/Tgstation.Server.Host.Service.csproj
+++ b/src/Tgstation.Server.Host.Service/Tgstation.Server.Host.Service.csproj
@@ -23,17 +23,18 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Usage: Command line argument support -->
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <!-- Usage: Windows event log logging plugin -->
     <PackageReference Include="Microsoft.Extensions.Logging.EventLog" Version="6.0.0" />
+    <!-- Usage: Console logging plugin -->
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <!-- Usage: Linting -->
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <!-- Usage: OS identification -->
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/Tgstation.Server.Host.Watchdog/Tgstation.Server.Host.Watchdog.csproj
+++ b/src/Tgstation.Server.Host.Watchdog/Tgstation.Server.Host.Watchdog.csproj
@@ -24,12 +24,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <!-- DO NOT UPDATE UNLESS YOU WANT TO DEAL WITH THE LOGGERFACTORY REFACTOR -->
+    <!-- Usage: Logging abstractions -->
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <!-- Usage: Linting -->
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Tgstation.Server.Host/Components/Byond/ByondManager.cs
+++ b/src/Tgstation.Server.Host/Components/Byond/ByondManager.cs
@@ -276,7 +276,7 @@ namespace Tgstation.Server.Host.Components.Byond
 		/// <returns>A <see cref="Task"/> representing the running operation.</returns>
 		async Task<string> InstallVersion(Version version, Stream customVersionStream, CancellationToken cancellationToken)
 		{
-			var ourTcs = new TaskCompletionSource<object>();
+			var ourTcs = new TaskCompletionSource();
 			Task inProgressTask;
 			string versionKey;
 			bool installed;
@@ -370,7 +370,7 @@ namespace Tgstation.Server.Host.Components.Byond
 					throw;
 				}
 
-				ourTcs.SetResult(null);
+				ourTcs.SetResult();
 			}
 			catch (Exception e)
 			{

--- a/src/Tgstation.Server.Host/Components/Chat/ChatManager.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/ChatManager.cs
@@ -483,6 +483,8 @@ namespace Tgstation.Server.Host.Components.Chat
 			logger.LogTrace("DeleteConnection {connectionId}", connectionId);
 			var provider = await RemoveProviderChannels(connectionId, true, cancellationToken);
 			if (provider != null)
+			{
+				var startTime = DateTimeOffset.UtcNow;
 				try
 				{
 					await provider.Disconnect(cancellationToken);
@@ -490,7 +492,11 @@ namespace Tgstation.Server.Host.Components.Chat
 				finally
 				{
 					await provider.DisposeAsync();
+					var duration = DateTimeOffset.UtcNow - startTime;
+					if (duration.TotalSeconds > 3)
+						logger.LogWarning("Disconnecting a {providerType} took {totalSeconds}s!", provider.GetType().Name, duration.TotalSeconds);
 				}
+			}
 			else
 				logger.LogTrace("DeleteConnection: ID {connectionId} doesn't exist!", connectionId);
 		}

--- a/src/Tgstation.Server.Host/Components/Chat/ChatManager.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/ChatManager.cs
@@ -109,9 +109,9 @@ namespace Tgstation.Server.Host.Components.Chat
 		Task messageSendTask;
 
 		/// <summary>
-		/// The <see cref="TaskCompletionSource{TResult}"/> that completes when <see cref="ChatBotSettings"/>s change.
+		/// The <see cref="TaskCompletionSource"/> that completes when <see cref="ChatBotSettings"/>s change.
 		/// </summary>
-		TaskCompletionSource<object> connectionsUpdated;
+		TaskCompletionSource connectionsUpdated;
 
 		/// <summary>
 		/// Used for remapping <see cref="ChannelRepresentation.RealId"/>s.
@@ -157,7 +157,7 @@ namespace Tgstation.Server.Host.Components.Chat
 			mappedChannels = new Dictionary<ulong, ChannelMapping>();
 			trackingContexts = new List<IChatTrackingContext>();
 			handlerCts = new CancellationTokenSource();
-			connectionsUpdated = new TaskCompletionSource<object>();
+			connectionsUpdated = new TaskCompletionSource();
 
 			messageSendTask = Task.CompletedTask;
 			channelIdCounter = 1;
@@ -293,8 +293,8 @@ namespace Tgstation.Server.Host.Components.Chat
 			{
 				// same thread shennanigans
 				var oldOne = connectionsUpdated;
-				connectionsUpdated = new TaskCompletionSource<object>();
-				oldOne.SetResult(null);
+				connectionsUpdated = new TaskCompletionSource();
+				oldOne.SetResult();
 			}
 
 			var reconnectionUpdateTask = provider?.SetReconnectInterval(

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordProvider.cs
@@ -88,9 +88,9 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		CancellationTokenSource gatewayCts;
 
 		/// <summary>
-		/// The <see cref="TaskCompletionSource{TResult}"/> for the initial gateway connection event.
+		/// The <see cref="TaskCompletionSource"/> for the initial gateway connection event.
 		/// </summary>
-		TaskCompletionSource<object> gatewayReadyTcs;
+		TaskCompletionSource gatewayReadyTcs;
 
 		/// <summary>
 		/// The <see cref="Task"/> representing the lifetime of the client.
@@ -559,7 +559,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 				throw new ArgumentNullException(nameof(readyEvent));
 
 			Logger.LogTrace("Gatway ready. Version: {version}", readyEvent.Version);
-			gatewayReadyTcs?.TrySetResult(null);
+			gatewayReadyTcs?.TrySetResult();
 			return Task.FromResult(Result.FromSuccess());
 		}
 
@@ -580,7 +580,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 				var gatewayClient = serviceProvider.GetRequiredService<DiscordGatewayClient>();
 
 				Task<Result> localGatewayTask;
-				gatewayReadyTcs = new TaskCompletionSource<object>();
+				gatewayReadyTcs = new TaskCompletionSource();
 
 				using var gatewayConnectionAbortRegistration = cancellationToken.Register(() => gatewayReadyTcs.TrySetCanceled());
 				gatewayCancellationToken.Register(() => Logger.LogTrace("Stopping gateway client..."));

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordProvider.cs
@@ -145,14 +145,14 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 				new EmbedField(
 					"Local Commit",
 					localCommitPushed && gitHub
-						? $"[{revisionInformation.CommitSha.Substring(0, 7)}](https://github.com/{gitHubOwner}/{gitHubRepo}/commit/{revisionInformation.CommitSha})"
-						: revisionInformation.CommitSha.Substring(0, 7),
+						? $"[{revisionInformation.CommitSha[..7]}](https://github.com/{gitHubOwner}/{gitHubRepo}/commit/{revisionInformation.CommitSha})"
+						: revisionInformation.CommitSha[..7],
 					true),
 				new EmbedField(
 					"Branch Commit",
 					gitHub
-						? $"[{revisionInformation.OriginCommitSha.Substring(0, 7)}](https://github.com/{gitHubOwner}/{gitHubRepo}/commit/{revisionInformation.OriginCommitSha})"
-						: revisionInformation.OriginCommitSha.Substring(0, 7),
+						? $"[{revisionInformation.OriginCommitSha[..7]}](https://github.com/{gitHubOwner}/{gitHubRepo}/commit/{revisionInformation.OriginCommitSha})"
+						: revisionInformation.OriginCommitSha[..7],
 					true),
 			};
 
@@ -160,7 +160,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 				.Select(x => x.TestMerge)
 				.Select(x => new EmbedField(
 					$"#{x.Number}",
-					$"[{x.TitleAtMerge}]({x.Url}) by _[@{x.Author}](https://github.com/{x.Author})_{Environment.NewLine}Commit: [{x.TargetCommitSha.Substring(0, 7)}](https://github.com/{gitHubOwner}/{gitHubRepo}/commit/{x.TargetCommitSha}){(String.IsNullOrWhiteSpace(x.Comment) ? String.Empty : $"{Environment.NewLine}_**{x.Comment}**_")}",
+					$"[{x.TitleAtMerge}]({x.Url}) by _[@{x.Author}](https://github.com/{x.Author})_{Environment.NewLine}Commit: [{x.TargetCommitSha[..7]}](https://github.com/{gitHubOwner}/{gitHubRepo}/commit/{x.TargetCommitSha}){(String.IsNullOrWhiteSpace(x.Comment) ? String.Empty : $"{Environment.NewLine}_**{x.Comment}**_")}",
 					false)));
 
 			return fields;
@@ -253,7 +253,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 
 				if (!result.IsSuccess)
 					Logger.LogWarning(
-						"Failed to send to channel {0}: {1}",
+						"Failed to send to channel {channelId}: {error}",
 						channelId,
 						result.Error);
 			}
@@ -267,7 +267,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 					if (!currentGuildsResponse.IsSuccess)
 					{
 						Logger.LogWarning(
-							"Error retrieving current discord guilds: {0}",
+							"Error retrieving current discord guilds: {error}",
 							currentGuildsResponse.Error.Message);
 						return;
 					}
@@ -758,10 +758,10 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 			if (embed == null)
 				return default;
 
-			List<string> embedErrors = new List<string>();
+			var embedErrors = new List<string>();
 			Optional<Color> colour = default;
 			if (embed.Colour != null)
-				if (Int32.TryParse(embed.Colour.Substring(1), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var argb))
+				if (Int32.TryParse(embed.Colour[1..], NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var argb))
 					colour = Color.FromArgb(argb);
 				else
 					embedErrors.Add(

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/IrcProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/IrcProvider.cs
@@ -168,8 +168,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 				// IRC doesn't allow newlines
 				// Explicitly ignore embeds
 				var messageText = message.Text;
-				if (messageText == null)
-					messageText = $"Embed Only: {JsonConvert.SerializeObject(message.Embed)}";
+				messageText ??= $"Embed Only: {JsonConvert.SerializeObject(message.Embed)}";
 
 				messageText = String.Concat(
 					messageText

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/IrcProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/IrcProvider.cs
@@ -380,7 +380,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 				Logger.LogTrace("Processing initial messages...");
 				await NonBlockingListen(cancellationToken);
 
-				var nickCheckCompleteTcs = new TaskCompletionSource<object>();
+				var nickCheckCompleteTcs = new TaskCompletionSource();
 				using (cancellationToken.Register(() => nickCheckCompleteTcs.TrySetCanceled()))
 				{
 					listenTask = Task.Factory.StartNew(
@@ -399,7 +399,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 								client.RfcNick(nickname);
 						}
 
-						nickCheckCompleteTcs.TrySetResult(null);
+						nickCheckCompleteTcs.TrySetResult();
 
 						Logger.LogTrace("Starting blocking listen...");
 						try

--- a/src/Tgstation.Server.Host/Components/Deployment/DmbFactory.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/DmbFactory.cs
@@ -80,9 +80,9 @@ namespace Tgstation.Server.Host.Components.Deployment
 		Task cleanupTask;
 
 		/// <summary>
-		/// <see cref="TaskCompletionSource{TResult}"/> resulting in the latest <see cref="DmbProvider"/> yet to exist.
+		/// <see cref="TaskCompletionSource"/> resulting in the latest <see cref="DmbProvider"/> yet to exist.
 		/// </summary>
-		TaskCompletionSource<object> newerDmbTcs;
+		TaskCompletionSource newerDmbTcs;
 
 		/// <summary>
 		/// The latest <see cref="DmbProvider"/>.
@@ -119,7 +119,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 			this.metadata = metadata ?? throw new ArgumentNullException(nameof(metadata));
 
 			cleanupTask = Task.CompletedTask;
-			newerDmbTcs = new TaskCompletionSource<object>();
+			newerDmbTcs = new TaskCompletionSource();
 			cleanupCts = new CancellationTokenSource();
 			jobLockCounts = new Dictionary<long, int>();
 		}
@@ -156,8 +156,8 @@ namespace Tgstation.Server.Host.Components.Deployment
 
 				// Oh god dammit
 				var temp = newerDmbTcs;
-				newerDmbTcs = new TaskCompletionSource<object>();
-				temp.SetResult(nextDmbProvider);
+				newerDmbTcs = new TaskCompletionSource();
+				temp.SetResult();
 			}
 		}
 

--- a/src/Tgstation.Server.Host/Components/IInstanceFactory.cs
+++ b/src/Tgstation.Server.Host/Components/IInstanceFactory.cs
@@ -3,6 +3,7 @@
 using Microsoft.Extensions.Hosting;
 
 using Tgstation.Server.Host.Components.Interop.Bridge;
+using Tgstation.Server.Host.IO;
 
 namespace Tgstation.Server.Host.Components
 {
@@ -18,5 +19,12 @@ namespace Tgstation.Server.Host.Components
 		/// <param name="metadata">The <see cref="Models.Instance"/>.</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in a new <see cref="IInstance"/>.</returns>
 		Task<IInstance> CreateInstance(IBridgeRegistrar bridgeRegistrar, Models.Instance metadata);
+
+		/// <summary>
+		/// Create an <see cref="IIOManager"/> that resolves to the "Game" directory of the <see cref="Models.Instance"/> defined by <paramref name="metadata"/>.
+		/// </summary>
+		/// <param name="metadata">The <see cref="Models.Instance"/>.</param>
+		/// <returns>The <see cref="IIOManager"/> for the instance's "Game" directory.</returns>
+		IIOManager CreateGameIOManager(Models.Instance metadata);
 	}
 }

--- a/src/Tgstation.Server.Host/Components/InstanceContainer.cs
+++ b/src/Tgstation.Server.Host/Components/InstanceContainer.cs
@@ -35,9 +35,9 @@ namespace Tgstation.Server.Host.Components
 		readonly object referenceCountLock;
 
 		/// <summary>
-		/// Backing <see cref="TaskCompletionSource{TResult}"/> for <see cref="OnZeroReferences"/>.
+		/// Backing <see cref="TaskCompletionSource"/> for <see cref="OnZeroReferences"/>.
 		/// </summary>
-		TaskCompletionSource<object> onZeroReferencesTcs;
+		TaskCompletionSource onZeroReferencesTcs;
 
 		/// <summary>
 		/// Count of active <see cref="IInstanceReference"/>s.
@@ -64,7 +64,7 @@ namespace Tgstation.Server.Host.Components
 			lock (referenceCountLock)
 			{
 				if (referenceCount++ == 0)
-					onZeroReferencesTcs = new TaskCompletionSource<object>();
+					onZeroReferencesTcs = new TaskCompletionSource();
 
 				try
 				{
@@ -72,7 +72,7 @@ namespace Tgstation.Server.Host.Components
 					{
 						lock (referenceCountLock)
 							if (--referenceCount == 0)
-								onZeroReferencesTcs.SetResult(null);
+								onZeroReferencesTcs.SetResult();
 					});
 				}
 				catch

--- a/src/Tgstation.Server.Host/Components/InstanceFactory.cs
+++ b/src/Tgstation.Server.Host/Components/InstanceFactory.cs
@@ -305,7 +305,7 @@ namespace Tgstation.Server.Host.Components
 							sessionControllerFactory,
 							gameIoManager,
 							diagnosticsIOManager,
-							eventConsumer,
+							configuration, // watchdog doesn't need itself as an event consumer
 							remoteDeploymentManagerFactory,
 							metadata,
 							metadata.DreamDaemonSettings);

--- a/src/Tgstation.Server.Host/Components/InstanceManager.cs
+++ b/src/Tgstation.Server.Host/Components/InstanceManager.cs
@@ -117,9 +117,9 @@ namespace Tgstation.Server.Host.Components
 		readonly SwarmConfiguration swarmConfiguration;
 
 		/// <summary>
-		/// The <see cref="TaskCompletionSource{TResult}"/> for <see cref="Ready"/>.
+		/// The <see cref="TaskCompletionSource"/> for <see cref="Ready"/>.
 		/// </summary>
-		readonly TaskCompletionSource<object> readyTcs;
+		readonly TaskCompletionSource readyTcs;
 
 		/// <summary>
 		/// If the <see cref="InstanceManager"/> has been <see cref="DisposeAsync"/>'d.
@@ -173,7 +173,7 @@ namespace Tgstation.Server.Host.Components
 
 			instances = new Dictionary<long, InstanceContainer>();
 			bridgeHandlers = new Dictionary<string, IBridgeHandler>();
-			readyTcs = new TaskCompletionSource<object>();
+			readyTcs = new TaskCompletionSource();
 			instanceStateChangeSemaphore = new SemaphoreSlim(1);
 		}
 
@@ -430,7 +430,7 @@ namespace Tgstation.Server.Host.Components
 				jobManager.Activate();
 
 				logger.LogInformation("Server ready!");
-				readyTcs.SetResult(null);
+				readyTcs.SetResult();
 			}
 			catch (OperationCanceledException ex)
 			{

--- a/src/Tgstation.Server.Host/Components/Session/SessionController.cs
+++ b/src/Tgstation.Server.Host/Components/Session/SessionController.cs
@@ -76,9 +76,9 @@ namespace Tgstation.Server.Host.Components.Session
 		public ReattachInformation ReattachInformation { get; }
 
 		/// <summary>
-		/// The <see cref="TaskCompletionSource{TResult}"/> that completes when DD makes it's first bridge request.
+		/// The <see cref="TaskCompletionSource"/> that completes when DD makes it's first bridge request.
 		/// </summary>
-		readonly TaskCompletionSource<object> initialBridgeRequestTcs;
+		readonly TaskCompletionSource initialBridgeRequestTcs;
 
 		/// <summary>
 		/// The <see cref="Instance"/> metadata.
@@ -141,14 +141,14 @@ namespace Tgstation.Server.Host.Components.Session
 		ushort? nextPort;
 
 		/// <summary>
-		/// The <see cref="TaskCompletionSource{TResult}"/> that completes when DD tells us about a reboot.
+		/// The <see cref="TaskCompletionSource"/> that completes when DD tells us about a reboot.
 		/// </summary>
-		TaskCompletionSource<object> rebootTcs;
+		TaskCompletionSource rebootTcs;
 
 		/// <summary>
-		/// The <see cref="TaskCompletionSource{TResult}"/> that completes when DD tells us it's primed.
+		/// The <see cref="TaskCompletionSource"/> that completes when DD tells us it's primed.
 		/// </summary>
-		TaskCompletionSource<object> primeTcs;
+		TaskCompletionSource primeTcs;
 
 		/// <summary>
 		/// If we know DreamDaemon currently has it's port closed.
@@ -219,9 +219,9 @@ namespace Tgstation.Server.Host.Components.Session
 			apiValidationStatus = ApiValidationStatus.NeverValidated;
 			released = false;
 
-			rebootTcs = new TaskCompletionSource<object>();
-			primeTcs = new TaskCompletionSource<object>();
-			initialBridgeRequestTcs = new TaskCompletionSource<object>();
+			rebootTcs = new TaskCompletionSource();
+			primeTcs = new TaskCompletionSource();
+			initialBridgeRequestTcs = new TaskCompletionSource();
 			reattachTopicCts = new CancellationTokenSource();
 			synchronizationLock = new object();
 
@@ -298,7 +298,7 @@ namespace Tgstation.Server.Host.Components.Session
 			using (LogContext.PushProperty("Instance", metadata.Id))
 			{
 				logger.LogTrace("Handling bridge request...");
-				initialBridgeRequestTcs.TrySetResult(null);
+				initialBridgeRequestTcs.TrySetResult();
 
 				var response = new BridgeResponse();
 				switch (parameters.CommandType)
@@ -333,8 +333,8 @@ namespace Tgstation.Server.Host.Components.Session
 						break;
 					case BridgeCommandType.Prime:
 						var oldPrimeTcs = primeTcs;
-						primeTcs = new TaskCompletionSource<object>();
-						oldPrimeTcs.SetResult(null);
+						primeTcs = new TaskCompletionSource();
+						oldPrimeTcs.SetResult();
 						break;
 					case BridgeCommandType.Kill:
 						logger.LogInformation("Bridge requested process termination!");
@@ -425,8 +425,8 @@ namespace Tgstation.Server.Host.Components.Session
 						}
 
 						var oldRebootTcs = rebootTcs;
-						rebootTcs = new TaskCompletionSource<object>();
-						oldRebootTcs.SetResult(null);
+						rebootTcs = new TaskCompletionSource();
+						oldRebootTcs.SetResult();
 						break;
 					case null:
 						response.ErrorMessage = "Missing commandType!";

--- a/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
@@ -57,9 +57,9 @@ namespace Tgstation.Server.Host.Components.Watchdog
 		public abstract RebootState? RebootState { get; }
 
 		/// <summary>
-		/// <see cref="TaskCompletionSource{TResult}"/> that completes when <see cref="ActiveLaunchParameters"/> are changed and we are running.
+		/// <see cref="TaskCompletionSource"/> that completes when <see cref="ActiveLaunchParameters"/> are changed and we are running.
 		/// </summary>
-		protected TaskCompletionSource<object> ActiveParametersUpdated { get; set; }
+		protected TaskCompletionSource ActiveParametersUpdated { get; set; }
 
 		/// <summary>
 		/// The <see cref="ISessionPersistor"/> for the <see cref="WatchdogBase"/>.
@@ -220,7 +220,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 
 			ActiveLaunchParameters = initialLaunchParameters;
 			releaseServers = false;
-			ActiveParametersUpdated = new TaskCompletionSource<object>();
+			ActiveParametersUpdated = new TaskCompletionSource();
 
 			restartRegistration = serverControl.RegisterForRestart(this);
 			try
@@ -261,8 +261,8 @@ namespace Tgstation.Server.Host.Components.Watchdog
 				if (match || Status == WatchdogStatus.Offline)
 					return;
 
-				ActiveParametersUpdated.TrySetResult(null); // queue an update
-				ActiveParametersUpdated = new TaskCompletionSource<object>();
+				ActiveParametersUpdated.TrySetResult(); // queue an update
+				ActiveParametersUpdated = new TaskCompletionSource();
 			}
 		}
 
@@ -872,7 +872,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 									cancellationToken);
 
 							// cancel waiting if requested
-							var cancelTcs = new TaskCompletionSource<object>();
+							var cancelTcs = new TaskCompletionSource();
 							var toWaitOn = Task.WhenAny(
 								activeServerLifetime,
 								activeServerReboot,

--- a/src/Tgstation.Server.Host/Core/Application.cs
+++ b/src/Tgstation.Server.Host/Core/Application.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
-using System.Threading.Tasks;
 
 using Cyberboss.AspNetCore.AsyncInitializer;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -420,9 +419,7 @@ namespace Tgstation.Server.Host.Core
 			// 503 requests made while the application is starting
 			applicationBuilder.UseAsyncInitialization(async (cancellationToken) =>
 			{
-				var tcs = new TaskCompletionSource<object>();
-				using (cancellationToken.Register(() => tcs.SetCanceled()))
-					await Task.WhenAny(tcs.Task, instanceManager.Ready);
+				await instanceManager.Ready.WithToken(cancellationToken);
 			});
 
 			// suppress OperationCancelledExceptions, they are just aborted HTTP requests

--- a/src/Tgstation.Server.Host/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Tgstation.Server.Host/Extensions/ServiceCollectionExtensions.cs
@@ -42,10 +42,8 @@ namespace Tgstation.Server.Host.Extensions
 			const string SectionFieldName = nameof(GeneralConfiguration.Section);
 
 			var configType = typeof(TConfig);
-			var sectionField = configType.GetField(SectionFieldName);
-			if (sectionField == null)
-				throw new InvalidOperationException(String.Format(CultureInfo.InvariantCulture, "{0} has no {1} field!", configType, SectionFieldName));
-
+			var sectionField = configType.GetField(SectionFieldName) ?? throw new InvalidOperationException(
+				String.Format(CultureInfo.InvariantCulture, "{0} has no {1} field!", configType, SectionFieldName));
 			var stringType = typeof(string);
 			if (sectionField.FieldType != stringType)
 				throw new InvalidOperationException(String.Format(CultureInfo.InvariantCulture, "{0} has invalid {1} field type, must be {2}!", configType, SectionFieldName, stringType));

--- a/src/Tgstation.Server.Host/Extensions/TaskExtensions.cs
+++ b/src/Tgstation.Server.Host/Extensions/TaskExtensions.cs
@@ -10,6 +10,11 @@ namespace Tgstation.Server.Host.Extensions
 	static class TaskExtensions
 	{
 		/// <summary>
+		/// A <see cref="TaskCompletionSource"/> that never completes.
+		/// </summary>
+		private static readonly TaskCompletionSource InfiniteTaskCompletionSource = new TaskCompletionSource();
+
+		/// <summary>
 		/// Create a <see cref="Task"/> that can be awaited while respecting a given <paramref name="cancellationToken"/>.
 		/// </summary>
 		/// <param name="task">The <see cref="Task"/> to add cancel support to.</param>
@@ -41,7 +46,7 @@ namespace Tgstation.Server.Host.Extensions
 			if (task == null)
 				throw new ArgumentNullException(nameof(task));
 
-			var cancelTcs = new TaskCompletionSource<object>();
+			var cancelTcs = new TaskCompletionSource();
 			using (cancellationToken.Register(() => cancelTcs.SetCanceled()))
 				await Task.WhenAny(task, cancelTcs.Task);
 			cancellationToken.ThrowIfCancellationRequested();
@@ -53,6 +58,6 @@ namespace Tgstation.Server.Host.Extensions
 		/// Creates a <see cref="Task"/> that never completes.
 		/// </summary>
 		/// <returns>A never ending <see cref="Task"/>.</returns>
-		public static Task InfiniteTask() => new TaskCompletionSource<object>().Task;
+		public static Task InfiniteTask() => InfiniteTaskCompletionSource.Task;
 	}
 }

--- a/src/Tgstation.Server.Host/Extensions/TaskExtensions.cs
+++ b/src/Tgstation.Server.Host/Extensions/TaskExtensions.cs
@@ -12,7 +12,7 @@ namespace Tgstation.Server.Host.Extensions
 		/// <summary>
 		/// A <see cref="TaskCompletionSource"/> that never completes.
 		/// </summary>
-		private static readonly TaskCompletionSource InfiniteTaskCompletionSource = new TaskCompletionSource();
+		static readonly TaskCompletionSource InfiniteTaskCompletionSource = new ();
 
 		/// <summary>
 		/// Create a <see cref="Task"/> that can be awaited while respecting a given <paramref name="cancellationToken"/>.

--- a/src/Tgstation.Server.Host/Jobs/JobManager.cs
+++ b/src/Tgstation.Server.Host/Jobs/JobManager.cs
@@ -44,9 +44,9 @@ namespace Tgstation.Server.Host.Jobs
 		readonly Dictionary<long, JobHandler> jobs;
 
 		/// <summary>
-		/// <see cref="TaskCompletionSource{TResult}"/> to delay starting jobs until the server is ready.
+		/// <see cref="TaskCompletionSource"/> to delay starting jobs until the server is ready.
 		/// </summary>
-		readonly TaskCompletionSource<object> activationTcs;
+		readonly TaskCompletionSource activationTcs;
 
 		/// <summary>
 		/// <see langword="lock"/> <see cref="object"/> for various operations.
@@ -76,7 +76,7 @@ namespace Tgstation.Server.Host.Jobs
 			this.loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
 			this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
 			jobs = new Dictionary<long, JobHandler>();
-			activationTcs = new TaskCompletionSource<object>();
+			activationTcs = new TaskCompletionSource();
 			synchronizationLock = new object();
 			addCancelLock = new object();
 		}
@@ -268,7 +268,7 @@ namespace Tgstation.Server.Host.Jobs
 		public void Activate()
 		{
 			logger.LogTrace("Activating job manager...");
-			activationTcs.SetResult(null);
+			activationTcs.SetResult();
 		}
 
 		/// <summary>

--- a/src/Tgstation.Server.Host/Setup/SetupWizard.cs
+++ b/src/Tgstation.Server.Host/Setup/SetupWizard.cs
@@ -240,9 +240,7 @@ namespace Tgstation.Server.Host.Setup
 					using (var command = testConnection.CreateCommand())
 					{
 						// I really don't care about user sanitization here, they want to fuck their own DB? so be it
-#pragma warning disable CA2100 // Review SQL queries for security vulnerabilities
 						command.CommandText = $"CREATE DATABASE {databaseName}";
-#pragma warning restore CA2100 // Review SQL queries for security vulnerabilities
 						await command.ExecuteNonQueryAsync(cancellationToken);
 					}
 
@@ -250,9 +248,7 @@ namespace Tgstation.Server.Host.Setup
 					await console.WriteAsync("Dropping test database...", true, cancellationToken);
 					using (var command = testConnection.CreateCommand())
 					{
-#pragma warning disable CA2100 // Review SQL queries for security vulnerabilities
 						command.CommandText = $"DROP DATABASE {databaseName}";
-#pragma warning restore CA2100 // Review SQL queries for security vulnerabilities
 						try
 						{
 							await command.ExecuteNonQueryAsync(cancellationToken);

--- a/src/Tgstation.Server.Host/Setup/SetupWizard.cs
+++ b/src/Tgstation.Server.Host/Setup/SetupWizard.cs
@@ -80,9 +80,9 @@ namespace Tgstation.Server.Host.Setup
 		readonly GeneralConfiguration generalConfiguration;
 
 		/// <summary>
-		/// A <see cref="TaskCompletionSource{TResult}"/> that will complete when the <see cref="IConfiguration"/> is reloaded.
+		/// A <see cref="TaskCompletionSource"/> that will complete when the <see cref="IConfiguration"/> is reloaded.
 		/// </summary>
-		TaskCompletionSource<object> reloadTcs;
+		TaskCompletionSource reloadTcs;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="SetupWizard"/> class.
@@ -125,7 +125,7 @@ namespace Tgstation.Server.Host.Setup
 			configuration
 				.GetReloadToken()
 				.RegisterChangeCallback(
-					state => reloadTcs?.TrySetResult(null),
+					state => reloadTcs?.TrySetResult(),
 					null);
 		}
 
@@ -942,7 +942,7 @@ namespace Tgstation.Server.Host.Setup
 
 			var configBytes = Encoding.UTF8.GetBytes(serializedYaml);
 
-			reloadTcs = new TaskCompletionSource<object>();
+			reloadTcs = new TaskCompletionSource();
 
 			try
 			{

--- a/src/Tgstation.Server.Host/Setup/SetupWizard.cs
+++ b/src/Tgstation.Server.Host/Setup/SetupWizard.cs
@@ -240,7 +240,9 @@ namespace Tgstation.Server.Host.Setup
 					using (var command = testConnection.CreateCommand())
 					{
 						// I really don't care about user sanitization here, they want to fuck their own DB? so be it
+#pragma warning disable CA2100 // Review SQL queries for security vulnerabilities
 						command.CommandText = $"CREATE DATABASE {databaseName}";
+#pragma warning restore CA2100 // Review SQL queries for security vulnerabilities
 						await command.ExecuteNonQueryAsync(cancellationToken);
 					}
 
@@ -248,7 +250,9 @@ namespace Tgstation.Server.Host.Setup
 					await console.WriteAsync("Dropping test database...", true, cancellationToken);
 					using (var command = testConnection.CreateCommand())
 					{
+#pragma warning disable CA2100 // Review SQL queries for security vulnerabilities
 						command.CommandText = $"DROP DATABASE {databaseName}";
+#pragma warning restore CA2100 // Review SQL queries for security vulnerabilities
 						try
 						{
 							await command.ExecuteNonQueryAsync(cancellationToken);

--- a/src/Tgstation.Server.Host/Swarm/SwarmService.cs
+++ b/src/Tgstation.Server.Host/Swarm/SwarmService.cs
@@ -51,7 +51,7 @@ namespace Tgstation.Server.Host.Swarm
 		/// <summary>
 		/// See <see cref="JsonSerializerSettings"/> for the swarm system.
 		/// </summary>
-		static readonly JsonSerializerSettings SerializerSettings = new JsonSerializerSettings
+		static readonly JsonSerializerSettings SerializerSettings = new ()
 		{
 			ContractResolver = new DefaultContractResolver
 			{
@@ -917,7 +917,7 @@ namespace Tgstation.Server.Host.Swarm
 					response.EnsureSuccessStatusCode();
 					return;
 				}
-				catch (Exception ex) when (!(ex is OperationCanceledException))
+				catch (Exception ex) when (ex is not OperationCanceledException)
 				{
 					logger.LogWarning(
 						ex,
@@ -1068,7 +1068,7 @@ namespace Tgstation.Server.Host.Swarm
 				logger.LogWarning("Error registering with swarm controller: HTTP {0}", response.StatusCode);
 				try
 				{
-					var responseData = await response.Content.ReadAsStringAsync();
+					var responseData = await response.Content.ReadAsStringAsync(cancellationToken);
 					if (!String.IsNullOrWhiteSpace(responseData))
 						logger.LogDebug("Response:{0}{1}", Environment.NewLine, responseData);
 				}
@@ -1114,7 +1114,7 @@ namespace Tgstation.Server.Host.Swarm
 					using var response = await httpClient.SendAsync(request, cancellationToken);
 					response.EnsureSuccessStatusCode();
 				}
-				catch (Exception ex) when (!(ex is OperationCanceledException))
+				catch (Exception ex) when (ex is not OperationCanceledException)
 				{
 					logger.LogWarning(ex, "Error during swarm server list update for node '{0}'! Unregistering...", swarmServer.Identifier);
 
@@ -1268,7 +1268,7 @@ namespace Tgstation.Server.Host.Swarm
 						else
 							await HealthCheckController(cancellationToken);
 					}
-					catch (Exception ex) when (!(ex is OperationCanceledException))
+					catch (Exception ex) when (ex is not OperationCanceledException)
 					{
 						logger.LogError(ex, "Health check error!");
 					}

--- a/src/Tgstation.Server.Host/Swarm/SwarmService.cs
+++ b/src/Tgstation.Server.Host/Swarm/SwarmService.cs
@@ -142,9 +142,9 @@ namespace Tgstation.Server.Host.Swarm
 		readonly bool swarmController;
 
 		/// <summary>
-		/// A <see cref="TaskCompletionSource{TResult}"/> that is used to force a health check.
+		/// A <see cref="TaskCompletionSource"/> that is used to force a health check.
 		/// </summary>
-		TaskCompletionSource<object> forceHealthCheckTcs;
+		TaskCompletionSource forceHealthCheckTcs;
 
 		/// <summary>
 		/// The <see cref="TaskCompletionSource{TResult}"/> that is used to proceed with committing an update.
@@ -233,7 +233,7 @@ namespace Tgstation.Server.Host.Swarm
 			if (SwarmMode)
 			{
 				serverHealthCheckCancellationTokenSource = new CancellationTokenSource();
-				forceHealthCheckTcs = new TaskCompletionSource<object>();
+				forceHealthCheckTcs = new TaskCompletionSource();
 				if (swarmController)
 					registrationIds = new Dictionary<string, Guid>();
 
@@ -963,8 +963,8 @@ namespace Tgstation.Server.Host.Swarm
 		bool TriggerHealthCheck()
 		{
 			var currentTcs = forceHealthCheckTcs;
-			forceHealthCheckTcs = new TaskCompletionSource<object>();
-			return currentTcs.TrySetResult(null);
+			forceHealthCheckTcs = new TaskCompletionSource();
+			return currentTcs.TrySetResult();
 		}
 
 		/// <summary>

--- a/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
+++ b/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
@@ -67,6 +67,7 @@
     <PackageReference Include="Cyberboss.SmartIrc4net.Standard" Version="0.4.7" />
     <PackageReference Include="Elastic.CommonSchema.Serilog" Version="1.5.3" />
     <PackageReference Include="GitLabApiClient" Version="1.8.0" />
+    <!-- Later versions are known to show issues with TGS. Do not upgrade without thorough git testing -->
     <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0034" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.15" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.15" />
@@ -82,8 +83,9 @@
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="NetEscapades.Configuration.Yaml" Version="3.0.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.8" />
-    <PackageReference Include="Octokit" Version="5.0.2" />
+    <PackageReference Include="Octokit" Version="5.0.3" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="6.0.2" />
+    <!-- 2022.49.0 is the last .NET 6.0 version but has issues -->
     <PackageReference Include="Remora.Discord" Version="2022.48.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
@@ -98,7 +100,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.5.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
     <PackageReference Include="System.DirectoryServices.AccountManagement" Version="6.0.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.27.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.28.1" />
     <PackageReference Include="System.Management" Version="6.0.0" />
     <PackageReference Include="Z.EntityFramework.Plus.EFCore" Version="6.20.1" />
   </ItemGroup>

--- a/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
+++ b/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
@@ -61,47 +61,79 @@
   </Target>
 
   <ItemGroup>
+    <!-- Usage: Concise throw statements for native Win32 errors -->
     <PackageReference Include="BetterWin32Errors" Version="0.2.0" />
+    <!-- Usage: Interop with BYOND's /world/Topic -->
     <PackageReference Include="Byond.TopicSender" Version="5.0.0" />
+    <!-- Usage: 503'ing request pipeline until server is finished initializing -->
     <PackageReference Include="Cyberboss.AspNetCore.AsyncInitializer" Version="1.2.0" />
+    <!-- Usage: IRC interop -->
     <PackageReference Include="Cyberboss.SmartIrc4net.Standard" Version="0.4.7" />
+    <!-- Usage: Text formatter for Elasticsearch logging plugin -->
     <PackageReference Include="Elastic.CommonSchema.Serilog" Version="1.5.3" />
+    <!-- Usage: GitLab interop -->
     <PackageReference Include="GitLabApiClient" Version="1.8.0" />
-    <!-- Later versions are known to show issues with TGS. Do not upgrade without thorough git testing -->
+    <!-- Usage: git interop -->
+    <!-- Pinned: Later versions are known to show issues with TGS. Do not upgrade without thorough git testing -->
     <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0034" />
+    <!-- Usage: JWT injection into HTTP pipeline -->
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.15" />
+    <!-- Usage: Support ""legacy"" Newotonsoft.Json in HTTP pipeline. The rest of our codebase uses Newtonsoft. -->
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.15" />
+    <!-- Usage: Database ORM -->
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.15" />
+    <!-- Usage: Automatic migration generation using command line -->
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.15">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <!-- Usage: Sqlite ORM plugin -->
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.15" />
+    <!-- Usage: MSSQL ORM plugin -->
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.15" />
-    <!-- Required for https://github.com/coverlet-coverage/coverlet/issues/1381 -->
+    <!-- Usage: Included transitively through other packages, workaround for https://github.com/coverlet-coverage/coverlet/issues/1381 -->
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.3" />
+    <!-- Usage: POSIX support for syscalls, signals, and symlinks -->
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
+    <!-- Usage: YAML config plugin -->
     <PackageReference Include="NetEscapades.Configuration.Yaml" Version="3.0.0" />
+    <!-- Usage: PostgresSQL ORM plugin -->
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.8" />
+    <!-- Usage: GitHub.com interop -->
     <PackageReference Include="Octokit" Version="5.0.3" />
+    <!-- Usage: MYSQL/MariaDB ORM plugin -->
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="6.0.2" />
-    <!-- 2022.49.0 is the last .NET 6.0 version but has issues -->
+    <!-- Usage: Discord interop -->
+    <!-- Pinned: 2022.49.0 is the last .NET 6.0 version but has issues -->
     <PackageReference Include="Remora.Discord" Version="2022.48.0" />
+    <!-- Usage: Rich logger builder -->
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+    <!-- Usage: Async logging plugin -->
     <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
+    <!-- Usage: Console logging plugin -->
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+    <!-- Usage: Elasticsearch logging plugin -->
     <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="9.0.0" />
+    <!-- Usage: File logging plugin -->
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <!-- Usage: Linting -->
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <!-- Usage: OpenAPI spec generator -->
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <!-- Usage: Newtonsoft.Json plugin for OpenAPI spec generator -->
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.5.0" />
+    <!-- Usage: Access to raw database connectors primarily for setup wizard -->
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
+    <!-- Usage: Windows authentication plugin allowing searching for users by name -->
     <PackageReference Include="System.DirectoryServices.AccountManagement" Version="6.0.0" />
+    <!-- Usage: JWT plugin needed to undo some Microsoft meddling in the HTTP pipeline -->
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.28.1" />
+    <!-- Usage: Identifying owning user of Windows Process objects -->
     <PackageReference Include="System.Management" Version="6.0.0" />
+    <!-- Usage: .DeleteAsync() support for IQueryable<T>s -->
     <PackageReference Include="Z.EntityFramework.Plus.EFCore" Version="6.20.1" />
   </ItemGroup>
 

--- a/src/Tgstation.Server.Host/Transfer/FileUploadProvider.cs
+++ b/src/Tgstation.Server.Host/Transfer/FileUploadProvider.cs
@@ -29,9 +29,9 @@ namespace Tgstation.Server.Host.Transfer
 		readonly TaskCompletionSource<Stream> taskCompletionSource;
 
 		/// <summary>
-		/// The <see cref="TaskCompletionSource{TResult}"/> that completes in <see cref="IDisposable.Dispose"/> or when <see cref="SetErrorMessage(ErrorMessageResponse)"/> is called.
+		/// The <see cref="TaskCompletionSource"/> that completes in <see cref="IDisposable.Dispose"/> or when <see cref="SetErrorMessage(ErrorMessageResponse)"/> is called.
 		/// </summary>
-		readonly TaskCompletionSource<object> completionTcs;
+		readonly TaskCompletionSource completionTcs;
 
 		/// <summary>
 		/// If synchronous IO is required. Uses a <see cref="FileBufferingReadStream"/> as a backend if set.
@@ -54,7 +54,7 @@ namespace Tgstation.Server.Host.Transfer
 
 			ticketExpiryCts = new CancellationTokenSource();
 			taskCompletionSource = new TaskCompletionSource<Stream>();
-			completionTcs = new TaskCompletionSource<object>();
+			completionTcs = new TaskCompletionSource();
 			this.requireSynchronousIO = requireSynchronousIO;
 		}
 
@@ -62,7 +62,7 @@ namespace Tgstation.Server.Host.Transfer
 		public void Dispose()
 		{
 			ticketExpiryCts.Dispose();
-			completionTcs.TrySetResult(null);
+			completionTcs.TrySetResult();
 		}
 
 		/// <inheritdoc />
@@ -125,7 +125,7 @@ namespace Tgstation.Server.Host.Transfer
 				throw new InvalidOperationException("ErrorMessage already set!");
 
 			this.errorMessage = errorMessage;
-			completionTcs.TrySetResult(null);
+			completionTcs.TrySetResult();
 		}
 	}
 }

--- a/tests/Tgstation.Server.Host.Tests.Signals/Program.cs
+++ b/tests/Tgstation.Server.Host.Tests.Signals/Program.cs
@@ -18,10 +18,10 @@ namespace Tgstation.Server.Host.Tests.Signals
 		{
 			var mockServerControl = new Mock<IServerControl>();
 
-			var tcs = new TaskCompletionSource<object>();
+			var tcs = new TaskCompletionSource();
 			mockServerControl
 				.Setup(x => x.GracefulShutdown())
-				.Callback(() => tcs.SetResult(null))
+				.Callback(() => tcs.SetResult())
 				.Returns(Task.CompletedTask);
 
 			var mockAsyncDelayer = new Mock<IAsyncDelayer>();

--- a/tests/Tgstation.Server.Host.Tests/IO/TestIOManager.cs
+++ b/tests/Tgstation.Server.Host.Tests/IO/TestIOManager.cs
@@ -20,13 +20,17 @@ namespace Tgstation.Server.Host.IO.Tests
 			Directory.CreateDirectory(tempPath);
 			try
 			{
+				await File.WriteAllTextAsync(Path.Combine(tempPath, "file.txt"), "asdf");
+				var subDir = Path.Combine(tempPath, "subdir");
+				Directory.CreateDirectory(subDir);
+				await File.WriteAllTextAsync(Path.Combine(subDir, "file2.txt"), "fdsa");
 				await ioManager.DeleteDirectory(tempPath, default);
 
 				Assert.IsFalse(Directory.Exists(tempPath));
 			}
 			catch
 			{
-				Directory.Delete(tempPath);
+				Directory.Delete(tempPath, true);
 				throw;
 			}
 		}

--- a/tests/Tgstation.Server.Host.Tests/Jobs/TestJobHandler.cs
+++ b/tests/Tgstation.Server.Host.Tests/Jobs/TestJobHandler.cs
@@ -35,14 +35,14 @@ namespace Tgstation.Server.Host.Jobs.Tests
 			//test with a cancelled cts
 			using (var cts = new CancellationTokenSource())
 			{
-				var tcs = new TaskCompletionSource<object>();
+				var tcs = new TaskCompletionSource();
 				currentWaitTask = tcs.Task;
 				cts.Cancel();
 				using var handler = new JobHandler(TestJob);
 				await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => handler.Wait(cts.Token));
 				handler.Start();
 				await Assert.ThrowsExceptionAsync<OperationCanceledException>(() => handler.Wait(cts.Token));
-				tcs.SetResult(null);
+				tcs.SetResult();
 				await handler.Wait(default);
 			}
 			Assert.IsFalse(cancelled);
@@ -65,14 +65,14 @@ namespace Tgstation.Server.Host.Jobs.Tests
 		[TestMethod]
 		public async Task TestCancellation()
 		{
-			var tcs = new TaskCompletionSource<object>();
+			var tcs = new TaskCompletionSource();
 			currentWaitTask = tcs.Task;
 			cancelled = false;
 			using (var handler = new JobHandler(TestJob))
 			{
 				handler.Start();
 				handler.Cancel();
-				tcs.SetResult(null);
+				tcs.SetResult();
 				await handler.Wait(default);
 			}
 			Assert.IsTrue(cancelled);

--- a/tests/Tgstation.Server.Tests/Instance/InstanceTest.cs
+++ b/tests/Tgstation.Server.Tests/Instance/InstanceTest.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 
 using Tgstation.Server.Client;
 using Tgstation.Server.Client.Components;
+using Tgstation.Server.Host.Components;
 
 namespace Tgstation.Server.Tests.Instance
 {
@@ -11,11 +12,13 @@ namespace Tgstation.Server.Tests.Instance
 	{
 		readonly IInstanceClient instanceClient;
 		readonly IInstanceManagerClient instanceManagerClient;
+		readonly IInstanceManager instanceManager;
 
-		public InstanceTest(IInstanceClient instanceClient, IInstanceManagerClient instanceManagerClient)
+		public InstanceTest(IInstanceClient instanceClient, IInstanceManagerClient instanceManagerClient, IInstanceManager instanceManager)
 		{
 			this.instanceClient = instanceClient ?? throw new ArgumentNullException(nameof(instanceClient));
 			this.instanceManagerClient = instanceManagerClient ?? throw new ArgumentNullException(nameof(instanceManagerClient));
+			this.instanceManager = instanceManager ?? throw new ArgumentNullException(nameof(instanceManager));
 		}
 
 		public async Task RunTests(CancellationToken cancellationToken)
@@ -35,7 +38,7 @@ namespace Tgstation.Server.Tests.Instance
 			await configTest.Run(cancellationToken);
 			await chatTests;
 			await repoTests;
-			await new WatchdogTest(instanceClient).Run(cancellationToken);
+			await new WatchdogTest(instanceClient, instanceManager).Run(cancellationToken);
 		}
 	}
 }

--- a/tests/Tgstation.Server.Tests/Instance/WatchdogTest.cs
+++ b/tests/Tgstation.Server.Tests/Instance/WatchdogTest.cs
@@ -101,11 +101,11 @@ namespace Tgstation.Server.Tests.Instance
 			File.Delete(dumpFiles.Single());
 
 			KillDD(true);
-			TaskCompletionSource<object> jobTcs = new TaskCompletionSource<object>();
-			TaskCompletionSource<object> killTaskStarted = new TaskCompletionSource<object>();
+			var jobTcs = new TaskCompletionSource();
+			var killTaskStarted = new TaskCompletionSource();
 			var killTask = Task.Run(() =>
 			{
-				killTaskStarted.SetResult(null);
+				killTaskStarted.SetResult();
 				while (!jobTcs.Task.IsCompleted)
 					KillDD(false);
 			}, cancellationToken);
@@ -119,7 +119,7 @@ namespace Tgstation.Server.Tests.Instance
 			}
 			finally
 			{
-				jobTcs.SetResult(null);
+				jobTcs.SetResult();
 				await killTask;
 			}
 			Assert.IsTrue(job.ErrorCode == ErrorCode.DreamDaemonOffline || job.ErrorCode == ErrorCode.GCoreFailure, $"{job.ErrorCode}: {job.ExceptionDetails}");

--- a/tests/Tgstation.Server.Tests/Instance/WatchdogTest.cs
+++ b/tests/Tgstation.Server.Tests/Instance/WatchdogTest.cs
@@ -335,29 +335,32 @@ namespace Tgstation.Server.Tests.Instance
 			await WaitForJob(startJob, 40, false, null, cancellationToken);
 
 			// oh god, oh fuck, blackbox testing
-			using var instanceReference = instanceManager.GetInstanceReference(instanceClient.Metadata);
-
+			MessageContent response;
 			var startTime = DateTimeOffset.UtcNow - TimeSpan.FromSeconds(5);
-			var response = await ((BasicWatchdog)instanceReference.Watchdog).HandleChatCommand(
-				"embeds_test",
-				String.Empty,
-				new Host.Components.Chat.ChatUser
-				{
-					Channel = new Host.Components.Chat.ChannelRepresentation
+			using (var instanceReference = instanceManager.GetInstanceReference(instanceClient.Metadata))
+			{
+				response = await ((BasicWatchdog)instanceReference.Watchdog).HandleChatCommand(
+					"embeds_test",
+					String.Empty,
+					new Host.Components.Chat.ChatUser
 					{
-						IsAdminChannel = true,
-						ConnectionName = "test_connection",
-						EmbedsSupported = true,
-						FriendlyName = "Test Connection",
-						Id = "test_channel_id",
-						IsPrivateChannel = false,
+						Channel = new Host.Components.Chat.ChannelRepresentation
+						{
+							IsAdminChannel = true,
+							ConnectionName = "test_connection",
+							EmbedsSupported = true,
+							FriendlyName = "Test Connection",
+							Id = "test_channel_id",
+							IsPrivateChannel = false,
+						},
+						FriendlyName = "Test Sender",
+						Id = "test_user_id",
+						Mention = "test_user_mention",
+						RealId = 1234,
 					},
-					FriendlyName = "Test Sender",
-					Id = "test_user_id",
-					Mention = "test_user_mention",
-					RealId = 1234,
-				},
-				cancellationToken);
+					cancellationToken);
+			}
+
 			var endTime = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(5);
 
 			Assert.IsNotNull(response);

--- a/tests/Tgstation.Server.Tests/TestingServer.cs
+++ b/tests/Tgstation.Server.Tests/TestingServer.cs
@@ -27,11 +27,11 @@ namespace Tgstation.Server.Tests
 
 		public bool DumpOpenApiSpecpath { get; }
 
-		public bool RestartRequested => realServer.RestartRequested;
+		public bool RestartRequested => RealServer.RestartRequested;
 
 		string[] args;
 
-		IServer realServer;
+		public IServer RealServer { get; private set; }
 
 		public TestingServer(SwarmConfiguration swarmConfiguration, bool enableOAuth, ushort port = 5010)
 		{
@@ -154,8 +154,8 @@ namespace Tgstation.Server.Tests
 		public async Task Run(CancellationToken cancellationToken)
 		{
 			Console.WriteLine("TEST SERVER START");
-			var firstRun = realServer == null;
-			realServer = await Application
+			var firstRun = RealServer == null;
+			RealServer = await Application
 				.CreateDefaultServerFactory()
 				.CreateServer(
 					args,
@@ -169,7 +169,8 @@ namespace Tgstation.Server.Tests
 				args = tmp.ToArray();
 			}
 
-			await realServer.Run(cancellationToken);
+			await RealServer.Run(cancellationToken);
+			RealServer = null;
 			Console.WriteLine("TEST SERVER END");
 		}
 	}

--- a/tests/Tgstation.Server.Tests/TestingServer.cs
+++ b/tests/Tgstation.Server.Tests/TestingServer.cs
@@ -170,7 +170,6 @@ namespace Tgstation.Server.Tests
 			}
 
 			await RealServer.Run(cancellationToken);
-			RealServer = null;
 			Console.WriteLine("TEST SERVER END");
 		}
 	}


### PR DESCRIPTION
:cl:
Fixed event types 15 through 21 (watchdog related events) getting sent to the DMAPI unintentionally.
Moving an instance now deletes its `Game` directory to destroy broken symlinks.
Fixed a massive delay when manually offlining an instance.
/:cl: