### PR TITLE
Double custom uploads fix (v5.12.3 release)

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -7,7 +7,7 @@
     <TgsConfigVersion>4.6.0</TgsConfigVersion>
     <TgsApiVersion>9.10.2</TgsApiVersion>
     <TgsApiLibraryVersion>10.4.1</TgsApiLibraryVersion>
-    <TgsClientVersion>11.4.2</TgsClientVersion>
+    <TgsClientVersion>11.4.3</TgsClientVersion>
     <TgsDmapiVersion>6.4.4</TgsDmapiVersion>
     <TgsInteropVersion>5.6.1</TgsInteropVersion>
     <TgsHostWatchdogVersion>1.2.2</TgsHostWatchdogVersion>

--- a/build/Version.props
+++ b/build/Version.props
@@ -8,7 +8,7 @@
     <TgsApiVersion>9.10.2</TgsApiVersion>
     <TgsApiLibraryVersion>10.4.1</TgsApiLibraryVersion>
     <TgsClientVersion>11.4.3</TgsClientVersion>
-    <TgsDmapiVersion>6.4.4</TgsDmapiVersion>
+    <TgsDmapiVersion>6.4.5</TgsDmapiVersion>
     <TgsInteropVersion>5.6.1</TgsInteropVersion>
     <TgsHostWatchdogVersion>1.2.2</TgsHostWatchdogVersion>
     <TgsContainerScriptVersion>1.2.1</TgsContainerScriptVersion>

--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>5.12.2</TgsCoreVersion>
+    <TgsCoreVersion>5.12.3</TgsCoreVersion>
     <TgsConfigVersion>4.6.0</TgsConfigVersion>
     <TgsApiVersion>9.10.2</TgsApiVersion>
     <TgsApiLibraryVersion>10.4.1</TgsApiLibraryVersion>

--- a/src/DMAPI/tgs.dm
+++ b/src/DMAPI/tgs.dm
@@ -1,6 +1,6 @@
 // tgstation-server DMAPI
 
-#define TGS_DMAPI_VERSION "6.4.4"
+#define TGS_DMAPI_VERSION "6.4.5"
 
 // All functions and datums outside this document are subject to change with any version and should not be relied on.
 

--- a/src/Tgstation.Server.Client/ApiClient.cs
+++ b/src/Tgstation.Server.Client/ApiClient.cs
@@ -305,18 +305,26 @@ namespace Tgstation.Server.Client
 				if (content != null)
 					request.Content = content;
 
-				var headersToUse = tokenRefresh ? tokenRefreshHeaders! : headers;
-				headersToUse.SetRequestHeaders(request.Headers, instanceId);
+				try
+				{
+					var headersToUse = tokenRefresh ? tokenRefreshHeaders! : headers;
+					headersToUse.SetRequestHeaders(request.Headers, instanceId);
 
-				if (authless)
-					request.Headers.Remove(HeaderNames.Authorization);
+					if (authless)
+						request.Headers.Remove(HeaderNames.Authorization);
 
-				if (fileDownload)
-					request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(MediaTypeNames.Application.Octet));
+					if (fileDownload)
+						request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(MediaTypeNames.Application.Octet));
 
-				await Task.WhenAll(requestLoggers.Select(x => x.LogRequest(request, cancellationToken))).ConfigureAwait(false);
+					await Task.WhenAll(requestLoggers.Select(x => x.LogRequest(request, cancellationToken))).ConfigureAwait(false);
 
-				response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+					response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+				}
+				finally
+				{
+					// prevent content param from getting disposed
+					request.Content = null;
+				}
 			}
 
 			try

--- a/src/Tgstation.Server.Client/Tgstation.Server.Client.csproj
+++ b/src/Tgstation.Server.Client/Tgstation.Server.Client.csproj
@@ -16,7 +16,7 @@
     <RepositoryUrl>https://github.com/tgstation/tgstation-server</RepositoryUrl>
     <Copyright>2018-2023</Copyright>
     <PackageTags>json web api tgstation-server tgstation ss13 byond client http</PackageTags>
-    <PackageReleaseNotes>Added missing Dispose() call to the StringContents for requests with bodies and added missing ConfigureAwait(false) to async call.</PackageReleaseNotes>
+    <PackageReleaseNotes>Fixed streams being passed into IByondClient.SetActiveVersion getting disposed.</PackageReleaseNotes>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <CodeAnalysisRuleSet>../../build/analyzers.ruleset</CodeAnalysisRuleSet>

--- a/src/Tgstation.Server.Host/Components/Byond/ByondManager.cs
+++ b/src/Tgstation.Server.Host/Components/Byond/ByondManager.cs
@@ -423,10 +423,10 @@ namespace Tgstation.Server.Host.Components.Byond
 			{
 				if (customVersionStream != null)
 				{
-					int customInstallationNumber = 1;
+					var customInstallationNumber = 1;
 					do
 					{
-						version = new Version(version.Major, version.Minor, customInstallationNumber);
+						version = new Version(version.Major, version.Minor, customInstallationNumber++);
 					}
 					while (installedVersions.ContainsKey(version));
 				}

--- a/tests/Tgstation.Server.Tests/Live/TestLiveServer.cs
+++ b/tests/Tgstation.Server.Tests/Live/TestLiveServer.cs
@@ -855,8 +855,8 @@ namespace Tgstation.Server.Tests.Live
 					var adminTest = FailFast(new AdministrationTest(adminClient.Administration).Run(cancellationToken));
 					var usersTest = FailFast(new UsersTest(adminClient).Run(cancellationToken));
 					var instanceMangagerTest = new InstanceManagerTest(adminClient, server.Directory);
-					var instancesTest = FailFast(instanceMangagerTest.RunPreTest(cancellationToken));
 					instance = await instanceMangagerTest.CreateTestInstance(cancellationToken);
+					var instancesTest = FailFast(instanceMangagerTest.RunPreTest(cancellationToken));
 					Assert.IsTrue(Directory.Exists(instance.Path));
 					var instanceClient = adminClient.Instances.CreateClient(instance);
 

--- a/tests/Tgstation.Server.Tests/Live/TestLiveServer.cs
+++ b/tests/Tgstation.Server.Tests/Live/TestLiveServer.cs
@@ -765,6 +765,8 @@ namespace Tgstation.Server.Tests.Live
 					}
 				}
 			}
+			else
+				await internalTask;
 		}
 
 		async Task TestTgsInternal(CancellationToken hardCancellationToken)
@@ -845,7 +847,7 @@ namespace Tgstation.Server.Tests.Live
 						}
 						catch (Exception ex)
 						{
-							System.Console.WriteLine($"[{DateTimeOffset.UtcNow}] TEST ERROR: {ex}");
+							Console.WriteLine($"[{DateTimeOffset.UtcNow}] TEST ERROR: {ex}");
 							serverCts.Cancel();
 							throw;
 						}


### PR DESCRIPTION
:cl:
Fixed uploading more than one custom BYOND version per BYOND build creating jobs that would hang indefinitely.
Fixed a rare race condition in server shutdown related to the job manager.
/:cl:

:cl: DreamMaker API
Release only includes an update to the V5 interop version, which was patched server-side.
/:cl:

Merging with `[NugetDeploy][DMDeploy][TGSDeploy]`

Fixes #1501 