### PR TITLE
Signals and SystemD Fixes

### DIFF
--- a/build/tgstation-server.service
+++ b/build/tgstation-server.service
@@ -9,6 +9,7 @@ After=mssql-server.service
 [Service]
 ExecStart=/bin/bash /opt/tgstation-server/tgs.sh General:SetupWizardMode=Never
 Restart=Always
+KillMode=process
 RestartKillSignal=SIGUSR1
 AmbientCapabilities=CAP_SYS_NICE
 StandardOutput=null

--- a/build/tgstation-server.service
+++ b/build/tgstation-server.service
@@ -10,7 +10,7 @@ After=mssql-server.service
 ExecStart=/bin/bash /opt/tgstation-server/tgs.sh General:SetupWizardMode=Never
 Restart=Always
 KillMode=process
-RestartKillSignal=SIGUSR1
+RestartKillSignal=SIGUSR2
 AmbientCapabilities=CAP_SYS_NICE
 StandardOutput=null
 StandardError=null

--- a/src/Tgstation.Server.Host/Components/Chat/ChatManager.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/ChatManager.cs
@@ -534,11 +534,10 @@ namespace Tgstation.Server.Host.Components.Chat
 		}
 
 		/// <inheritdoc />
-		public Task HandleRestart(Version updateVersion, bool gracefulShutdown, CancellationToken cancellationToken)
+		public Task HandleRestart(Version updateVersion, bool handlerMayDelayShutdownWithExtremelyLongRunningTasks, CancellationToken cancellationToken)
 		{
-			var message =
-				updateVersion == null
-				? $"TGS: {(gracefulShutdown ? "Graceful shutdown" : "Restart")} requested..."
+			var message = updateVersion == null
+				? $"TGS: {(handlerMayDelayShutdownWithExtremelyLongRunningTasks ? "Graceful shutdown" : "Going down")}..."
 				: $"TGS: Updating to version {updateVersion}...";
 			List<ulong> wdChannels;
 			lock (mappedChannels) // so it doesn't change while we're using it

--- a/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
@@ -402,15 +402,15 @@ namespace Tgstation.Server.Host.Components.Watchdog
 		}
 
 		/// <inheritdoc />
-		public async Task HandleRestart(Version updateVersion, bool gracefulShutdown, CancellationToken cancellationToken)
+		public async Task HandleRestart(Version updateVersion, bool handlerMayDelayShutdownWithExtremelyLongRunningTasks, CancellationToken cancellationToken)
 		{
-			if (gracefulShutdown)
+			if (handlerMayDelayShutdownWithExtremelyLongRunningTasks)
 			{
 				await Terminate(true, cancellationToken);
 
 				if (Status != WatchdogStatus.Offline)
 				{
-					Logger.LogTrace("Waiting for server to gracefully shut down.");
+					Logger.LogDebug("Waiting for server to gracefully shut down.");
 					await monitorTask.WithToken(cancellationToken);
 				}
 				else

--- a/src/Tgstation.Server.Host/Core/IRestartHandler.cs
+++ b/src/Tgstation.Server.Host/Core/IRestartHandler.cs
@@ -13,9 +13,9 @@ namespace Tgstation.Server.Host.Core
 		/// Handle a restart of the server.
 		/// </summary>
 		/// <param name="updateVersion">The <see cref="Version"/> being updated to, <see langword="null"/> if not being changed.</param>
-		/// <param name="gracefulShutdown">If <see langword="true"/> the server should not expect to restart.</param>
+		/// <param name="handlerMayDelayShutdownWithExtremelyLongRunningTasks">If <see langword="false"/> the <see cref="IRestartHandler"/> should aim to complete the <see cref="Task"/> returned from this function ASAP.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task"/> representing the running operation.</returns>
-		Task HandleRestart(Version updateVersion, bool gracefulShutdown, CancellationToken cancellationToken);
+		Task HandleRestart(Version updateVersion, bool handlerMayDelayShutdownWithExtremelyLongRunningTasks, CancellationToken cancellationToken);
 	}
 }

--- a/src/Tgstation.Server.Host/Core/IServerControl.cs
+++ b/src/Tgstation.Server.Host/Core/IServerControl.cs
@@ -42,8 +42,9 @@ namespace Tgstation.Server.Host.Core
 		/// <summary>
 		/// Gracefully shutsdown the <see cref="Host"/>.
 		/// </summary>
+		/// <param name="detach">If the graceful shutdown should detach any running watchdog. If <see langword="false"/> the server will wait for the next TgsReboot() or world exit before shutting down.</param>
 		/// <returns>A <see cref="Task"/> representing the running operation.</returns>
-		Task GracefulShutdown();
+		Task GracefulShutdown(bool detach);
 
 		/// <summary>
 		/// Kill the server with a fatal exception.

--- a/src/Tgstation.Server.Host/Server.cs
+++ b/src/Tgstation.Server.Host/Server.cs
@@ -192,7 +192,7 @@ namespace Tgstation.Server.Host
 				if (await updateExecutor.ExecuteUpdate(updatePath, criticalCancellationToken, criticalCancellationToken))
 				{
 					logger.LogTrace("Update complete!");
-					await Restart(newVersion, null, true);
+					await RestartImpl(newVersion, null, true, true);
 				}
 				else if (terminateIfUpdateFails)
 				{
@@ -235,13 +235,13 @@ namespace Tgstation.Server.Host
 		}
 
 		/// <inheritdoc />
-		public Task Restart() => Restart(null, null, true);
+		public Task Restart() => RestartImpl(null, null, true, true);
 
 		/// <inheritdoc />
-		public Task GracefulShutdown() => Restart(null, null, false);
+		public Task GracefulShutdown(bool detach) => RestartImpl(null, null, false, detach);
 
 		/// <inheritdoc />
-		public Task Die(Exception exception) => Restart(null, exception, false);
+		public Task Die(Exception exception) => RestartImpl(null, exception, false, true);
 
 		/// <summary>
 		/// Throws an <see cref="InvalidOperationException"/> if the <see cref="IServerControl"/> cannot be used.
@@ -277,8 +277,9 @@ namespace Tgstation.Server.Host
 		/// <param name="newVersion">The <see cref="Version"/> of any potential updates being applied.</param>
 		/// <param name="exception">The potential value of <see cref="propagatedException"/>.</param>
 		/// <param name="requireWatchdog">If the host watchdog is required for this "restart".</param>
+		/// <param name="completeAsap">If the restart should wait for extremely long running tasks to complete (Like the current DreamDaemon world).</param>
 		/// <returns>A <see cref="Task"/> representing the running operation.</returns>
-		async Task Restart(Version newVersion, Exception exception, bool requireWatchdog)
+		async Task RestartImpl(Version newVersion, Exception exception, bool requireWatchdog, bool completeAsap)
 		{
 			CheckSanity(requireWatchdog);
 
@@ -287,7 +288,9 @@ namespace Tgstation.Server.Host
 			logger.LogTrace(
 				"Begin {restartType}...",
 				isGracefulShutdown
-					? "graceful shutdown"
+					? completeAsap
+						? "semi-graceful shutdown"
+						: "graceful shutdown"
 					: "restart");
 
 			lock (restartLock)
@@ -304,10 +307,11 @@ namespace Tgstation.Server.Host
 
 			if (exception == null)
 			{
+				var giveHandlersTimeToWaitAround = isGracefulShutdown && !completeAsap;
 				logger.LogInformation("Stopping server...");
 				using var cts = new CancellationTokenSource(
 					TimeSpan.FromMinutes(
-						isGracefulShutdown
+						giveHandlersTimeToWaitAround
 							? generalConfiguration.ShutdownTimeoutMinutes
 							: generalConfiguration.RestartTimeoutMinutes));
 				var cancellationToken = cts.Token;
@@ -315,7 +319,7 @@ namespace Tgstation.Server.Host
 				{
 					var eventsTask = Task.WhenAll(
 						restartHandlers.Select(
-							x => x.HandleRestart(newVersion, isGracefulShutdown, cancellationToken))
+							x => x.HandleRestart(newVersion, giveHandlersTimeToWaitAround, cancellationToken))
 						.ToList());
 
 					logger.LogTrace("Joining restart handlers...");

--- a/tests/Tgstation.Server.Host.Tests.Signals/Program.cs
+++ b/tests/Tgstation.Server.Host.Tests.Signals/Program.cs
@@ -21,7 +21,7 @@ namespace Tgstation.Server.Host.Tests.Signals
 
 			var tcs = new TaskCompletionSource();
 			mockServerControl
-				.Setup(x => x.GracefulShutdown())
+				.Setup(x => x.GracefulShutdown(It.IsAny<bool>()))
 				.Callback(() => tcs.SetResult())
 				.Returns(Task.CompletedTask);
 


### PR DESCRIPTION
:cl:
Sending SIGUSR2 to the main TGS process now act as if TGS received a restart request (i.e. the watchdog will detach and the TGS main process will exit) except it won't come back without system operator intervention.
Added .deb package compatible with both Debian and Ubuntu. These will be made available at the future apt repository https://github.com/tgstation/tgstation-ppa.
/:cl: