### PR TITLE
Fix CI: `mysqladmin` is gone in latest mariadb

### DIFF
--- a/.github/workflows/auto-approve-dominions-prs.yml
+++ b/.github/workflows/auto-approve-dominions-prs.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   approve-pr-if-dominion-is-author:
     name: Approve PR if Dominion is Author
-    if: github.event.pull_request.user.login == 'Cyberboss' && (github.event.pull_request.base.repo.owner.login == 'tgstation' || && github.event.pull_request.base.repo.owner.login == 'Cyberboss')
+    if: github.event.pull_request.user.login == 'Cyberboss' && (github.event.pull_request.base.repo.owner.login == 'tgstation' || github.event.pull_request.base.repo.owner.login == 'Cyberboss')
     runs-on: ubuntu-latest
     steps:
     - name: GitHub API Call

--- a/.github/workflows/ci-suite.yml
+++ b/.github/workflows/ci-suite.yml
@@ -448,7 +448,7 @@ jobs:
         env:
           MYSQL_ROOT_PASSWORD: mariadb
         options: >-
-          --health-cmd="mysqladmin ping"
+          --health-cmd="mariadb-admin ping"
           --health-interval=5s
           --health-timeout=2s
           --health-retries=3


### PR DESCRIPTION
Use `mariadb-admin` instead. See https://github.com/MariaDB/mariadb-docker/issues/512

Also fix auto-approve workflow which I broke.