### PR TITLE
Updates docker image to debian 12

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-bookworm-slim AS build
 
 # install node and npm
 # replace shell with bash so we can source files
@@ -63,7 +63,7 @@ RUN dotnet publish -c Release -o /app
 WORKDIR /repo/src/Tgstation.Server.Host
 RUN dotnet publish -c Release -o /app/lib/Default && mv /app/lib/Default/appsettings* /app
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-bookworm-slim
 
 #needed for byond
 RUN apt-get update \


### PR DESCRIPTION
:cl:
Docker image is now based off of debian bookworm(12).
/:cl:

It's quite silly and funny. Dunno if this is a breaking change or not. TGS itself should keep working but event scripts might feel a bit sad. This is mostly because I want the latest toys from 12