### PR TITLE
Fix service arguments during install. v5.13.4 Release

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>5.13.3</TgsCoreVersion>
+    <TgsCoreVersion>5.13.4</TgsCoreVersion>
     <TgsConfigVersion>4.7.1</TgsConfigVersion>
     <TgsApiVersion>9.11.0</TgsApiVersion>
     <TgsCommonLibraryVersion>6.0.0</TgsCommonLibraryVersion>

--- a/src/Tgstation.Server.Host/Components/StaticFiles/Configuration.cs
+++ b/src/Tgstation.Server.Host/Components/StaticFiles/Configuration.cs
@@ -202,12 +202,14 @@ namespace Tgstation.Server.Host.Components.StaticFiles
 		{
 			using (await SemaphoreSlimContext.Lock(semaphore, cancellationToken))
 			{
-				await EnsureDirectories(cancellationToken);
+				var ensureDirectoriesTask = EnsureDirectories(cancellationToken);
 
 				// just assume no other fs race conditions here
 				var dmeExistsTask = ioManager.FileExists(ioManager.ConcatPath(CodeModificationsSubdirectory, dmeFile), cancellationToken);
 				var headFileExistsTask = ioManager.FileExists(ioManager.ConcatPath(CodeModificationsSubdirectory, CodeModificationsHeadFile), cancellationToken);
 				var tailFileExistsTask = ioManager.FileExists(ioManager.ConcatPath(CodeModificationsSubdirectory, CodeModificationsTailFile), cancellationToken);
+
+				await ensureDirectoriesTask;
 				var copyTask = ioManager.CopyDirectory(
 					null,
 					null,


### PR DESCRIPTION
:cl:
Slightly improved the performance of applying CodeModifications to deployments.
/:cl:

:cl: Host Watchdog
Fixed manual Windows service setup always pointing the configuration directory to `C:/ProgramData/tgstation-server`.
/:cl: