### PR TITLE
Discord Improvements (v5.10.0)

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>5.9.0</TgsCoreVersion>
+    <TgsCoreVersion>5.10.0</TgsCoreVersion>
     <TgsConfigVersion>4.5.0</TgsConfigVersion>
     <TgsApiVersion>9.9.0</TgsApiVersion>
     <TgsApiLibraryVersion>10.3.0</TgsApiLibraryVersion>

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordProvider.cs
@@ -292,7 +292,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 					// discord API confirmed weak boned: https://stackoverflow.com/a/52462336
 					if (unmappedTextChannels.Any())
 					{
-						Logger.LogTrace("Dispatching to {0} unmapped channels...", unmappedTextChannels.Count());
+						Logger.LogTrace("Dispatching to {count} unmapped channels...", unmappedTextChannels.Count());
 						await Task.WhenAll(
 							unmappedTextChannels.Select(
 								x => SendToChannel(x.ID)));
@@ -342,7 +342,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 				Timestamp = estimatedCompletionTime ?? default,
 			};
 
-			Logger.LogTrace("Attempting to post deploy embed to channel {0}...", channelId);
+			Logger.LogTrace("Attempting to post deploy embed to channel {channelId}...", channelId);
 			var channelsClient = serviceProvider.GetRequiredService<IDiscordRestChannelAPI>();
 
 			var messageResponse = await channelsClient.CreateMessageAsync(
@@ -353,7 +353,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 				;
 
 			if (!messageResponse.IsSuccess)
-				Logger.LogWarning("Failed to post deploy embed to channel {0}: {1}", channelId, messageResponse.Error.Message);
+				Logger.LogWarning("Failed to post deploy embed to channel {channelId}: {errorMessage}", channelId, messageResponse.Error.Message);
 
 			return async (errorMessage, dreamMakerOutput) =>
 			{
@@ -412,7 +412,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 
 					if (!createUpdatedMessageResponse.IsSuccess)
 						Logger.LogWarning(
-							"Creating updated deploy embed failed! Error: {0}",
+							"Creating updated deploy embed failed! Error: {errorMessage}",
 							createUpdatedMessageResponse.Error.Message);
 				}
 
@@ -431,7 +431,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 					if (!editResponse.IsSuccess)
 					{
 						Logger.LogWarning(
-							"Updating deploy embed {0} failed, attempting new post! Error: {1}",
+							"Updating deploy embed {messageId} failed, attempting new post! Error: {errorMessage}",
 							messageResponse.Entity.ID,
 							editResponse.Error.Message);
 						await CreateUpdatedMessage();
@@ -481,7 +481,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 			if (!channelResponse.IsSuccess)
 			{
 				Logger.LogWarning(
-					"Failed to get channel {0} in response to message {1}!",
+					"Failed to get channel {channelId} in response to message {messageId}!",
 					messageCreateEvent.ChannelID,
 					messageCreateEvent.ID);
 
@@ -503,7 +503,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 			{
 				if (mentionedUs)
 					Logger.LogTrace(
-						"Ignoring mention from {0} ({1}) by {2} ({3}). Channel not mapped!",
+						"Ignoring mention from {channelId} ({channelName}) by {authorId} ({authorName}). Channel not mapped!",
 						messageCreateEvent.ChannelID,
 						channelResponse.Entity.Name,
 						messageCreateEvent.Author.ID,
@@ -521,7 +521,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 					guildName = messageGuildResponse.Entity.Name;
 				else
 					Logger.LogWarning(
-						"Failed to get channel {0} in response to message {1}!",
+						"Failed to get channel {channelID} in response to message {messageID}!",
 						messageCreateEvent.ChannelID,
 						messageCreateEvent.ID);
 			}
@@ -600,7 +600,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 					var currentUserResult = await userClient.GetCurrentUserAsync(localCombinedCts.Token);
 					if (!currentUserResult.IsSuccess)
 					{
-						Logger.LogWarning("Unable to retrieve current user: {0}", currentUserResult.Error.Message);
+						Logger.LogWarning("Unable to retrieve current user: {errorMessage}", currentUserResult.Error.Message);
 						throw new JobException(ErrorCode.ChatCannotConnectProvider);
 					}
 
@@ -639,7 +639,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 			localGatewayCts.Cancel();
 			var gatewayResult = await localGatewayTask;
 			if (!gatewayResult.IsSuccess)
-				Logger.LogWarning("Gateway issue: {0}", gatewayResult.Error.Message);
+				Logger.LogWarning("Gateway issue: {errorMessage}", gatewayResult.Error.Message);
 
 			localGatewayCts.Dispose();
 		}
@@ -720,7 +720,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 					EmbedsSupported = true,
 				};
 
-				Logger.LogTrace("Mapped channel {0}: {1}", channelModel.RealId, channelModel.FriendlyName);
+				Logger.LogTrace("Mapped channel {realId}: {friendlyName}", channelModel.RealId, channelModel.FriendlyName);
 				return Tuple.Create(channelFromDB, channelModel);
 			}
 

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordProvider.cs
@@ -21,6 +21,7 @@ using Remora.Results;
 
 using Tgstation.Server.Api.Models;
 using Tgstation.Server.Host.Components.Interop;
+using Tgstation.Server.Host.Extensions;
 using Tgstation.Server.Host.Jobs;
 using Tgstation.Server.Host.Models;
 using Tgstation.Server.Host.System;
@@ -253,9 +254,9 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 
 				if (!result.IsSuccess)
 					Logger.LogWarning(
-						"Failed to send to channel {channelId}: {error}",
+						"Failed to send to channel {channelId}: {result}",
 						channelId,
-						result.Error);
+						result.LogFormat());
 			}
 
 			try
