### PR TITLE
Copy Directory Custom Throttle

### DIFF
--- a/src/Tgstation.Server.Host/Components/InstanceFactory.cs
+++ b/src/Tgstation.Server.Host/Components/InstanceFactory.cs
@@ -140,6 +140,11 @@ namespace Tgstation.Server.Host.Components
 		readonly IRemoteDeploymentManagerFactory remoteDeploymentManagerFactory;
 
 		/// <summary>
+		/// The <see cref="GeneralConfiguration"/> for the <see cref="InstanceFactory"/>.
+		/// </summary>
+		readonly GeneralConfiguration generalConfiguration;
+
+		/// <summary>
 		/// The <see cref="SessionConfiguration"/> for the <see cref="InstanceFactory"/>.
 		/// </summary>
 		readonly SessionConfiguration sessionConfiguration;
@@ -177,6 +182,7 @@ namespace Tgstation.Server.Host.Components
 		/// <param name="fileTransferService">The value of <see cref="fileTransferService"/>.</param>
 		/// <param name="gitRemoteFeaturesFactory">The value of <see cref="gitRemoteFeaturesFactory"/>.</param>
 		/// <param name="remoteDeploymentManagerFactory">The value of <see cref="remoteDeploymentManagerFactory"/>.</param>
+		/// <param name="generalConfigurationOptions">The <see cref="IOptions{TOptions}"/> containing the value of <see cref="generalConfiguration"/>.</param>
 		/// <param name="sessionConfigurationOptions">The <see cref="IOptions{TOptions}"/> containing the value of <see cref="sessionConfiguration"/>.</param>
 		public InstanceFactory(
 			IIOManager ioManager,
@@ -201,6 +207,7 @@ namespace Tgstation.Server.Host.Components
 			IFileTransferTicketProvider fileTransferService,
 			IGitRemoteFeaturesFactory gitRemoteFeaturesFactory,
 			IRemoteDeploymentManagerFactory remoteDeploymentManagerFactory,
+			IOptions<GeneralConfiguration> generalConfigurationOptions,
 			IOptions<SessionConfiguration> sessionConfigurationOptions)
 		{
 			this.ioManager = ioManager ?? throw new ArgumentNullException(nameof(ioManager));
@@ -225,6 +232,7 @@ namespace Tgstation.Server.Host.Components
 			this.fileTransferService = fileTransferService ?? throw new ArgumentNullException(nameof(fileTransferService));
 			this.gitRemoteFeaturesFactory = gitRemoteFeaturesFactory ?? throw new ArgumentNullException(nameof(gitRemoteFeaturesFactory));
 			this.remoteDeploymentManagerFactory = remoteDeploymentManagerFactory ?? throw new ArgumentNullException(nameof(remoteDeploymentManagerFactory));
+			generalConfiguration = generalConfigurationOptions?.Value ?? throw new ArgumentNullException(nameof(generalConfigurationOptions));
 			sessionConfiguration = sessionConfigurationOptions?.Value ?? throw new ArgumentNullException(nameof(sessionConfigurationOptions));
 		}
 #pragma warning restore CA1502
@@ -266,7 +274,8 @@ namespace Tgstation.Server.Host.Components
 				postWriteHandler,
 				platformIdentifier,
 				fileTransferService,
-				loggerFactory.CreateLogger<StaticFiles.Configuration>());
+				loggerFactory.CreateLogger<StaticFiles.Configuration>(),
+				generalConfiguration);
 			var eventConsumer = new EventConsumer(configuration);
 			var repoManager = new RepositoryManager(
 				repositoryFactory,
@@ -276,7 +285,8 @@ namespace Tgstation.Server.Host.Components
 				postWriteHandler,
 				gitRemoteFeaturesFactory,
 				loggerFactory.CreateLogger<Repository.Repository>(),
-				loggerFactory.CreateLogger<RepositoryManager>());
+				loggerFactory.CreateLogger<RepositoryManager>(),
+				generalConfiguration);
 			try
 			{
 				var byond = new ByondManager(byondIOManager, byondInstaller, eventConsumer, loggerFactory.CreateLogger<ByondManager>());

--- a/src/Tgstation.Server.Host/Components/Repository/RepositoryManager.cs
+++ b/src/Tgstation.Server.Host/Components/Repository/RepositoryManager.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 
 using Tgstation.Server.Api.Models;
 using Tgstation.Server.Host.Components.Events;
+using Tgstation.Server.Host.Configuration;
 using Tgstation.Server.Host.Core;
 using Tgstation.Server.Host.IO;
 using Tgstation.Server.Host.Jobs;
@@ -63,6 +64,11 @@ namespace Tgstation.Server.Host.Components.Repository
 		readonly ILogger<RepositoryManager> logger;
 
 		/// <summary>
+		/// The <see cref="GeneralConfiguration"/> for the <see cref="RepositoryManager"/>.
+		/// </summary>
+		readonly GeneralConfiguration generalConfiguration;
+
+		/// <summary>
 		/// Used for controlling single access to the <see cref="IRepository"/>.
 		/// </summary>
 		readonly SemaphoreSlim semaphore;
@@ -78,6 +84,7 @@ namespace Tgstation.Server.Host.Components.Repository
 		/// <param name="gitRemoteFeaturesFactory">The value of <see cref="gitRemoteFeaturesFactory"/>.</param>
 		/// <param name="repositoryLogger">The value of <see cref="repositoryLogger"/>.</param>
 		/// <param name="logger">The value of <see cref="logger"/>.</param>
+		/// <param name="generalConfiguration">The value of <see cref="generalConfiguration"/>.</param>
 		public RepositoryManager(
 			ILibGit2RepositoryFactory repositoryFactory,
 			ILibGit2Commands commands,
@@ -86,7 +93,8 @@ namespace Tgstation.Server.Host.Components.Repository
 			IPostWriteHandler postWriteHandler,
 			IGitRemoteFeaturesFactory gitRemoteFeaturesFactory,
 			ILogger<Repository> repositoryLogger,
-			ILogger<RepositoryManager> logger)
+			ILogger<RepositoryManager> logger,
+			GeneralConfiguration generalConfiguration)
 		{
 			this.repositoryFactory = repositoryFactory ?? throw new ArgumentNullException(nameof(repositoryFactory));
 			this.commands = commands ?? throw new ArgumentNullException(nameof(commands));
@@ -96,6 +104,7 @@ namespace Tgstation.Server.Host.Components.Repository
 			this.gitRemoteFeaturesFactory = gitRemoteFeaturesFactory ?? throw new ArgumentNullException(nameof(gitRemoteFeaturesFactory));
 			this.repositoryLogger = repositoryLogger ?? throw new ArgumentNullException(nameof(repositoryLogger));
 			this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+			this.generalConfiguration = generalConfiguration ?? throw new ArgumentNullException(nameof(generalConfiguration));
 			semaphore = new SemaphoreSlim(1);
 		}
 
@@ -217,6 +226,7 @@ namespace Tgstation.Server.Host.Components.Repository
 						postWriteHandler,
 						gitRemoteFeaturesFactory,
 						repositoryLogger,
+						generalConfiguration,
 						() =>
 						{
 							logger.LogTrace("Releasing semaphore due to Repository disposal...");

--- a/src/Tgstation.Server.Host/Components/Repository/RepositoryManager.cs
+++ b/src/Tgstation.Server.Host/Components/Repository/RepositoryManager.cs
@@ -130,7 +130,7 @@ namespace Tgstation.Server.Host.Components.Repository
 			if (progressReporter == null)
 				throw new ArgumentNullException(nameof(progressReporter));
 
-			logger.LogInformation("Begin clone {0} (Branch: {1})", url, initialBranch);
+			logger.LogInformation("Begin clone {url} (Branch: {initialBranch})", url, initialBranch);
 			lock (semaphore)
 			{
 				if (CloneInProgress)

--- a/src/Tgstation.Server.Host/Components/StaticFiles/Configuration.cs
+++ b/src/Tgstation.Server.Host/Components/StaticFiles/Configuration.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Logging;
 using Tgstation.Server.Api.Models;
 using Tgstation.Server.Api.Models.Response;
 using Tgstation.Server.Host.Components.Events;
+using Tgstation.Server.Host.Configuration;
 using Tgstation.Server.Host.Core;
 using Tgstation.Server.Host.IO;
 using Tgstation.Server.Host.Jobs;
@@ -112,6 +113,11 @@ namespace Tgstation.Server.Host.Components.StaticFiles
 		readonly ILogger<Configuration> logger;
 
 		/// <summary>
+		/// The <see cref="GeneralConfiguration"/> for <see cref="Configuration"/>.
+		/// </summary>
+		readonly GeneralConfiguration generalConfiguration;
+
+		/// <summary>
 		/// The <see cref="SemaphoreSlim"/> for <see cref="Configuration"/>. Also used as a <see langword="lock"/> <see cref="object"/>.
 		/// </summary>
 		readonly SemaphoreSlim semaphore;
@@ -137,6 +143,7 @@ namespace Tgstation.Server.Host.Components.StaticFiles
 		/// <param name="platformIdentifier">The value of <see cref="platformIdentifier"/>.</param>
 		/// <param name="fileTransferService">The value of <see cref="fileTransferService"/>.</param>
 		/// <param name="logger">The value of <see cref="logger"/>.</param>
+		/// <param name="generalConfiguration">The value of <see cref="generalConfiguration"/>.</param>
 		public Configuration(
 			IIOManager ioManager,
 			ISynchronousIOManager synchronousIOManager,
@@ -145,7 +152,8 @@ namespace Tgstation.Server.Host.Components.StaticFiles
 			IPostWriteHandler postWriteHandler,
 			IPlatformIdentifier platformIdentifier,
 			IFileTransferTicketProvider fileTransferService,
-			ILogger<Configuration> logger)
+			ILogger<Configuration> logger,
+			GeneralConfiguration generalConfiguration)
 		{
 			this.ioManager = ioManager ?? throw new ArgumentNullException(nameof(ioManager));
 			this.synchronousIOManager = synchronousIOManager ?? throw new ArgumentNullException(nameof(synchronousIOManager));
@@ -155,6 +163,7 @@ namespace Tgstation.Server.Host.Components.StaticFiles
 			this.platformIdentifier = platformIdentifier ?? throw new ArgumentNullException(nameof(platformIdentifier));
 			this.fileTransferService = fileTransferService ?? throw new ArgumentNullException(nameof(fileTransferService));
 			this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+			this.generalConfiguration = generalConfiguration ?? throw new ArgumentNullException(nameof(generalConfiguration));
 
 			semaphore = new SemaphoreSlim(1);
 			disposeCts = new CancellationTokenSource();
@@ -180,7 +189,13 @@ namespace Tgstation.Server.Host.Components.StaticFiles
 				var dmeExistsTask = ioManager.FileExists(ioManager.ConcatPath(CodeModificationsSubdirectory, dmeFile), cancellationToken);
 				var headFileExistsTask = ioManager.FileExists(ioManager.ConcatPath(CodeModificationsSubdirectory, CodeModificationsHeadFile), cancellationToken);
 				var tailFileExistsTask = ioManager.FileExists(ioManager.ConcatPath(CodeModificationsSubdirectory, CodeModificationsTailFile), cancellationToken);
-				var copyTask = ioManager.CopyDirectory(CodeModificationsSubdirectory, destination, null, null, cancellationToken);
+				var copyTask = ioManager.CopyDirectory(
+					null,
+					null,
+					CodeModificationsSubdirectory,
+					destination,
+					generalConfiguration.GetCopyDirectoryTaskThrottle(),
+					cancellationToken);
 
 				await Task.WhenAll(dmeExistsTask, headFileExistsTask, tailFileExistsTask, copyTask);
 

--- a/src/Tgstation.Server.Host/IO/IIOManager.cs
+++ b/src/Tgstation.Server.Host/IO/IIOManager.cs
@@ -48,17 +48,19 @@ namespace Tgstation.Server.Host.IO
 		/// <summary>
 		/// Copies a directory from <paramref name="src"/> to <paramref name="dest"/>.
 		/// </summary>
-		/// <param name="src">The source directory path.</param>
-		/// <param name="dest">The destination directory path.</param>
 		/// <param name="ignore">Files and folders to ignore at the root level.</param>
 		/// <param name="postCopyCallback">The optional callback called for each source/dest file pair post copy.</param>
+		/// <param name="src">The source directory path.</param>
+		/// <param name="dest">The destination directory path.</param>
+		/// <param name="taskThrottle">The optional maximum number of simultaneous tasks allowed to execute.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task"/> representing the running operation.</returns>
 		Task CopyDirectory(
-			string src,
-			string dest,
 			IEnumerable<string> ignore,
 			Func<string, string, Task> postCopyCallback,
+			string src,
+			string dest,
+			int? taskThrottle,
 			CancellationToken cancellationToken);
 
 		/// <summary>

--- a/src/Tgstation.Server.Host/appsettings.yml
+++ b/src/Tgstation.Server.Host/appsettings.yml
@@ -12,6 +12,7 @@ General:
   ValidInstancePaths:
   HostApiDocumentation: false
   SkipAddingByondFirewallException: false
+  DeploymentDirectoryCopyTasksPerCore: 100
 Session:
   HighPriorityLiveDreamDaemon: false
   LowPriorityDeploymentProcesses: true

--- a/tests/Tgstation.Server.Host.Tests/IO/TestIOManager.cs
+++ b/tests/Tgstation.Server.Host.Tests/IO/TestIOManager.cs
@@ -1,5 +1,8 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+using Remora.Discord.API.Objects;
+
+using System;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -69,6 +72,109 @@ namespace Tgstation.Server.Host.IO.Tests
 			{
 				Directory.Delete(tempPath);
 				throw;
+			}
+		}
+
+		[TestMethod]
+		public async Task TestCopyDirectoryThrows()
+		{
+			int? throttle = null;
+			var tempPath1 = Guid.NewGuid().ToString();
+			var tempPath2 = Guid.NewGuid().ToString();
+
+			await Assert.ThrowsExceptionAsync<ArgumentNullException>(() => ioManager.CopyDirectory(
+				null,
+				null,
+				null,
+				tempPath2,
+				throttle,
+				default));
+			await Assert.ThrowsExceptionAsync<ArgumentNullException>(() => ioManager.CopyDirectory(
+				null,
+				null,
+				tempPath1,
+				null,
+				throttle,
+				default));
+			await Assert.ThrowsExceptionAsync<ArgumentNullException>(() => ioManager.CopyDirectory(
+				null,
+				null,
+				null,
+				null,
+				throttle,
+				default));
+			await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => ioManager.CopyDirectory(
+				null,
+				null,
+				tempPath1,
+				tempPath2,
+				-1,
+				default));
+		}
+
+		[TestMethod]
+		public async Task TestCopyDirectoryOneTask()
+		{
+			await TestCopyDirectory(1);
+		}
+
+		[TestMethod]
+		public async Task TestCopyDirectoryMaxTasks()
+		{
+			await TestCopyDirectory(Int32.MaxValue);
+		}
+
+		[TestMethod]
+		public async Task TestCopyDirectoryUnlimitedTasks()
+		{
+			await TestCopyDirectory(null);
+		}
+
+		async Task TestCopyDirectory(int? throttle)
+		{
+			var tempPath = Path.GetTempFileName();
+			File.Delete(tempPath);
+			Directory.CreateDirectory(tempPath);
+			try
+			{
+				var tempPath2 = Path.GetTempFileName();
+				File.Delete(tempPath2);
+
+				await File.WriteAllTextAsync(Path.Combine(tempPath, "file.txt"), "asdf");
+				var subDir = Path.Combine(tempPath, "subdir");
+				Directory.CreateDirectory(subDir);
+				await File.WriteAllTextAsync(Path.Combine(subDir, "file2.txt"), "fdsa");
+
+				try
+				{
+					await ioManager.CopyDirectory(
+						null,
+						null,
+						tempPath,
+						tempPath2,
+						throttle,
+						default);
+
+					Assert.IsTrue(Directory.Exists(tempPath2));
+					var newFilePath = Path.Combine(tempPath2, "file.txt");
+					Assert.IsTrue(File.Exists(newFilePath));
+					var newFileText = await File.ReadAllTextAsync(newFilePath);
+					Assert.AreEqual("asdf", newFileText);
+					var newDirPath = Path.Combine(tempPath2, "subdir");
+					Assert.IsTrue(Directory.Exists(newDirPath));
+					var newFile2Path = Path.Combine(newDirPath, "file2.txt");
+					Assert.IsTrue(File.Exists(newFile2Path));
+					var newFile2Text = await File.ReadAllTextAsync(newFile2Path);
+					Assert.AreEqual("fdsa", newFile2Text);
+				}
+				finally
+				{
+					Directory.Delete(tempPath2, true);
+				}
+			}
+			finally
+			{
+				Directory.Delete(tempPath, true);
 			}
 		}
 	}

--- a/tests/Tgstation.Server.Tests/Live/Instance/ConfigurationTest.cs
+++ b/tests/Tgstation.Server.Tests/Live/Instance/ConfigurationTest.cs
@@ -106,15 +106,17 @@ namespace Tgstation.Server.Tests.Live.Instance
 			var ioManager = new DefaultIOManager();
 			return Task.WhenAll(
 				ioManager.CopyDirectory(
+					Enumerable.Empty<string>(),
+					null,
 					"../../../../DMAPI",
 					ioManager.ConcatPath(instance.Path, "Repository", "tests", "DMAPI"),
-					Enumerable.Empty<string>(),
 					null,
 					cancellationToken),
 				ioManager.CopyDirectory(
+					Enumerable.Empty<string>(),
+					null,
 					"../../../../../src/DMAPI",
 					ioManager.ConcatPath(instance.Path, "Repository", "src", "DMAPI"),
-					Enumerable.Empty<string>(),
 					null,
 					cancellationToken)
 				);

--- a/tests/Tgstation.Server.Tests/TestRepository.cs
+++ b/tests/Tgstation.Server.Tests/TestRepository.cs
@@ -7,6 +7,7 @@ using Moq;
 
 using Tgstation.Server.Host.Components.Events;
 using Tgstation.Server.Host.Components.Repository;
+using Tgstation.Server.Host.Configuration;
 using Tgstation.Server.Host.IO;
 using Tgstation.Server.Host.Jobs;
 using Tgstation.Server.Tests.Live;
@@ -31,6 +32,7 @@ namespace Tgstation.Server.Tests
 				Mock.Of<IPostWriteHandler>(),
 				Mock.Of<IGitRemoteFeaturesFactory>(),
 				Mock.Of<ILogger<Repository>>(),
+				new GeneralConfiguration(),
 				() => { });
 
 			const string StartSha = "af4da8beb9f9b374b04a3cc4d65acca662e8cc1a";


### PR DESCRIPTION
Closes #1460 

:cl: **Configuration**
Added `General:DeploymentDirectoryCopyTasksPerCore` to allow operators to manually adjust the rate at which asynchronous file copies are performed on instances. Too few can significantly increase deployment times, too many can make TGS unresponsive and slowdown other I/O operations on the machine. Leaving this unset disables the throttle entirely. **Note that this is the default for upgraded TGS installations. Server operators should highly consider setting the throttle.** The default value for new installations is `100`.
/:cl: