### PR TITLE
Fix rare but possible infinite bridge request hang. Lockdown package versions that consume secrets. Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# This list auto requests reviews from the specified org members
+# when a PR that modifies the file in question is opened
+# This list is alphabetized by User -> Filename and separated into sections for Maintainers/Contributors KEEP IT THAT WAY
+# In the event that people are to be informed of changes
+# to the same file or dir, add them to the end of under Multiple Owners
+
+# MAINTAINERS
+
+# Dominion/Cyberboss
+
+* @Cyberboss

--- a/.github/workflows/ci-suite.yml
+++ b/.github/workflows/ci-suite.yml
@@ -1014,18 +1014,18 @@ jobs:
       with:
         ref: "refs/pull/${{ github.event.number }}/merge"
 
-    - name: Publish Tgstation.Server.Api to NuGet
-      uses: alirezanet/publish-nuget@c12b8546b67672ee38ac87bea491ac94a587f7cc # v3.0.0
-      with:
-        PROJECT_FILE_PATH: src/Tgstation.Server.Api/Tgstation.Server.Api.csproj
-        TAG_COMMIT: false
-        INCLUDE_SYMBOLS: true
-        NUGET_KEY: ${{ secrets.NUGET_API_KEY }}
-
     - name: Publish Tgstation.Server.Common to NuGet
       uses: alirezanet/publish-nuget@c12b8546b67672ee38ac87bea491ac94a587f7cc # v3.0.0
       with:
         PROJECT_FILE_PATH: src/Tgstation.Server.Client/Tgstation.Server.Client.csproj
+        TAG_COMMIT: false
+        INCLUDE_SYMBOLS: true
+        NUGET_KEY: ${{ secrets.NUGET_API_KEY }}
+
+    - name: Publish Tgstation.Server.Api to NuGet
+      uses: alirezanet/publish-nuget@c12b8546b67672ee38ac87bea491ac94a587f7cc # v3.0.0
+      with:
+        PROJECT_FILE_PATH: src/Tgstation.Server.Api/Tgstation.Server.Api.csproj
         TAG_COMMIT: false
         INCLUDE_SYMBOLS: true
         NUGET_KEY: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/ci-suite.yml
+++ b/.github/workflows/ci-suite.yml
@@ -924,7 +924,7 @@ jobs:
         path: swagger
 
     - name: Create GitHub Release
-      uses: juitnow/github-action-create-release@v1
+      uses: juitnow/github-action-create-release@80dc88a9d09c0ee394a4a31b0450e8cbe62996ef # v1
       id: create_release
       env:
         GITHUB_TOKEN: ${{ secrets.DEV_PUSH_TOKEN }}
@@ -1015,7 +1015,7 @@ jobs:
         ref: "refs/pull/${{ github.event.number }}/merge"
 
     - name: Publish Tgstation.Server.Api to NuGet
-      uses: alirezanet/publish-nuget@v3.0.0
+      uses: alirezanet/publish-nuget@c12b8546b67672ee38ac87bea491ac94a587f7cc # v3.0.0
       with:
         PROJECT_FILE_PATH: src/Tgstation.Server.Api/Tgstation.Server.Api.csproj
         TAG_COMMIT: false
@@ -1023,7 +1023,7 @@ jobs:
         NUGET_KEY: ${{ secrets.NUGET_API_KEY }}
 
     - name: Publish Tgstation.Server.Common to NuGet
-      uses: alirezanet/publish-nuget@v3.0.0
+      uses: alirezanet/publish-nuget@c12b8546b67672ee38ac87bea491ac94a587f7cc # v3.0.0
       with:
         PROJECT_FILE_PATH: src/Tgstation.Server.Client/Tgstation.Server.Client.csproj
         TAG_COMMIT: false
@@ -1031,7 +1031,7 @@ jobs:
         NUGET_KEY: ${{ secrets.NUGET_API_KEY }}
 
     - name: Publish Tgstation.Server.Client to NuGet
-      uses: alirezanet/publish-nuget@v3.0.0
+      uses: alirezanet/publish-nuget@c12b8546b67672ee38ac87bea491ac94a587f7cc # v3.0.0
       with:
         PROJECT_FILE_PATH: src/Tgstation.Server.Common/Tgstation.Server.Common.csproj
         TAG_COMMIT: false
@@ -1209,7 +1209,7 @@ jobs:
         echo "TGS_VERSION=$(xmlstarlet sel -N X="http://schemas.microsoft.com/developer/msbuild/2003" --template --value-of /X:Project/X:PropertyGroup/X:TgsCoreVersion build/Version.props)" >> $GITHUB_ENV
 
     - name: Docker Build and Push
-      uses: elgohr/Publish-Docker-Github-Action@v5
+      uses: elgohr/Publish-Docker-Github-Action@43dc228e327224b2eda11c8883232afd5b34943b # v5
       with:
         name: tgstation/server
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/stable-merge.yml
+++ b/.github/workflows/stable-merge.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Merge master into dev
-      uses: robotology/gh-action-nightly-merge@v1.3.3
+      uses: robotology/gh-action-nightly-merge@22f5e45d028f22837d617fa07512925457eec184 #v1.3.3
       with:
         stable_branch: 'master'
         development_branch: 'dev'

--- a/src/Tgstation.Server.Host/Components/Session/SessionController.cs
+++ b/src/Tgstation.Server.Host/Components/Session/SessionController.cs
@@ -21,6 +21,7 @@ using Tgstation.Server.Host.Components.Deployment;
 using Tgstation.Server.Host.Components.Interop;
 using Tgstation.Server.Host.Components.Interop.Bridge;
 using Tgstation.Server.Host.Components.Interop.Topic;
+using Tgstation.Server.Host.Extensions;
 using Tgstation.Server.Host.System;
 using Tgstation.Server.Host.Utils;
 
@@ -778,7 +779,7 @@ namespace Tgstation.Server.Host.Components.Session
 						}
 
 						Interlocked.Exchange(ref rebootTcs, new TaskCompletionSource()).SetResult();
-						await RebootGate;
+						await RebootGate.WithToken(cancellationToken);
 					}
 					finally
 					{

--- a/tgstation-server.sln
+++ b/tgstation-server.sln
@@ -118,6 +118,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{DCC75431-7
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{E82104F4-F5C4-4786-ACD4-B635166CDB21}"
 	ProjectSection(SolutionItems) = preProject
+		.github\CODEOWNERS = .github\CODEOWNERS
 		.github\CODE_OF_CONDUCT.md = .github\CODE_OF_CONDUCT.md
 		.github\CONTRIBUTING.md = .github\CONTRIBUTING.md
 		.github\ISSUE_TEMPLATE.md = .github\ISSUE_TEMPLATE.md


### PR DESCRIPTION
:cl:
Fixed a memory leak that sometimes occurred if DreamDaemon crashed during a `TgsReboot()` bridge request.
/:cl: