### PR TITLE
`--staged` param for `prs` chat command

### DIFF
--- a/src/Tgstation.Server.Host/Components/Chat/Commands/CommandFactory.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Commands/CommandFactory.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 
 using Tgstation.Server.Host.Components.Byond;
+using Tgstation.Server.Host.Components.Deployment;
 using Tgstation.Server.Host.Components.Repository;
 using Tgstation.Server.Host.Components.Watchdog;
 using Tgstation.Server.Host.Database;
@@ -33,6 +34,11 @@ namespace Tgstation.Server.Host.Components.Chat.Commands
 		readonly IDatabaseContextFactory databaseContextFactory;
 
 		/// <summary>
+		/// The <see cref="ILatestCompileJobProvider"/> for the <see cref="CommandFactory"/>.
+		/// </summary>
+		readonly ILatestCompileJobProvider compileJobProvider;
+
+		/// <summary>
 		/// The <see cref="Models.Instance"/> for the <see cref="CommandFactory"/>.
 		/// </summary>
 		readonly Models.Instance instance;
@@ -49,18 +55,21 @@ namespace Tgstation.Server.Host.Components.Chat.Commands
 		/// <param name="byondManager">The value of <see cref="byondManager"/>.</param>
 		/// <param name="repositoryManager">The value of <see cref="repositoryManager"/>.</param>
 		/// <param name="databaseContextFactory">The value of <see cref="databaseContextFactory"/>.</param>
+		/// <param name="compileJobProvider">The value of <see cref="compileJobProvider"/>.</param>
 		/// <param name="instance">The value of <see cref="instance"/>.</param>
 		public CommandFactory(
 			IAssemblyInformationProvider assemblyInformationProvider,
 			IByondManager byondManager,
 			IRepositoryManager repositoryManager,
 			IDatabaseContextFactory databaseContextFactory,
+			ILatestCompileJobProvider compileJobProvider,
 			Models.Instance instance)
 		{
 			this.assemblyInformationProvider = assemblyInformationProvider ?? throw new ArgumentNullException(nameof(assemblyInformationProvider));
 			this.byondManager = byondManager ?? throw new ArgumentNullException(nameof(byondManager));
 			this.repositoryManager = repositoryManager ?? throw new ArgumentNullException(nameof(repositoryManager));
 			this.databaseContextFactory = databaseContextFactory ?? throw new ArgumentNullException(nameof(databaseContextFactory));
+			this.compileJobProvider = compileJobProvider ?? throw new ArgumentNullException(nameof(compileJobProvider));
 			this.instance = instance ?? throw new ArgumentNullException(nameof(instance));
 		}
 
@@ -85,7 +94,7 @@ namespace Tgstation.Server.Host.Components.Chat.Commands
 				new VersionCommand(assemblyInformationProvider),
 				new ByondCommand(byondManager, watchdog),
 				new RevisionCommand(watchdog, repositoryManager),
-				new PullRequestsCommand(watchdog, repositoryManager, databaseContextFactory, instance),
+				new PullRequestsCommand(watchdog, repositoryManager, databaseContextFactory, compileJobProvider, instance),
 				new KekCommand(),
 			};
 		}

--- a/src/Tgstation.Server.Host/Components/Chat/Commands/PullRequestsCommand.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Commands/PullRequestsCommand.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 
 using Tgstation.Server.Api.Models;
+using Tgstation.Server.Host.Components.Deployment;
 using Tgstation.Server.Host.Components.Interop;
 using Tgstation.Server.Host.Components.Repository;
 using Tgstation.Server.Host.Components.Watchdog;
@@ -23,7 +24,7 @@ namespace Tgstation.Server.Host.Components.Chat.Commands
 		public string Name => "prs";
 
 		/// <inheritdoc />
-		public string HelpText => "Display live test merge numbers. Add --repo to view test merges in the repository as opposed to live.";
+		public string HelpText => "Display live test merge numbers. Add --repo to view test merges in the repository as opposed to live. Add --staged to view PRs in the upcoming deployment.";
 
 		/// <inheritdoc />
 		public bool AdminOnly => false;
