### PR TITLE
If the DMAPI is available, delay non-basic watchdog swaps until TgsReboot() is called

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -43,6 +43,8 @@ COPY tgstation-server.sln ./
 COPY src/Tgstation.Server.Host.Console/Tgstation.Server.Host.Console.csproj src/Tgstation.Server.Host.Console/
 COPY src/Tgstation.Server.Host.Watchdog/Tgstation.Server.Host.Watchdog.csproj src/Tgstation.Server.Host.Watchdog/
 COPY src/Tgstation.Server.Api/Tgstation.Server.Api.csproj src/Tgstation.Server.Api/
+COPY src/Tgstation.Server.Common/Tgstation.Server.Common.csproj src/Tgstation.Server.Common/
+COPY src/Tgstation.Server.Host.Common/Tgstation.Server.Host.Common.csproj src/Tgstation.Server.Host.Common/
 
 RUN dotnet restore -nowarn:MSB3202,nu1503 -p:RestoreUseSkipNonexistentTargets=false
 

--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>5.12.5</TgsCoreVersion>
+    <TgsCoreVersion>5.12.6</TgsCoreVersion>
     <TgsConfigVersion>4.6.0</TgsConfigVersion>
     <TgsApiVersion>9.10.2</TgsApiVersion>
     <TgsApiLibraryVersion>10.4.1</TgsApiLibraryVersion>

--- a/src/Tgstation.Server.Host/Components/Deployment/SwappableDmbProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/SwappableDmbProvider.cs
@@ -80,9 +80,11 @@ namespace Tgstation.Server.Host.Components.Deployment
 			if (Interlocked.Exchange(ref swapped, 1) != 0)
 				throw new InvalidOperationException("Already swapped!");
 
-			// Note this comment from TGS3:
-			// These next two lines should be atomic but this is the best we can do
-			await ioManager.DeleteDirectory(LiveGameDirectory, cancellationToken);
+			if (symlinkFactory.SymlinkedDirectoriesAreDeletedAsFiles)
+				await ioManager.DeleteFile(LiveGameDirectory, cancellationToken);
+			else
+				await ioManager.DeleteDirectory(LiveGameDirectory, cancellationToken);
+
 			await symlinkFactory.CreateSymbolicLink(
 				ioManager.ResolvePath(baseProvider.Directory),
 				ioManager.ResolvePath(LiveGameDirectory),

--- a/src/Tgstation.Server.Host/Components/Session/ISessionController.cs
+++ b/src/Tgstation.Server.Host/Components/Session/ISessionController.cs
@@ -55,6 +55,11 @@ namespace Tgstation.Server.Host.Components.Session
 		RebootState RebootState { get; }
 
 		/// <summary>
+		/// A <see cref="Task"/> that completes when the server calls /world/TgsNew().
+		/// </summary>
+		Task OnStartup { get; }
+
+		/// <summary>
 		/// A <see cref="Task"/> that completes when the server calls /world/TgsReboot().
 		/// </summary>
 		Task OnReboot { get; }
@@ -113,6 +118,7 @@ namespace Tgstation.Server.Host.Components.Session
 		/// Replace the <see cref="IDmbProvider"/> in use with a given <paramref name="newProvider"/>, disposing the old one.
 		/// </summary>
 		/// <param name="newProvider">The new <see cref="IDmbProvider"/>.</param>
-		void ReplaceDmbProvider(IDmbProvider newProvider);
+		/// <returns>An <see cref="IDisposable"/> to be disposed once certain that the original <see cref="IDmbProvider"/> is no longer in use.</returns>
+		IDisposable ReplaceDmbProvider(IDmbProvider newProvider);
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Session/ISessionController.cs
+++ b/src/Tgstation.Server.Host/Components/Session/ISessionController.cs
@@ -50,6 +50,11 @@ namespace Tgstation.Server.Host.Components.Session
 		bool ClosePortOnReboot { get; set; }
 
 		/// <summary>
+		/// If the <see cref="ISessionController"/> is currently processing a bridge request from TgsReboot().
+		/// </summary>
+		bool ProcessingRebootBridgeRequest { get; }
+
+		/// <summary>
 		/// The current <see cref="RebootState"/>.
 		/// </summary>
 		RebootState RebootState { get; }

--- a/src/Tgstation.Server.Host/Components/Watchdog/BasicWatchdog.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/BasicWatchdog.cs
@@ -170,6 +170,8 @@ namespace Tgstation.Server.Host.Components.Watchdog
 				case MonitorActivationReason.ActiveServerPrimed:
 					await HandleEvent(EventType.WorldPrime, Enumerable.Empty<string>(), false, cancellationToken);
 					break;
+				case MonitorActivationReason.ActiveServerStartup:
+					break; // unused in BasicWatchdog
 				case MonitorActivationReason.Heartbeat:
 				default:
 					throw new InvalidOperationException($"Invalid activation reason: {reason}");

--- a/src/Tgstation.Server.Host/Components/Watchdog/BasicWatchdog.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/BasicWatchdog.cs
@@ -143,21 +143,27 @@ namespace Tgstation.Server.Host.Components.Watchdog
 					gracefulRebootRequired = false;
 					Server.ResetRebootState();
 
-					await HandleEvent(EventType.WorldReboot, Enumerable.Empty<string>(), false, cancellationToken);
-
-					switch (rebootState)
+					var eventTask = HandleEvent(EventType.WorldReboot, Enumerable.Empty<string>(), false, cancellationToken);
+					try
 					{
-						case Session.RebootState.Normal:
-							return await HandleNormalReboot(cancellationToken);
-						case Session.RebootState.Restart:
-							return MonitorAction.Restart;
-						case Session.RebootState.Shutdown:
-							// graceful shutdown time
-							Chat.QueueWatchdogMessage(
-								"Active server rebooted! Shutting down due to graceful termination request...");
-							return MonitorAction.Exit;
-						default:
-							throw new InvalidOperationException($"Invalid reboot state: {rebootState}");
+						switch (rebootState)
+						{
+							case Session.RebootState.Normal:
+								return await HandleNormalReboot(cancellationToken);
+							case Session.RebootState.Restart:
+								return MonitorAction.Restart;
+							case Session.RebootState.Shutdown:
+								// graceful shutdown time
+								Chat.QueueWatchdogMessage(
+									"Active server rebooted! Shutting down due to graceful termination request...");
+								return MonitorAction.Exit;
+							default:
+								throw new InvalidOperationException($"Invalid reboot state: {rebootState}");
+						}
+					}
+					finally
+					{
+						await eventTask;
 					}
 
 				case MonitorActivationReason.ActiveLaunchParametersUpdated:

--- a/src/Tgstation.Server.Host/Components/Watchdog/MonitorActivationReason.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/MonitorActivationReason.cs
@@ -34,5 +34,11 @@
 		/// Server primed.
 		/// </summary>
 		ActiveServerPrimed,
+
+		/// <summary>
+		/// Server started.
+		/// </summary>
+		/// <remarks>The monitor misses the first startup of a session.</remarks>
+		ActiveServerStartup,
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Watchdog/PosixWatchdog.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/PosixWatchdog.cs
@@ -84,7 +84,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 		}
 
 		/// <inheritdoc />
-		protected override Task ApplyInitialDmb(CancellationToken cancellationToken) => Task.CompletedTask;
+		protected override Task ApplyInitialDmb(CancellationToken cancellationToken) => Task.CompletedTask; // not necessary to hold initial .dmb on Linux because of based inode deletes
 
 		/// <inheritdoc />
 		protected override async Task InitialLink(CancellationToken cancellationToken)

--- a/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
@@ -796,6 +796,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 				MonitorAction nextAction = MonitorAction.Continue;
 				Task activeServerLifetime = null,
 					activeServerReboot = null,
+					activeServerStartup = null,
 					serverPrimed = null,
 					activeLaunchParametersChanged = null,
 					newDmbAvailable = null;
@@ -825,12 +826,14 @@ namespace Tgstation.Server.Host.Components.Watchdog
 									TryUpdateTask(ref activeServerLifetime, () => controller.Lifetime);
 									TryUpdateTask(ref activeServerReboot, () => controller.OnReboot);
 									TryUpdateTask(ref serverPrimed, () => controller.OnPrime);
+									TryUpdateTask(ref activeServerStartup, () => controller.OnStartup);
 								}
 								else
 								{
 									activeServerLifetime = controller.Lifetime;
 									activeServerReboot = controller.OnReboot;
 									serverPrimed = controller.OnPrime;
+									activeServerStartup = controller.OnStartup;
 									lastController = controller;
 								}
 
@@ -862,6 +865,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 							var toWaitOn = Task.WhenAny(
 								activeServerLifetime,
 								activeServerReboot,
+								activeServerStartup,
 								heartbeat,
 								newDmbAvailable,
 								cancelTcs.Task,
@@ -908,7 +912,8 @@ namespace Tgstation.Server.Host.Components.Watchdog
 										|| CheckActivationReason(ref newDmbAvailable, MonitorActivationReason.NewDmbAvailable)
 										|| CheckActivationReason(ref activeLaunchParametersChanged, MonitorActivationReason.ActiveLaunchParametersUpdated)
 										|| CheckActivationReason(ref heartbeat, MonitorActivationReason.Heartbeat)
-										|| CheckActivationReason(ref serverPrimed, MonitorActivationReason.ActiveServerPrimed);
+										|| CheckActivationReason(ref serverPrimed, MonitorActivationReason.ActiveServerPrimed)
+										|| CheckActivationReason(ref activeServerStartup, MonitorActivationReason.ActiveServerStartup);
 
 									UpdateMonitoredTasks();
 

--- a/src/Tgstation.Server.Host/Components/Watchdog/WindowsWatchdog.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/WindowsWatchdog.cs
@@ -318,7 +318,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 		/// </summary>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task"/> representing the running operation.</returns>
-		protected virtual Task InitialLink(CancellationToken cancellationToken)
+		Task InitialLink(CancellationToken cancellationToken)
 		{
 			Logger.LogTrace("Symlinking compile job...");
 			return ActiveSwappable.MakeActive(cancellationToken);

--- a/src/Tgstation.Server.Host/IO/ISymlinkFactory.cs
+++ b/src/Tgstation.Server.Host/IO/ISymlinkFactory.cs
@@ -9,6 +9,12 @@ namespace Tgstation.Server.Host.IO
 	interface ISymlinkFactory
 	{
 		/// <summary>
+		/// If directory symlinks must be deleted as files would in the current environment.
+		/// </summary>
+		/// <remarks>This is because Linux symlinked directories must be deleted with <see cref="global::System.IO.File.Delete(string)"/>.</remarks>
+		bool SymlinkedDirectoriesAreDeletedAsFiles { get; }
+
+		/// <summary>
 		/// Create a symbolic link.
 		/// </summary>
 		/// <param name="targetPath">The path to the hard target.</param>

--- a/src/Tgstation.Server.Host/IO/PosixSymlinkFactory.cs
+++ b/src/Tgstation.Server.Host/IO/PosixSymlinkFactory.cs
@@ -13,6 +13,9 @@ namespace Tgstation.Server.Host.IO
 	sealed class PosixSymlinkFactory : ISymlinkFactory
 	{
 		/// <inheritdoc />
+		public bool SymlinkedDirectoriesAreDeletedAsFiles => true;
+
+		/// <inheritdoc />
 		public Task CreateSymbolicLink(string targetPath, string linkPath, CancellationToken cancellationToken) => Task.Factory.StartNew(
 			() =>
 			{

--- a/src/Tgstation.Server.Host/IO/WindowsSymlinkFactory.cs
+++ b/src/Tgstation.Server.Host/IO/WindowsSymlinkFactory.cs
@@ -14,6 +14,9 @@ namespace Tgstation.Server.Host.IO
 	sealed class WindowsSymlinkFactory : ISymlinkFactory
 	{
 		/// <inheritdoc />
+		public bool SymlinkedDirectoriesAreDeletedAsFiles => false;
+
+		/// <inheritdoc />
 		public Task CreateSymbolicLink(string targetPath, string linkPath, CancellationToken cancellationToken) => Task.Factory.StartNew(
 			() =>
 			{

--- a/src/Tgstation.Server.Host/System/PosixProcessFeatures.cs
+++ b/src/Tgstation.Server.Host/System/PosixProcessFeatures.cs
@@ -48,7 +48,7 @@ namespace Tgstation.Server.Host.System
 		{
 			var result = Syscall.kill(process.Id, Signum.SIGCONT);
 			if (result != 0)
-				throw new UnixIOException(result);
+				throw new UnixIOException(Stdlib.GetLastError());
 		}
 
 		/// <inheritdoc />
@@ -56,7 +56,7 @@ namespace Tgstation.Server.Host.System
 		{
 			var result = Syscall.kill(process.Id, Signum.SIGSTOP);
 			if (result != 0)
-				throw new UnixIOException(result);
+				throw new UnixIOException(Stdlib.GetLastError());
 		}
 
 		/// <inheritdoc />

--- a/tests/DMAPI/LongRunning/Test.dm
+++ b/tests/DMAPI/LongRunning/Test.dm
@@ -128,6 +128,12 @@ var/run_bridge_test
 		var/list/channels = TgsChatChannelInfo()
 		return "[length(channels)]"
 
+	var/legalize_nuclear_bombs = data["shadow_wizard_money_gang"]
+	if(legalize_nuclear_bombs)
+		text2file("I expect this to remain here for a while", "kajigger.txt")
+		kajigger_test = TRUE
+		return "we love casting spells"
+
 	TgsChatBroadcast(new /datum/tgs_message_content("Recieved non-tgs topic: `[T]`"))
 
 	return "feck"
@@ -147,9 +153,17 @@ var/run_bridge_test
 	world.TgsChatBroadcast(new /datum/tgs_message_content("2/3 queued detached chat messages"))
 	world.TgsChatBroadcast(new /datum/tgs_message_content("3/3 queued detached chat messages"))
 
+var/kajigger_test = FALSE
+
 /world/Reboot(reason)
 	TgsChatBroadcast("World Rebooting")
+
+	if(kajigger_test && !fexists("kajigger.txt"))
+		FailTest("TGS STOLE MY KAJIGGER (#1548 regression)")
+
 	TgsReboot()
+
+	..()
 
 /datum/tgs_event_handler/impl/HandleEvent(event_code, ...)
 	set waitfor = FALSE
@@ -174,6 +188,7 @@ var/run_bridge_test
 	sleep(30)
 	world.log << "Done sleep, calling Reboot"
 	world.Reboot()
+
 
 /datum/tgs_chat_command/embeds_test
 	name = "embeds_test"

--- a/tests/Tgstation.Server.Host.Tests/IO/TestPostWriteHandler.cs
+++ b/tests/Tgstation.Server.Host.Tests/IO/TestPostWriteHandler.cs
@@ -70,7 +70,8 @@ namespace Tgstation.Server.Host.IO.Tests
 		public void TestThrowsOnUnix()
 		{
 			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-				return;
+				Assert.Inconclusive("POSIX only test.");
+
 			var postWriteHandler = new PosixPostWriteHandler(Mock.Of<ILogger<PosixPostWriteHandler>>());
 			var tmpFile = Path.GetTempFileName();
 			File.Delete(tmpFile);

--- a/tests/Tgstation.Server.Host.Tests/System/TestSymlinkFactory.cs
+++ b/tests/Tgstation.Server.Host.Tests/System/TestSymlinkFactory.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Tgstation.Server.Host.IO;
+
+namespace Tgstation.Server.Host.System.Tests
+{
+	[TestClass]
+	public sealed class TestSymlinkFactory
+	{
+		readonly ISymlinkFactory factory = new PlatformIdentifier().IsWindows
+			? new WindowsSymlinkFactory()
+			: new PosixSymlinkFactory();
+
+		[TestMethod]
+		public async Task TestSymlinks()
+		{
+			var cancellationToken = CancellationToken.None;
+			var cwd = Path.GetTempFileName();
+			File.Delete(cwd);
+			Directory.CreateDirectory(cwd);
+			try
+			{
+				var realDir = Path.Combine(cwd, "RealDir");
+				var symDir = Path.Combine(cwd, "SymDir");
+				var realFile = Path.Combine(cwd, "RealFile.txt");
+				var symFile = Path.Combine(realDir, "RealFile.txt");
+
+				var subRealFile = Path.Combine(realDir, "test.txt");
+				var subSymFile = Path.Combine(symDir, "test.txt");
+
+				try
+				{
+					await factory.CreateSymbolicLink(subRealFile, subSymFile, cancellationToken);
+					Assert.Fail("Expected Exception!");
+				}
+				catch
+				{
+				}
+
+				Directory.CreateDirectory(realDir);
+				Directory.CreateDirectory(symDir);
+
+				await File.WriteAllBytesAsync(realFile, Array.Empty<byte>(), cancellationToken);
+				await File.WriteAllBytesAsync(symFile, Array.Empty<byte>(), cancellationToken);
+
+				try
+				{
+					await factory.CreateSymbolicLink(realFile, symFile, cancellationToken);
+					Assert.Fail("Expected Exception!");
+				}
+				catch
+				{
+				}
+
+				Directory.Delete(symDir);
+				File.Delete(symFile);
+
+				await factory.CreateSymbolicLink(realFile, symFile, cancellationToken);
+				Assert.IsTrue(File.Exists(symFile));
+				Assert.IsFalse(Directory.Exists(symFile));
+
+				await File.WriteAllTextAsync(realFile, "test", cancellationToken);
+				var symFileContents = await File.ReadAllTextAsync(symFile, cancellationToken);
+				Assert.AreEqual("test", symFileContents);
+				File.Delete(symFile);
+				File.Delete(realFile);
+
+				try
+				{
+					await factory.CreateSymbolicLink(realDir, symDir, cancellationToken);
+
+					Assert.IsFalse(File.Exists(symDir));
+					Assert.IsTrue(Directory.Exists(symDir));
+
+					await File.WriteAllTextAsync(subRealFile, "test", cancellationToken);
+					Assert.IsTrue(File.Exists(subSymFile));
+
+					File.Delete(subSymFile);
+					Assert.IsFalse(File.Exists(subRealFile));
+				}
+				finally
+				{
+					if (factory.SymlinkedDirectoriesAreDeletedAsFiles)
+						File.Delete(symDir);
+					else
+						Directory.Delete(symDir);
+				}
+
+				if (factory.SymlinkedDirectoriesAreDeletedAsFiles)
+					Assert.IsFalse(File.Exists(symDir));
+				else
+					Assert.IsFalse(Directory.Exists(symDir));
+			}
+			finally
+			{
+				Directory.Delete(cwd, true);
+			}
+		}
+	}
+}

--- a/tests/Tgstation.Server.Tests/Live/Instance/WatchdogTest.cs
+++ b/tests/Tgstation.Server.Tests/Live/Instance/WatchdogTest.cs
@@ -132,7 +132,7 @@ namespace Tgstation.Server.Tests.Live.Instance
 		async ValueTask RegressionTest1550(CancellationToken cancellationToken)
 		{
 			// we need to cycle deployments twice because TGS holds the initial deployment
-			var job = await DeployTestDme("LongRunning/long_running_test", DreamDaemonSecurity.Trusted, true, cancellationToken);
+			await DeployTestDme("LongRunning/long_running_test", DreamDaemonSecurity.Trusted, true, cancellationToken);
 			var currentStatus = await instanceClient.DreamDaemon.Read(cancellationToken);
 
 			Assert.AreEqual(WatchdogStatus.Online, currentStatus.Status);

--- a/tests/Tgstation.Server.Tests/Live/Instance/WatchdogTest.cs
+++ b/tests/Tgstation.Server.Tests/Live/Instance/WatchdogTest.cs
@@ -102,6 +102,8 @@ namespace Tgstation.Server.Tests.Live.Instance
 		{
 			await StartAndLeaveRunning(cancellationToken);
 
+			await RegressionTest1550(cancellationToken);
+
 			var deleteJobTask = TestDeleteByondInstallErrorCasesAndQueing(cancellationToken);
 
 			SessionController.LogTopicRequests = false;
@@ -125,6 +127,54 @@ namespace Tgstation.Server.Tests.Live.Instance
 			var restartJob = await instanceClient.DreamDaemon.Restart(cancellationToken);
 			await WaitForJob(deleteJob, 15, false, null, cancellationToken);
 			await WaitForJob(restartJob, 15, false, null, cancellationToken);
+		}
+
+		async ValueTask RegressionTest1550(CancellationToken cancellationToken)
+		{
+			// we need to cycle deployments twice because TGS holds the initial deployment
+			var job = await DeployTestDme("LongRunning/long_running_test", DreamDaemonSecurity.Trusted, true, cancellationToken);
+			var currentStatus = await instanceClient.DreamDaemon.Read(cancellationToken);
+
+			Assert.AreEqual(WatchdogStatus.Online, currentStatus.Status);
+			Assert.IsNotNull(currentStatus.StagedCompileJob);
+			var expectedStaged = currentStatus.StagedCompileJob;
+			Assert.AreNotEqual(expectedStaged.Id, currentStatus.ActiveCompileJob.Id);
+
+			await TellWorldToReboot(cancellationToken);
+
+			currentStatus = await instanceClient.DreamDaemon.Read(cancellationToken);
+			Assert.AreEqual(expectedStaged.Id, currentStatus.ActiveCompileJob.Id);
+
+			await Task.Delay(TimeSpan.FromSeconds(3), cancellationToken);
+
+			var topicRequestResult = await TopicClient.SendTopic(
+				IPAddress.Loopback,
+				$"shadow_wizard_money_gang=1",
+				TestLiveServer.DDPort,
+				cancellationToken);
+
+			Assert.IsNotNull(topicRequestResult);
+			Assert.AreEqual("we love casting spells", topicRequestResult.StringData);
+
+			await DeployTestDme("LongRunning/long_running_test", DreamDaemonSecurity.Trusted, true, cancellationToken);
+
+			currentStatus = await instanceClient.DreamDaemon.Read(cancellationToken);
+
+			Assert.AreEqual(WatchdogStatus.Online, currentStatus.Status);
+			Assert.IsNotNull(currentStatus.StagedCompileJob);
+			Assert.AreEqual(expectedStaged.Id, currentStatus.ActiveCompileJob.Id);
+			expectedStaged = currentStatus.StagedCompileJob;
+			Assert.AreNotEqual(expectedStaged.Id, currentStatus.ActiveCompileJob.Id);
+
+			await TellWorldToReboot(cancellationToken);
+
+			currentStatus = await instanceClient.DreamDaemon.Read(cancellationToken);
+			Assert.AreEqual(WatchdogStatus.Online, currentStatus.Status);
+			Assert.IsNull(currentStatus.StagedCompileJob);
+			Assert.AreEqual(expectedStaged.Id, currentStatus.ActiveCompileJob.Id);
+
+			await CheckDMApiFail(currentStatus.ActiveCompileJob, cancellationToken, false);
+			await CheckDMApiFail(expectedStaged, cancellationToken, false);
 		}
 
 		async Task<JobResponse> TestDeleteByondInstallErrorCasesAndQueing(CancellationToken cancellationToken)
@@ -950,32 +1000,28 @@ namespace Tgstation.Server.Tests.Live.Instance
 		public async Task<DreamDaemonResponse> TellWorldToReboot(CancellationToken cancellationToken)
 		{
 			var daemonStatus = await instanceClient.DreamDaemon.Read(cancellationToken);
+			Assert.IsNotNull(daemonStatus.StagedCompileJob);
 			var initialCompileJob = daemonStatus.ActiveCompileJob;
 
-			try
-			{
-				System.Console.WriteLine("TEST: Sending world reboot topic...");
-				var result = await TopicClient.SendTopic(IPAddress.Loopback, "tgs_integration_test_special_tactics=1", TestLiveServer.DDPort, cancellationToken);
-				Assert.AreEqual("ack", result.StringData);
+			System.Console.WriteLine("TEST: Sending world reboot topic...");
+			var result = await TopicClient.SendTopic(IPAddress.Loopback, "tgs_integration_test_special_tactics=1", TestLiveServer.DDPort, cancellationToken);
+			Assert.AreEqual("ack", result.StringData);
 
-				using (var tempCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
-				using (tempCts.Token.Register(() => System.Console.WriteLine("TEST ERROR: Timeout in TellWorldToReboot!")))
+			using var tempCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+			var tempToken = tempCts.Token;
+			using (tempToken.Register(() => System.Console.WriteLine("TEST ERROR: Timeout in TellWorldToReboot!")))
+			{
+				tempCts.CancelAfter(TimeSpan.FromMinutes(2));
+
+				do
 				{
-					tempCts.CancelAfter(TimeSpan.FromMinutes(2));
-					var tempToken = tempCts.Token;
-
-					do
-					{
-						await Task.Delay(TimeSpan.FromSeconds(1), tempToken);
-						daemonStatus = await instanceClient.DreamDaemon.Read(tempToken);
-					}
-					while (initialCompileJob.Id == daemonStatus.ActiveCompileJob.Id);
+					await Task.Delay(TimeSpan.FromSeconds(1), tempToken);
+					daemonStatus = await instanceClient.DreamDaemon.Read(tempToken);
 				}
+				while (initialCompileJob.Id == daemonStatus.ActiveCompileJob.Id);
 			}
-			catch (OperationCanceledException)
-			{
-				throw;
-			}
+
+			await Task.Delay(TimeSpan.FromSeconds(3), cancellationToken);
 
 			return daemonStatus;
 		}

--- a/tests/Tgstation.Server.Tests/Live/Instance/WatchdogTest.cs
+++ b/tests/Tgstation.Server.Tests/Live/Instance/WatchdogTest.cs
@@ -530,10 +530,11 @@ namespace Tgstation.Server.Tests.Live.Instance
 			};
 
 			var json = JsonConvert.SerializeObject(baseTopic, DMApiConstants.SerializerSettings);
-			var topicString = $"tgs_integration_test_tactics3={TopicClient.SanitizeString(json)}";
 
-			var baseSize = topicString.Length;
-			var wrappingSize = baseSize;
+			var baseSize = (int)(DMApiConstants.MaximumTopicRequestLength - 1);
+
+			var topicString = $"tgs_integration_test_tactics3={TopicClient.SanitizeString(json)}";
+			var wrappingSize = topicString.Length;
 
 			while (!cancellationToken.IsCancellationRequested)
 			{
@@ -584,7 +585,7 @@ namespace Tgstation.Server.Tests.Live.Instance
 			System.Console.WriteLine("TEST: Receiving Topic tests topics...");
 
 			// Receive
-			baseSize = 1;
+			baseSize = (int)(DMApiConstants.MaximumTopicResponseLength - 1);
 			nextPow = 0;
 			lastSize = 0;
 			while (!cancellationToken.IsCancellationRequested)


### PR DESCRIPTION
:cl:
If a deployment has the DMAPI available, the code tree change-out will be delayed until `world.TgsReboot()` is called. This prevents the working directory from changing unexpectedly around an active server.
Deployment cleanups will now be slightly delayed to avoid tripping on files still in use.
Fixed error handling when sending SIGSTOP or SIGCONT to DreamDaemon failed on Linux.
The `Live` game directory symlinking process on Linux is now less error prone.
/:cl:

Fixes #1550

Merge with `[TGSDeploy]`