### PR TITLE
Fix server applying the deployment low priority config to live servers and the live server priority config to deployments.

### DIFF
--- a/src/Tgstation.Server.Host/Components/Session/SessionControllerFactory.cs
+++ b/src/Tgstation.Server.Host/Components/Session/SessionControllerFactory.cs
@@ -525,7 +525,7 @@ namespace Tgstation.Server.Host.Components.Session
 
 			try
 			{
-				if (apiValidate)
+				if (!apiValidate)
 				{
 					if (sessionConfiguration.HighPriorityLiveDreamDaemon)
 						process.AdjustPriority(true);


### PR DESCRIPTION
This was causing prod live byond servers to run in low priority if `Session:LowPriorityDeploymentProcesses` was enabled.


:cl: Core
Fix server applying the deployment low priority config to live servers and the live server priority config to deployments.
/:cl:
