### PR TITLE
Fix 500 error on entering a registered Windows login with invalid password

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>5.12.4</TgsCoreVersion>
+    <TgsCoreVersion>5.12.5</TgsCoreVersion>
     <TgsConfigVersion>4.6.0</TgsConfigVersion>
     <TgsApiVersion>9.10.2</TgsApiVersion>
     <TgsApiLibraryVersion>10.4.1</TgsApiLibraryVersion>

--- a/src/Tgstation.Server.Host/Controllers/HomeController.cs
+++ b/src/Tgstation.Server.Host/Controllers/HomeController.cs
@@ -298,8 +298,7 @@ namespace Tgstation.Server.Host.Controllers
 						Enabled = x.Enabled,
 						Name = x.Name,
 					})
-					.ToListAsync(cancellationToken)
-					;
+					.ToListAsync(cancellationToken);
 
 				// Pick the DB user first
 				var user = users
@@ -322,7 +321,7 @@ namespace Tgstation.Server.Host.Controllers
 					if (!usingSystemIdentity)
 					{
 						// DB User password check and update
-						if (!cryptographySuite.CheckUserPassword(user, ApiHeaders.Password))
+						if (originalHash == null || !cryptographySuite.CheckUserPassword(user, ApiHeaders.Password))
 							return Unauthorized();
 						if (user.PasswordHash != originalHash)
 						{

--- a/src/Tgstation.Server.Host/Security/CryptographySuite.cs
+++ b/src/Tgstation.Server.Host/Security/CryptographySuite.cs
@@ -54,6 +54,11 @@ namespace Tgstation.Server.Host.Security
 		/// <inheritdoc />
 		public bool CheckUserPassword(User user, string password)
 		{
+			if (user == null)
+				throw new ArgumentNullException(nameof(user));
+			if (password == null)
+				throw new ArgumentNullException(nameof(password));
+
 			var result = passwordHasher.VerifyHashedPassword(user, user.PasswordHash, password);
 			switch (result)
 			{


### PR DESCRIPTION
Fixes #1521

:cl:
Fixed an internal error that could occur if an incorrect password was entered for a registered Windows user.
/:cl:

Merging with `[TGSDeploy]`