@@ -44,6 +45,11 @@ namespace Tgstation.Server.Host.Components.Chat.Commands
 		readonly IDatabaseContextFactory databaseContextFactory;
 
 		/// <summary>
+		/// The <see cref="ILatestCompileJobProvider"/> for the <see cref="PullRequestsCommand"/>.
+		/// </summary>
+		readonly ILatestCompileJobProvider compileJobProvider;
+
+		/// <summary>
 		/// The <see cref="Models.Instance"/> for the <see cref="PullRequestsCommand"/>.
 		/// </summary>
 		readonly Models.Instance instance;
@@ -54,12 +60,19 @@ namespace Tgstation.Server.Host.Components.Chat.Commands
 		/// <param name="watchdog">The value of <see cref="watchdog"/>.</param>
 		/// <param name="repositoryManager">The value of <see cref="repositoryManager"/>.</param>
 		/// <param name="databaseContextFactory">The value of <see cref="databaseContextFactory"/>.</param>
+		/// <param name="compileJobProvider">The value of <see cref="compileJobProvider"/>.</param>
 		/// <param name="instance">The value of <see cref="instance"/>.</param>
-		public PullRequestsCommand(IWatchdog watchdog, IRepositoryManager repositoryManager, IDatabaseContextFactory databaseContextFactory, Models.Instance instance)
+		public PullRequestsCommand(
+			IWatchdog watchdog,
+			IRepositoryManager repositoryManager,
+			IDatabaseContextFactory databaseContextFactory,
+			ILatestCompileJobProvider compileJobProvider,
+			Models.Instance instance)
 		{
 			this.watchdog = watchdog ?? throw new ArgumentNullException(nameof(watchdog));
 			this.repositoryManager = repositoryManager ?? throw new ArgumentNullException(nameof(repositoryManager));
 			this.databaseContextFactory = databaseContextFactory ?? throw new ArgumentNullException(nameof(databaseContextFactory));
+			this.compileJobProvider = compileJobProvider ?? throw new ArgumentNullException(nameof(compileJobProvider));
 			this.instance = instance ?? throw new ArgumentNullException(nameof(instance));
 		}
 
@@ -69,7 +82,17 @@ namespace Tgstation.Server.Host.Components.Chat.Commands
 		public async Task<MessageContent> Invoke(string arguments, ChatUser user, CancellationToken cancellationToken)
 		{
 			IEnumerable<Models.TestMerge> results = null;
-			if (arguments.Split(' ').Any(x => x.ToUpperInvariant() == "--REPO"))
+			var splits = arguments.Split(' ');
+			var hasRepo = splits.Any(x => x.Equals("--repo", StringComparison.OrdinalIgnoreCase));
+			var hasStaged = splits.Any(x => x.Equals("--staged", StringComparison.OrdinalIgnoreCase));
+
+			if (hasStaged && hasRepo)
+				return new MessageContent
+				{
+					Text = "Please use only one of `--staged` or `--repo`",
+				};
+
+			if (hasRepo)
 			{
 				string head;
 				using (var repo = await repositoryManager.LoadRepository(cancellationToken))
@@ -97,14 +120,24 @@ namespace Tgstation.Server.Host.Components.Chat.Commands
 						})
 						.ToListAsync(cancellationToken));
 			}
+			else if (watchdog.Status == WatchdogStatus.Offline)
+				return new MessageContent
+				{
+					Text = "Server offline!",
+				};
 			else
 			{
-				if (watchdog.Status == WatchdogStatus.Offline)
-					return new MessageContent
-					{
-						Text = "Server offline!",
-					};
-				results = watchdog.ActiveCompileJob?.RevisionInformation.ActiveTestMerges.Select(x => x.TestMerge).ToList() ?? new List<Models.TestMerge>();
+				var compileJobToUse = watchdog.ActiveCompileJob;
+				if (hasStaged)
+				{
+					var latestCompileJob = compileJobProvider.LatestCompileJob();
+					if (latestCompileJob?.Id != compileJobToUse?.Id)
+						compileJobToUse = latestCompileJob;
+					else
+						compileJobToUse = null;
+				}
+
+				results = compileJobToUse?.RevisionInformation.ActiveTestMerges.Select(x => x.TestMerge).ToList() ?? Enumerable.Empty<Models.TestMerge>();
 			}
 
 			return new MessageContent

--- a/src/Tgstation.Server.Host/Components/Chat/Commands/PullRequestsCommand.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Commands/PullRequestsCommand.cs
@@ -94,6 +94,12 @@ namespace Tgstation.Server.Host.Components.Chat.Commands
 
 			if (hasRepo)
 			{
+				if (repositoryManager.CloneInProgress || repositoryManager.InUse)
+					return new MessageContent
+					{
+						Text = "Repository busy! Try again later",
+					};
+
 				string head;
 				using (var repo = await repositoryManager.LoadRepository(cancellationToken))
 				{

--- a/src/Tgstation.Server.Host/Components/Chat/Commands/RevisionCommand.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Commands/RevisionCommand.cs
@@ -51,6 +51,13 @@ namespace Tgstation.Server.Host.Components.Chat.Commands
 		{
 			string result;
 			if (arguments.Split(' ').Any(x => x.ToUpperInvariant() == "--REPO"))
+			{
+				if (repositoryManager.CloneInProgress || repositoryManager.InUse)
+					return new MessageContent
+					{
+						Text = "Repository busy! Try again later",
+					};
+
 				using (var repo = await repositoryManager.LoadRepository(cancellationToken))
 				{
 					if (repo == null)
@@ -60,6 +67,7 @@ namespace Tgstation.Server.Host.Components.Chat.Commands
 						};
 					result = repo.Head;
 				}
+			}
 			else
 			{
 				if (watchdog.Status == WatchdogStatus.Offline)

--- a/src/Tgstation.Server.Host/Controllers/DreamDaemonController.cs
+++ b/src/Tgstation.Server.Host/Controllers/DreamDaemonController.cs
@@ -170,8 +170,7 @@ namespace Tgstation.Server.Host.Controllers
 				.AsQueryable()
 				.Where(x => x.Id == Instance.Id)
 				.Select(x => x.DreamDaemonSettings)
-				.FirstOrDefaultAsync(cancellationToken)
-				;
+				.FirstOrDefaultAsync(cancellationToken);
 
 			if (current == default)
 				return Gone();
@@ -182,8 +181,8 @@ namespace Tgstation.Server.Host.Controllers
 					.GetAvailablePort(
 						model.Port.Value,
 						true,
-						cancellationToken)
-					;
+						cancellationToken);
+
 				if (verifiedPort != model.Port)
 					return Conflict(new ErrorMessageResponse(ErrorCode.PortNotAvailable));
 			}

--- a/tests/Tgstation.Server.Tests/Live/DummyChatProviderFactory.cs
+++ b/tests/Tgstation.Server.Tests/Live/DummyChatProviderFactory.cs
@@ -9,6 +9,7 @@ using Tgstation.Server.Api.Models;
 using Tgstation.Server.Host.Components.Byond;
 using Tgstation.Server.Host.Components.Chat.Commands;
 using Tgstation.Server.Host.Components.Chat.Providers;
+using Tgstation.Server.Host.Components.Deployment;
 using Tgstation.Server.Host.Components.Repository;
 using Tgstation.Server.Host.Components.Watchdog;
 using Tgstation.Server.Host.Database;
@@ -42,6 +43,7 @@ namespace Tgstation.Server.Tests.Live
 				Mock.Of<IByondManager>(),
 				Mock.Of<IRepositoryManager>(),
 				Mock.Of<IDatabaseContextFactory>(),
+				Mock.Of<ILatestCompileJobProvider>(),
 				new Host.Models.Instance());
 
 			commandFactory.SetWatchdog(Mock.Of<IWatchdog>());


### PR DESCRIPTION
:cl:
The `prs` chat command now supports a `--staged` argument that will give you the test merges in the revision staged for deployment if any.
`--repo` parameter for `prs` and `revision` commands no longer block until the repository is available.
/:cl: