### PR TITLE
Test the Basic watchdog and Debug mode on Linux

### DIFF
--- a/.github/workflows/ci-suite.yml
+++ b/.github/workflows/ci-suite.yml
@@ -425,8 +425,8 @@ jobs:
       fail-fast: false
       matrix:
         database-type: [ 'Sqlite', 'PostgresSql', 'MariaDB', 'MySql' ]
-        watchdog-type: [ 'System' ]
-        configuration: [ 'Release' ]
+        watchdog-type: [ 'Basic', 'System' ]
+        configuration: [ 'Debug', 'Release' ]
     runs-on: ubuntu-latest
     steps:
     - name: Disable ptrace_scope
@@ -619,6 +619,78 @@ jobs:
       with:
         name: linux-integration-test-coverage-Release-System-MySql
         path: ./code_coverage/integration_tests/linux_integration_tests_release_system_mysql
+
+    - name: Retrieve Linux Integration Test Coverage (Release, Basic, Sqlite)
+      uses: actions/download-artifact@v3
+      with:
+        name: linux-integration-test-coverage-Release-System-Sqlite
+        path: ./code_coverage/integration_tests/linux_integration_tests_release_basic_sqlite
+
+    - name: Retrieve Linux Integration Test Coverage (Release, Basic, PostgresSql)
+      uses: actions/download-artifact@v3
+      with:
+        name: linux-integration-test-coverage-Release-System-PostgresSql
+        path: ./code_coverage/integration_tests/linux_integration_tests_release_basic_mariadb
+
+    - name: Retrieve Linux Integration Test Coverage (Release, Basic, MariaDB)
+      uses: actions/download-artifact@v3
+      with:
+        name: linux-integration-test-coverage-Release-System-MariaDB
+        path: ./code_coverage/integration_tests/linux_integration_tests_release_basic_mysql
+
+    - name: Retrieve Linux Integration Test Coverage (Release, Basic, MySql)
+      uses: actions/download-artifact@v3
+      with:
+        name: linux-integration-test-coverage-Release-System-MySql
+        path: ./code_coverage/integration_tests/linux_integration_tests_release_basic_mysql
+
+    - name: Retrieve Linux Integration Test Coverage (Debug, System, Sqlite)
+      uses: actions/download-artifact@v3
+      with:
+        name: linux-integration-test-coverage-Debug-System-Sqlite
+        path: ./code_coverage/integration_tests/linux_integration_tests_debug_system_sqlite
+
+    - name: Retrieve Linux Integration Test Coverage (Debug, System, PostgresSql)
+      uses: actions/download-artifact@v3
+      with:
+        name: linux-integration-test-coverage-Debug-System-PostgresSql
+        path: ./code_coverage/integration_tests/linux_integration_tests_debug_system_mariadb
+
+    - name: Retrieve Linux Integration Test Coverage (Debug, System, MariaDB)
+      uses: actions/download-artifact@v3
+      with:
+        name: linux-integration-test-coverage-Debug-System-MariaDB
+        path: ./code_coverage/integration_tests/linux_integration_tests_debug_system_mysql
+
+    - name: Retrieve Linux Integration Test Coverage (Debug, System, MySql)
+      uses: actions/download-artifact@v3
+      with:
+        name: linux-integration-test-coverage-Debug-System-MySql
+        path: ./code_coverage/integration_tests/linux_integration_tests_debug_system_mysql
+
+    - name: Retrieve Linux Integration Test Coverage (Debug, Basic, Sqlite)
+      uses: actions/download-artifact@v3
+      with:
+        name: linux-integration-test-coverage-Debug-System-Sqlite
+        path: ./code_coverage/integration_tests/linux_integration_tests_debug_basic_sqlite
+
+    - name: Retrieve Linux Integration Test Coverage (Debug, Basic, PostgresSql)
+      uses: actions/download-artifact@v3
+      with:
+        name: linux-integration-test-coverage-Debug-System-PostgresSql
+        path: ./code_coverage/integration_tests/linux_integration_tests_debug_basic_mariadb
+
+    - name: Retrieve Linux Integration Test Coverage (Debug, Basic, MariaDB)
+      uses: actions/download-artifact@v3
+      with:
+        name: linux-integration-test-coverage-Debug-System-MariaDB
+        path: ./code_coverage/integration_tests/linux_integration_tests_debug_basic_mysql
+
+    - name: Retrieve Linux Integration Test Coverage (Debug, Basic, MySql)
+      uses: actions/download-artifact@v3
+      with:
+        name: linux-integration-test-coverage-Debug-System-MySql
+        path: ./code_coverage/integration_tests/linux_integration_tests_debug_basic_mysql
 
     - name: Retrieve Windows Unit Test Coverage (Release)
       uses: actions/download-artifact@v3


### PR DESCRIPTION
Quadruples the amount of Linux Live tests but that's fine since they mostly work now