### PR TITLE
Elasticsearch configuration improvements. Fix System Channels. winget README update. v5.13.2 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ Follow the instructions for your OS below.
 
 Note that the Windows Service and installer executables require administrative privileges. These are digitally signed against the Root CA managed by [Jordan Dominion](https://github.com/Cyberboss). Consider installing the certificate into your `Trusted Root Authorities` store for cleaner UAC prompts. The certificate can be downloaded [here](https://file.house/zpFb.cer), please validate the thumbprint is `70176acf7ffa2898fa5b5cd6e38b43b38ea5d07f` before installing. The OCSP server for this is `http://ocsp.dextraspace.net`.
 
+##### Installer
+
+[Download the latest release's tgstation-server-installer.exe](https://github.com/tgstation/tgstation-server/releases/latest). Executing it will take you through the process of installing and configuring your server. The required dotnet runtime may be installed as a pre-requisite.
+
+Note: If you use the `/silent` or `/passive` arguments to the installer, you will need to either pre-configure TGS or configure and start the `tgstation-server` service after installing. A shortcut will be placed on your desktop and in your start menu to assist with this.
+
 ##### winget (Windows 10 or later)
 
 [winget](https://github.com/microsoft/winget-cli) installed is the easiest way to install the latest version of tgstation-server (provided Microsoft has approved the most recent package manifest).
@@ -77,11 +83,7 @@ The required dotnet runtime may be installed as a pre-requisite.
 
 Note: If you use the `-h` or `--disable-interactivity` winget arguments, you will need to either pre-configure TGS or configure and start the `tgstation-server` service after installing. A shortcut will be placed on your desktop and in your start menu to assist with this.
 
-##### Installer
-
-[Download the latest release's tgstation-server-installer.exe](https://github.com/tgstation/tgstation-server/releases/latest). Executing it will take you through the process of installing and configuring your server. The required dotnet runtime may be installed as a pre-requisite.
-
-Note: If you use the `/silent` or `/passive` arguments to the installer, you will need to either pre-configure TGS or configure and start the `tgstation-server` service after installing. A shortcut will be placed on your desktop and in your start menu to assist with this.
+Note: The `winget` package is submitted to Microsoft for approval once TGS releases. This means the winget version may be out of date with the current release version. You can always use the TGS updater after installing. You can see the versions still awaiting approval [here](https://github.com/microsoft/winget-pkgs/pulls?q=is%3Apr+is%3Aopen+Tgstation.Server).
 
 ##### Manual
 

--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>5.13.1</TgsCoreVersion>
+    <TgsCoreVersion>5.13.2</TgsCoreVersion>
     <TgsConfigVersion>4.7.1</TgsConfigVersion>
     <TgsApiVersion>9.11.0</TgsApiVersion>
     <TgsCommonLibraryVersion>6.0.0</TgsCommonLibraryVersion>

--- a/build/Version.props
+++ b/build/Version.props
@@ -4,7 +4,7 @@
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
     <TgsCoreVersion>5.13.1</TgsCoreVersion>
-    <TgsConfigVersion>4.7.0</TgsConfigVersion>
+    <TgsConfigVersion>4.7.1</TgsConfigVersion>
     <TgsApiVersion>9.11.0</TgsApiVersion>
     <TgsCommonLibraryVersion>6.0.0</TgsCommonLibraryVersion>
     <TgsApiLibraryVersion>11.0.0</TgsApiLibraryVersion>

--- a/src/Tgstation.Server.Host/Components/Chat/ChatManager.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/ChatManager.cs
@@ -538,15 +538,15 @@ namespace Tgstation.Server.Host.Components.Chat
 			var message = updateVersion == null
 				? $"TGS: {(handlerMayDelayShutdownWithExtremelyLongRunningTasks ? "Graceful shutdown" : "Going down")}..."
 				: $"TGS: Updating to version {updateVersion}...";
-			List<ulong> wdChannels;
+			List<ulong> systemChannels;
 			lock (mappedChannels) // so it doesn't change while we're using it
-				wdChannels = mappedChannels
-					.Where(x => !x.Value.IsSystemChannel)
+				systemChannels = mappedChannels
+					.Where(x => x.Value.IsSystemChannel)
 					.Select(x => x.Key)
 					.ToList();
 
 			return SendMessage(
-				wdChannels,
+				systemChannels,
 				null,
 				new MessageContent
 				{

--- a/src/Tgstation.Server.Host/Configuration/ElasticsearchConfiguration.cs
+++ b/src/Tgstation.Server.Host/Configuration/ElasticsearchConfiguration.cs
@@ -1,4 +1,6 @@
-﻿namespace Tgstation.Server.Host.Configuration
+﻿using System;
+
+namespace Tgstation.Server.Host.Configuration
 	{
 	/// <summary>
 	/// Configuration options pertaining to elasticsearch log storage.
@@ -18,7 +20,7 @@
 		/// <summary>
 		/// The host of the elasticsearch endpoint.
 		/// </summary>
-		public string Host { get; set; }
+		public Uri Host { get; set; }
 
 		/// <summary>
 		/// Username for elasticsearch.

--- a/src/Tgstation.Server.Host/Core/Application.cs
+++ b/src/Tgstation.Server.Host/Core/Application.cs
@@ -196,11 +196,7 @@ namespace Tgstation.Server.Host.Core
 						rollOnFileSizeLimit: true);
 				},
 				elasticsearchConfiguration.Enable
-					? new ElasticsearchSinkOptions(
-						new Uri(
-							String.IsNullOrWhiteSpace(elasticsearchConfiguration.Host)
-								? throw new InvalidOperationException($"Missing {ElasticsearchConfiguration.Section}:{nameof(elasticsearchConfiguration.Host)}!")
-								: elasticsearchConfiguration.Host))
+					? new ElasticsearchSinkOptions(elasticsearchConfiguration.Host ?? throw new InvalidOperationException($"Missing {ElasticsearchConfiguration.Section}:{nameof(elasticsearchConfiguration.Host)}!"))
 					{
 						// Yes I know this means they cannot use a self signed cert unless they also have authentication, but lets be real here
 						// No one is going to be doing one of those but not the other

--- a/src/Tgstation.Server.Host/Setup/SetupWizard.cs
+++ b/src/Tgstation.Server.Host/Setup/SetupWizard.cs
@@ -790,11 +790,17 @@ namespace Tgstation.Server.Host.Setup
 				do
 				{
 					await console.WriteAsync("ElasticSearch server endpoint (Include protocol and port, leave blank for http://127.0.0.1:9200): ", false, cancellationToken);
-					elasticsearchConfiguration.Host = await console.ReadLineAsync(false, cancellationToken);
-					if (!String.IsNullOrWhiteSpace(elasticsearchConfiguration.Host))
+					var hostString = await console.ReadLineAsync(false, cancellationToken);
+					if (String.IsNullOrWhiteSpace(hostString))
+						hostString = "http://127.0.0.1:9200";
+
+					if (Uri.TryCreate(hostString, UriKind.Absolute, out var host))
 					{
+						elasticsearchConfiguration.Host = host;
 						break;
 					}
+
+					await console.WriteAsync("Invalid URI!", true, cancellationToken);
 				}
 				while (true);
 
@@ -803,9 +809,7 @@ namespace Tgstation.Server.Host.Setup
 					await console.WriteAsync("Enter Elasticsearch username: ", false, cancellationToken);
 					elasticsearchConfiguration.Username = await console.ReadLineAsync(false, cancellationToken);
 					if (!String.IsNullOrWhiteSpace(elasticsearchConfiguration.Username))
-					{
 						break;
-					}
 				}
 				while (true);
 
@@ -814,9 +818,7 @@ namespace Tgstation.Server.Host.Setup
 					await console.WriteAsync("Enter password: ", false, cancellationToken);
 					elasticsearchConfiguration.Password = await console.ReadLineAsync(true, cancellationToken);
 					if (!String.IsNullOrWhiteSpace(elasticsearchConfiguration.Username))
-					{
 						break;
-					}
 				}
 				while (true);
 			}

--- a/tests/Tgstation.Server.Host.Tests/Setup/TestSetupWizard.cs
+++ b/tests/Tgstation.Server.Host.Tests/Setup/TestSetupWizard.cs
@@ -200,7 +200,12 @@ namespace Tgstation.Server.Host.Setup.Tests
 				//logging config
 				"no",
 				// elasticsearch config
-				"n", // were not validating this travesty in CI
+				"y",
+				String.Empty,
+				String.Empty,
+				"user",
+				String.Empty,
+				"pass",
 				//cp config
 				"y",
 				"y",
@@ -267,7 +272,11 @@ namespace Tgstation.Server.Host.Setup.Tests
 				"None",
 				"Critical",
 				// elasticsearch config
-				"n", // were not validating this travesty in CI
+				"y",
+				"bad url",
+				"http://localhost:929",
+				"user",
+				"pass",
 				//cp config
 				"y",
 				"n",


### PR DESCRIPTION
:cl: **Configuration**
Added strict URL parsing the the `Elasticsearch:Host` option.
/:cl:

:cl:
Fixed default option for `Elasticsearch:Host` in the setup wizard not working.
Fixed the behavior of system channels being inverted.
/:cl:

Fixes #1599 