### PR TITLE
Catch potential IOExceptions when listing a config directory

### DIFF
--- a/src/Tgstation.Server.Host/Components/StaticFiles/Configuration.cs
+++ b/src/Tgstation.Server.Host/Components/StaticFiles/Configuration.cs
@@ -227,28 +227,28 @@ namespace Tgstation.Server.Host.Components.StaticFiles
 
 			void ListImpl()
 			{
-				var enumerator = synchronousIOManager.GetDirectories(path, cancellationToken);
 				try
 				{
+					var enumerator = synchronousIOManager.GetDirectories(path, cancellationToken);
 					result.AddRange(enumerator.Select(x => new ConfigurationFileResponse
 					{
 						IsDirectory = true,
 						Path = ioManager.ConcatPath(configurationRelativePath, x),
 					}).OrderBy(file => file.Path));
+
+					enumerator = synchronousIOManager.GetFiles(path, cancellationToken);
+					result.AddRange(enumerator.Select(x => new ConfigurationFileResponse
+					{
+						IsDirectory = false,
+						Path = ioManager.ConcatPath(configurationRelativePath, x),
+					}).OrderBy(file => file.Path));
 				}
 				catch (IOException e)
 				{
-					logger.LogDebug(e, "IOException while writing {path}!", path);
+					logger.LogDebug(e, "IOException while enumerating direcotry {path}!", path);
 					result = null;
 					return;
 				}
-
-				enumerator = synchronousIOManager.GetFiles(path, cancellationToken);
-				result.AddRange(enumerator.Select(x => new ConfigurationFileResponse
-				{
-					IsDirectory = false,
-					Path = ioManager.ConcatPath(configurationRelativePath, x),
-				}).OrderBy(file => file.Path));
 			}
 
 			using (await SemaphoreSlimContext.Lock(semaphore, cancellationToken))


### PR DESCRIPTION
:cl:
Fixed a potential 500 error when listing an instance's configuration directory if an IO error occurred.
/:cl: