### PR TITLE
Fix exploit allowing for the reading of discord connection strings.

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>5.12.0</TgsCoreVersion>
+    <TgsCoreVersion>5.12.1</TgsCoreVersion>
     <TgsConfigVersion>4.6.0</TgsConfigVersion>
     <TgsApiVersion>9.10.2</TgsApiVersion>
     <TgsApiLibraryVersion>10.4.1</TgsApiLibraryVersion>

--- a/src/Tgstation.Server.Host/Controllers/ChatController.cs
+++ b/src/Tgstation.Server.Host/Controllers/ChatController.cs
@@ -220,7 +220,7 @@ namespace Tgstation.Server.Host.Controllers
 							.OrderBy(x => x.Id))),
 				chatBot =>
 				{
-					if (connectionStrings)
+					if (!connectionStrings)
 						chatBot.ConnectionString = null;
 
 					return Task.CompletedTask;


### PR DESCRIPTION
Enabling view json in the web panel was the correct call.

:cl: HTTP API
Fixed exploit allowing for the reading of chat bot connection strings.
/:cl:

