### PR TITLE
Release v5.12.7: Fix deployments failing if creating GitHub deployments was enabled and GitHub returned bad data

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>5.12.6</TgsCoreVersion>
+    <TgsCoreVersion>5.12.7</TgsCoreVersion>
     <TgsConfigVersion>4.6.0</TgsConfigVersion>
     <TgsApiVersion>9.10.2</TgsApiVersion>
     <TgsApiLibraryVersion>10.4.1</TgsApiLibraryVersion>

--- a/src/Tgstation.Server.Host/Components/Deployment/Remote/GitHubRemoteDeploymentManager.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/Remote/GitHubRemoteDeploymentManager.cs
@@ -140,7 +140,7 @@ namespace Tgstation.Server.Host.Components.Deployment.Remote
 				compileJob.GitHubRepoId = await repositoryIdTask;
 				Logger.LogTrace("Set GitHub ID as {gitHubRepoId}", compileJob.GitHubRepoId);
 			}
-			catch (RateLimitExceededException ex) when (!repositorySettings.CreateGitHubDeployments.Value)
+			catch (Exception ex) when (ex is not OperationCanceledException)
 			{
 				Logger.LogWarning(ex, "Unable to set compile job repository ID!");
 			}

--- a/src/Tgstation.Server.Host/Components/Deployment/Remote/GitHubRemoteDeploymentManager.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/Remote/GitHubRemoteDeploymentManager.cs
@@ -129,9 +129,9 @@ namespace Tgstation.Server.Host.Components.Deployment.Remote
 
 					Logger.LogTrace("In-progress deployment status created");
 				}
-				catch (ApiException ex)
+				catch (Exception ex) when (ex is not OperationCanceledException)
 				{
-					Logger.LogWarning(ex, "Unable to create deployment!");
+					Logger.LogWarning(ex, "Unable to create GitHub deployment!");
 				}
 			}
 
@@ -257,9 +257,9 @@ namespace Tgstation.Server.Host.Components.Deployment.Remote
 			{
 				await gitHubService.CommentOnIssue(remoteRepositoryOwner, remoteRepositoryName, comment, testMergeNumber, cancellationToken);
 			}
-			catch (ApiException e)
+			catch (Exception ex) when (ex is not OperationCanceledException)
 			{
-				Logger.LogWarning(e, "Error posting GitHub comment!");
+				Logger.LogWarning(ex, "Error posting GitHub comment!");
 			}
 		}
 
@@ -342,14 +342,21 @@ namespace Tgstation.Server.Host.Components.Deployment.Remote
 
 			var gitHubService = gitHubServiceFactory.CreateService(gitHubAccessToken);
 
-			await gitHubService.CreateDeploymentStatus(
-				new NewDeploymentStatus(deploymentState)
-				{
-					Description = description,
-				},
-				compileJob.GitHubRepoId.Value,
-				compileJob.GitHubDeploymentId.Value,
-				cancellationToken);
+			try
+			{
+				await gitHubService.CreateDeploymentStatus(
+					new NewDeploymentStatus(deploymentState)
+					{
+						Description = description,
+					},
+					compileJob.GitHubRepoId.Value,
+					compileJob.GitHubDeploymentId.Value,
+					cancellationToken);
+			}
+			catch (Exception ex) when (ex is not OperationCanceledException)
+			{
+				Logger.LogWarning(ex, "Error updating GitHub deployment!");
+			}
 		}
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Deployment/Remote/GitLabRemoteDeploymentManager.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/Remote/GitLabRemoteDeploymentManager.cs
@@ -123,7 +123,7 @@ namespace Tgstation.Server.Host.Components.Deployment.Remote
 			CancellationToken cancellationToken) => Task.CompletedTask;
 
 		/// <inheritdoc />
-		protected override Task CommentOnTestMergeSource(
+		protected override async Task CommentOnTestMergeSource(
 			RepositorySettings repositorySettings,
 			string remoteRepositoryOwner,
 			string remoteRepositoryName,
@@ -135,13 +135,20 @@ namespace Tgstation.Server.Host.Components.Deployment.Remote
 				? new GitLabClient(GitLabRemoteFeatures.GitLabUrl, repositorySettings.AccessToken)
 				: new GitLabClient(GitLabRemoteFeatures.GitLabUrl);
 
-			return client
-				.MergeRequests
-				.CreateNoteAsync(
-					$"{remoteRepositoryOwner}/{remoteRepositoryName}",
-					testMergeNumber,
-					new CreateMergeRequestNoteRequest(comment))
-				.WithToken(cancellationToken);
+			try
+			{
+				await client
+					.MergeRequests
+					.CreateNoteAsync(
+						$"{remoteRepositoryOwner}/{remoteRepositoryName}",
+						testMergeNumber,
+						new CreateMergeRequestNoteRequest(comment))
+					.WithToken(cancellationToken);
+			}
+			catch (Exception ex) when (ex is not OperationCanceledException)
+			{
+				Logger.LogWarning(ex, "Error posting GitHub comment!");
+			}
 		}
 
 		/// <inheritdoc />


### PR DESCRIPTION
:cl:
Fixed deployments failing if creating GitHub deployments was enabled and GitHub returned bad data.
Fixed deployments failing if the GitHub repository ID could not be retrieved under certain circumstances.
Fixed deployments failing if posting test merge comments was enabled and the GitLab request failed.
/:cl: