### PR TITLE
Ignore migrations when tracking code coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,3 +7,5 @@ coverage:
     patch: off
 comment:
   layout: "header, diff, changes"
+ignore:
+  - "src/Tgstation.Server.Host/Database/Migrations"


### PR DESCRIPTION
This is gonna hurt...

Pushing this to `dev` because more than likely I'll have to bypass branch protections when the coverage check fails.