### PR TITLE
Populate `HeadInclude.dm` and `TailInclude.dm` on instance creation

### DIFF
--- a/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
@@ -890,7 +890,13 @@ namespace Tgstation.Server.Host.Components.Deployment
 			var dmePath = ioManager.ConcatPath(job.DirectoryName.ToString(), dmeFileName);
 			var dmeReadTask = ioManager.ReadAllBytes(dmePath, cancellationToken);
 
-			var dmeModificationsTask = configuration.CopyDMFilesTo(dmeFileName, ioManager.ResolvePath(job.DirectoryName.ToString()), cancellationToken);
+			var dmeModificationsTask = configuration.CopyDMFilesTo(
+				dmeFileName,
+				ioManager.ResolvePath(
+					ioManager.ConcatPath(
+						job.DirectoryName.ToString(),
+						ioManager.GetDirectoryName(dmeFileName))),
+				cancellationToken);
 
 			var dmeBytes = await dmeReadTask;
 			var dme = Encoding.UTF8.GetString(dmeBytes);

--- a/tests/Tgstation.Server.Tests/Live/Instance/ConfigurationTest.cs
+++ b/tests/Tgstation.Server.Tests/Live/Instance/ConfigurationTest.cs
@@ -119,9 +119,32 @@ namespace Tgstation.Server.Tests.Live.Instance
 				);
 		}
 
+		Task TestPregeneratedFilesExist(CancellationToken cancellationToken) => Task.Factory.StartNew(
+			_ =>
+			{
+				var configDir = Path.Combine(instance.Path, "Configuration");
+				var baseDir = Path.Combine(configDir, "CodeModifications");
+				var path = Path.Combine(baseDir, "HeadInclude.dm");
+				var result = File.Exists(path);
+				Assert.IsTrue(result);
+				path = Path.Combine(baseDir, "TailInclude.dm");
+				result = File.Exists(path);
+				Assert.IsTrue(result);
+				var tgsIgnore = Path.Combine(configDir, "GameStaticFiles", ".tgsignore");
+				result = File.Exists(tgsIgnore);
+				Assert.IsTrue(result);
+			},
+			null,
+			cancellationToken,
+			TaskCreationOptions.LongRunning,
+			TaskScheduler.Current);
+
 		public Task RunPreWatchdog(CancellationToken cancellationToken)
 		{
-			return Task.WhenAll(TestUploadDownloadAndDeleteDirectory(cancellationToken), SetupDMApiTests(cancellationToken));
+			return Task.WhenAll(
+				TestUploadDownloadAndDeleteDirectory(cancellationToken),
+				SetupDMApiTests(cancellationToken),
+				TestPregeneratedFilesExist(cancellationToken));
 		}
 	}
 }

--- a/tests/Tgstation.Server.Tests/Live/Instance/InstanceTest.cs
+++ b/tests/Tgstation.Server.Tests/Live/Instance/InstanceTest.cs
@@ -26,7 +26,7 @@ namespace Tgstation.Server.Tests.Live.Instance
 			this.serverPort = serverPort;
 		}
 
-		public async Task RunTests(CancellationToken cancellationToken, bool highPrioDD, bool lowPrioDeployment)
+		public async Task RunTests(bool highPrioDD, bool lowPrioDeployment, CancellationToken cancellationToken)
 		{
 			var byondTest = new ByondTest(instanceClient.Byond, instanceClient.Jobs, fileDownloader, instanceClient.Metadata);
 			var chatTest = new ChatTest(instanceClient.ChatBots, instanceManagerClient, instanceClient.Jobs, instanceClient.Metadata);

--- a/tests/Tgstation.Server.Tests/Live/Instance/RepositoryTest.cs
+++ b/tests/Tgstation.Server.Tests/Live/Instance/RepositoryTest.cs
@@ -40,6 +40,7 @@ namespace Tgstation.Server.Tests.Live.Instance
 
 			async Task<JobResponse> Rest()
 			{
+				await Task.Yield();
 				await ApiAssert.ThrowsException<ConflictException>(() => repositoryClient.Read(cancellationToken), ErrorCode.RepoCloning);
 				Assert.IsNotNull(clone);
 				Assert.AreEqual(cloneRequest.Origin, clone.Origin);

--- a/tests/Tgstation.Server.Tests/Live/TestLiveServer.cs
+++ b/tests/Tgstation.Server.Tests/Live/TestLiveServer.cs
@@ -1052,9 +1052,9 @@ namespace Tgstation.Server.Tests.Live
 							GetInstanceManager(),
 							(ushort)server.Url.Port)
 						.RunTests(
-							cancellationToken,
 							server.HighPriorityDreamDaemon,
-							server.LowPriorityDeployments));
+							server.LowPriorityDeployments,
+							cancellationToken));
 
 					await Task.WhenAll(rootTest, adminTest, instancesTest, instanceTests, usersTest);
 


### PR DESCRIPTION
:cl:
A stub `HeadInclude.dm` and `TailInclude.dm` will be generated in the `Configuration/CodeModifications` directory on instance startup if said directory didn't previously exist.
Fixed `HeadInclude.dm` and `TailInclude.dm` if the deployement's target `.dme` wasn't in the root of the game directory.
/:cl: