### PR TITLE
Fix incorrect Discord embed error messages. Fix potential deadlock when a directory copy gets cancelled

### DIFF
--- a/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordProvider.cs
@@ -975,7 +975,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 						embedErrors.Add(
 							String.Format(
 								CultureInfo.InvariantCulture,
-								"Null or whitespace field author at index {0}!",
+								"Null or whitespace field name at index {0}!",
 								i));
 						invalid = true;
 					}
@@ -985,7 +985,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 						embedErrors.Add(
 							String.Format(
 								CultureInfo.InvariantCulture,
-								"Null or whitespace field author at index {0}!",
+								"Null or whitespace field value at index {0}!",
 								i));
 						invalid = true;
 					}

--- a/src/Tgstation.Server.Host/IO/DefaultIOManager.cs
+++ b/src/Tgstation.Server.Host/IO/DefaultIOManager.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Tgstation.Server.Host.Extensions;
 using Tgstation.Server.Host.Utils;
 
 namespace Tgstation.Server.Host.IO
@@ -387,7 +388,7 @@ namespace Tgstation.Server.Host.IO
 
 				async Task CopyThisFile()
 				{
-					await subdirCreationTask;
+					await subdirCreationTask.WithToken(cancellationToken);
 					using var lockContext = semaphore != null
 						? await SemaphoreSlimContext.Lock(semaphore, cancellationToken)
 						: null;

--- a/src/Tgstation.Server.Host/manifest.xml
+++ b/src/Tgstation.Server.Host/manifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-	<assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
 	<trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
 		<security>
 			<requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">


### PR DESCRIPTION
:cl:
Fixed incorrect wording in the error message embed TGS sends when receiving bad input from DM code.
Fixed a deadlock that could happen if a directory copy operation was cancelled.
/:cl: