### PR TITLE
Add a 1 hour test timeout to CI

### DIFF
--- a/build/ci.runsettings
+++ b/build/ci.runsettings
@@ -2,6 +2,7 @@
 <RunSettings>
   <RunConfiguration>
     <CollectSourceInformation>true</CollectSourceInformation>
+    <TestSessionTimeout>3600000</TestSessionTimeout>
   </RunConfiguration>
   <DataCollectionRunSettings>
     <DataCollectors>


### PR DESCRIPTION
Mainly to catch those cases where the unit tests deadlock