@@ -267,8 +268,8 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 					if (!currentGuildsResponse.IsSuccess)
 					{
 						Logger.LogWarning(
-							"Error retrieving current discord guilds: {error}",
-							currentGuildsResponse.Error.Message);
+							"Error retrieving current discord guilds: {result}",
+							currentGuildsResponse.LogFormat());
 						return;
 					}
 
@@ -353,7 +354,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 				;
 
 			if (!messageResponse.IsSuccess)
-				Logger.LogWarning("Failed to post deploy embed to channel {channelId}: {errorMessage}", channelId, messageResponse.Error.Message);
+				Logger.LogWarning("Failed to post deploy embed to channel {channelId}: {result}", channelId, messageResponse.LogFormat());
 
 			return async (errorMessage, dreamMakerOutput) =>
 			{
@@ -412,8 +413,8 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 
 					if (!createUpdatedMessageResponse.IsSuccess)
 						Logger.LogWarning(
-							"Creating updated deploy embed failed! Error: {errorMessage}",
-							createUpdatedMessageResponse.Error.Message);
+							"Creating updated deploy embed failed: {result}",
+							createUpdatedMessageResponse.LogFormat());
 				}
 
 				if (!messageResponse.IsSuccess)
@@ -431,9 +432,9 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 					if (!editResponse.IsSuccess)
 					{
 						Logger.LogWarning(
-							"Updating deploy embed {messageId} failed, attempting new post! Error: {errorMessage}",
+							"Updating deploy embed {messageId} failed, attempting new post: {result}",
 							messageResponse.Entity.ID,
-							editResponse.Error.Message);
+							editResponse.LogFormat());
 						await CreateUpdatedMessage();
 					}
 				}
@@ -521,9 +522,10 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 					guildName = messageGuildResponse.Entity.Name;
 				else
 					Logger.LogWarning(
-						"Failed to get channel {channelID} in response to message {messageID}!",
+						"Failed to get channel {channelID} in response to message {messageID}: {result}",
 						messageCreateEvent.ChannelID,
-						messageCreateEvent.ID);
+						messageCreateEvent.ID,
+						messageGuildResponse.LogFormat());
 			}
 
 			var result = new DiscordMessage
@@ -600,7 +602,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 					var currentUserResult = await userClient.GetCurrentUserAsync(localCombinedCts.Token);
 					if (!currentUserResult.IsSuccess)
 					{
-						Logger.LogWarning("Unable to retrieve current user: {errorMessage}", currentUserResult.Error.Message);
+						Logger.LogWarning("Unable to retrieve current user: {result}", currentUserResult.LogFormat());
 						throw new JobException(ErrorCode.ChatCannotConnectProvider);
 					}
 
@@ -639,7 +641,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 			localGatewayCts.Cancel();
 			var gatewayResult = await localGatewayTask;
 			if (!gatewayResult.IsSuccess)
-				Logger.LogWarning("Gateway issue: {errorMessage}", gatewayResult.Error.Message);
+				Logger.LogWarning("Gateway issue: {result}", gatewayResult.LogFormat());
 
 			localGatewayCts.Dispose();
 		}
@@ -672,10 +674,9 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 					if (!discordChannelResponse.IsSuccess)
 					{
 						Logger.LogWarning(
-							"Error retrieving discord channel {channelId}: {error} Inner: {innerError}",
+							"Error retrieving discord channel {channelId}: {result}",
 							channelId,
-							discordChannelResponse.Error.Message,
-							discordChannelResponse.Inner?.Error?.Message);
+							discordChannelResponse.LogFormat());
 						remapRequired = true;
 						return null;
 					}
@@ -698,10 +699,9 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 					if (!guildsResponse.IsSuccess)
 					{
 						Logger.LogWarning(
-							"Error retrieving discord guild {guildID}: {error} Inner: {innerError}",
+							"Error retrieving discord guild {guildID}: {result}",
 							guildId,
-							guildsResponse.Error.Message,
-							guildsResponse.Inner?.Error?.Message);
+							guildsResponse.LogFormat());
 						remapRequired = true;
 						return null;
 					}

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/IProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/IProvider.cs
@@ -58,8 +58,8 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		/// </summary>
 		/// <param name="channels">The <see cref="Api.Models.ChatChannel"/>s to map.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
-		/// <returns>A <see cref="Task{TResult}"/> resulting in a <see cref="IReadOnlyCollection{T}"/> of the <see cref="ChatChannel"/>'s <see cref="ChannelRepresentation"/>s representing <paramref name="channels"/>.</returns>
-		Task<IReadOnlyCollection<Tuple<ChatChannel, ChannelRepresentation>>> MapChannels(IEnumerable<ChatChannel> channels, CancellationToken cancellationToken);
+		/// <returns>A <see cref="Task{TResult}"/> resulting in a <see cref="Dictionary{TKey, TValue}"/> of the <see cref="ChatChannel"/>'s <see cref="ChannelRepresentation"/>s representing <paramref name="channels"/>.</returns>
+		Task<Dictionary<ChatChannel, IEnumerable<ChannelRepresentation>>> MapChannels(IEnumerable<ChatChannel> channels, CancellationToken cancellationToken);
 
 		/// <summary>
 		/// Send a message to the <see cref="IProvider"/>.

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/Provider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/Provider.cs
@@ -118,7 +118,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		public void InitialMappingComplete() => initialConnectionTcs.TrySetResult();
 
 		/// <inheritdoc />
-		public async Task<IReadOnlyCollection<Tuple<ChatChannel, ChannelRepresentation>>> MapChannels(IEnumerable<ChatChannel> channels, CancellationToken cancellationToken)
+		public async Task<Dictionary<ChatChannel, IEnumerable<ChannelRepresentation>>> MapChannels(IEnumerable<ChatChannel> channels, CancellationToken cancellationToken)
 		{
 			try
 			{
@@ -198,15 +198,15 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		/// </summary>
 		/// <param name="channels">The <see cref="ChatChannel"/>s to map.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
-		/// <returns>A <see cref="Task{TResult}"/> resulting in a <see cref="IReadOnlyCollection{T}"/> of the <see cref="ChatChannel"/>'s <see cref="ChannelRepresentation"/>s representing <paramref name="channels"/>.</returns>
-		protected abstract Task<IReadOnlyCollection<Tuple<ChatChannel, ChannelRepresentation>>> MapChannelsImpl(
+		/// <returns>A <see cref="Task{TResult}"/> resulting in a <see cref="Dictionary{TKey, TValue}"/> of the <see cref="ChatChannel"/>'s <see cref="ChannelRepresentation"/>s representing <paramref name="channels"/>.</returns>
+		protected abstract Task<Dictionary<ChatChannel, IEnumerable<ChannelRepresentation>>> MapChannelsImpl(
 			IEnumerable<ChatChannel> channels,
 			CancellationToken cancellationToken);
 
 		/// <summary>
 		/// Queues a <paramref name="message"/> for <see cref="NextMessage(CancellationToken)"/>.
 		/// </summary>
-		/// <param name="message">The <see cref="Message"/> to queue.</param>
+		/// <param name="message">The <see cref="Message"/> to queue. A value of <see langword="null"/> indicates the channel mappings a out of date.</param>
 		protected void EnqueueMessage(Message message)
 		{
 			if (message == null)

--- a/src/Tgstation.Server.Host/Controllers/InstanceController.cs
+++ b/src/Tgstation.Server.Host/Controllers/InstanceController.cs
@@ -686,7 +686,7 @@ namespace Tgstation.Server.Host.Controllers
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the new <see cref="Models.Instance"/> or <see langword="null"/> if ports could not be allocated.</returns>
 		async Task<Models.Instance> CreateDefaultInstance(InstanceCreateRequest initialSettings, CancellationToken cancellationToken)
 		{
-			var ddPort = await portAllocator.GetAvailablePort(1, false, cancellationToken);
+			var ddPort = await portAllocator.GetAvailablePort(1024, false, cancellationToken);
 			if (!ddPort.HasValue)
 				return null;
 

--- a/src/Tgstation.Server.Host/Extensions/ResultExtensions.cs
+++ b/src/Tgstation.Server.Host/Extensions/ResultExtensions.cs
@@ -1,6 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Text;
 
+using Remora.Discord.API.Abstractions.Objects;
+using Remora.Discord.API.Objects;
+using Remora.Rest.Results;
 using Remora.Results;
 
 namespace Tgstation.Server.Host.Extensions
@@ -28,6 +32,39 @@ namespace Tgstation.Server.Host.Extensions
 			if (result.Error != null)
 			{
 				stringBuilder.Append(result.Error.Message);
+				if (result.Error is RestResultError<RestError> restError)
+				{
+					stringBuilder.Append(" (");
+					if (restError.Error != null)
+					{
+						stringBuilder.Append(restError.Error.Code);
+						stringBuilder.Append(": ");
+						stringBuilder.Append(restError.Error.Message);
+						stringBuilder.Append('|');
+					}
+
+					stringBuilder.Append(restError.Message);
+					if ((restError.Error?.Errors.HasValue ?? false) && restError.Error.Errors.Value.Count > 0)
+					{
+						stringBuilder.Append(" (");
+						foreach (var error in restError.Error.Errors.Value)
+						{
+							stringBuilder.Append(error.Key);
+							stringBuilder.Append(':');
+							if (error.Value.IsT0)
+							{
+								FormatErrorDetails(error.Value.AsT0, stringBuilder);
+							}
+							else
+								FormatErrorDetails(error.Value.AsT1, stringBuilder);
+							stringBuilder.Append(',');
+						}
+
+						stringBuilder.Remove(stringBuilder.Length - 1, 1);
+					}
+
+					stringBuilder.Append(')');
+				}
 			}
 
 			if (result.Inner != null)
@@ -40,6 +77,62 @@ namespace Tgstation.Server.Host.Extensions
 			}
 
 			return stringBuilder.ToString();
+		}
+
+		/// <summary>
+		/// Formats given <paramref name="propertyErrorDetails"/> into a given <paramref name="stringBuilder"/>.
+		/// </summary>
+		/// <param name="propertyErrorDetails">The <see cref="IPropertyErrorDetails"/>.</param>
+		/// <param name="stringBuilder">The <see cref="StringBuilder"/> to mutate.</param>
+		static void FormatErrorDetails(IPropertyErrorDetails propertyErrorDetails, StringBuilder stringBuilder)
+		{
+			if (propertyErrorDetails == null)
+				return;
+
+			FormatErrorDetails(propertyErrorDetails.Errors, stringBuilder);
+
+			if (propertyErrorDetails.Errors != null && propertyErrorDetails.MemberErrors != null)
+			{
+				stringBuilder.Append(',');
+			}
+
+			if (propertyErrorDetails.MemberErrors != null)
+			{
+				stringBuilder.Append('{');
+				foreach (var error in propertyErrorDetails.MemberErrors)
+				{
+					stringBuilder.Append(error.Key);
+					stringBuilder.Append(':');
+					FormatErrorDetails(error.Value, stringBuilder);
+					stringBuilder.Append(',');
+				}
+
+				stringBuilder.Remove(stringBuilder.Length - 1, 1);
+				stringBuilder.Append('}');
+			}
+		}
+
+		/// <summary>
+		/// Formats given <paramref name="errorDetails"/> into a given <paramref name="stringBuilder"/>.
+		/// </summary>
+		/// <param name="errorDetails">The <see cref="IEnumerable{T}"/> of <see cref="IErrorDetails"/>.</param>
+		/// <param name="stringBuilder">The <see cref="StringBuilder"/> to mutate.</param>
+		static void FormatErrorDetails(IEnumerable<IErrorDetails> errorDetails, StringBuilder stringBuilder)
+		{
+			if (errorDetails == null)
+				return;
+
+			stringBuilder.Append('[');
+			foreach (var error in errorDetails)
+			{
+				stringBuilder.Append(error.Code);
+				stringBuilder.Append(':');
+				stringBuilder.Append(error.Message);
+				stringBuilder.Append(',');
+			}
+
+			stringBuilder.Remove(stringBuilder.Length - 1, 1);
+			stringBuilder.Append(']');
 		}
 	}
 }

--- a/src/Tgstation.Server.Host/Extensions/ResultExtensions.cs
+++ b/src/Tgstation.Server.Host/Extensions/ResultExtensions.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Text;
+
+using Remora.Results;
+
+namespace Tgstation.Server.Host.Extensions
+{
+	/// <summary>
+	/// Extensions for <see cref="IResult"/>.
+	/// </summary>
+	static class ResultExtensions
+	{
+		/// <summary>
+		/// Converts a given <paramref name="result"/> into a log entry <see cref="string"/>.
+		/// </summary>
+		/// <param name="result">The <see cref="IResult"/> to convert.</param>
+		/// <param name="level">Used internally for nesting.</param>
+		/// <returns>The <see cref="string"/> formatted <paramref name="result"/>.</returns>
+		public static string LogFormat(this IResult result, uint level = 0)
+		{
+			if (result == null)
+				throw new ArgumentNullException(nameof(result));
+
+			if (result.IsSuccess)
+				return "SUCCESS?";
+
+			var stringBuilder = new StringBuilder();
+			if (result.Error != null)
+			{
+				stringBuilder.Append(result.Error.Message);
+			}
+
+			if (result.Inner != null)
+			{
+				stringBuilder.Append(Environment.NewLine);
+				++level;
+				for (var i = 0; i < level; ++i)
+					stringBuilder.Append('\t');
+				stringBuilder.Append(result.Inner.LogFormat(level));
+			}
+
+			return stringBuilder.ToString();
+		}
+	}
+}


### PR DESCRIPTION
:cl:
Significantly improved the logging for DiscordProvider messages.
Fixed all sorts of problems with using Discord channel ID zero.
Fixed infinite retries when mapping an inaccessible or invalid Discord channel ID.
Added support for Discord threads as mappable channels.
Chat processing error replies now properly reply to the invoker on Discord.
Instances will no longer select initial values for the DreamDaemon port < 1024.
/:cl: