### PR TITLE
Prevent DumpOnHealthCheckRestart from crashing the monitor

### DIFF
--- a/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
@@ -4,7 +4,10 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
+using BetterWin32Errors;
+
 using Microsoft.Extensions.Logging;
+
 using Serilog.Context;
 
 using Tgstation.Server.Api.Models;
@@ -1086,7 +1089,18 @@ namespace Tgstation.Server.Host.Components.Watchdog
 						if (ActiveLaunchParameters.DumpOnHealthCheckRestart.Value)
 						{
 							Logger.LogDebug("DumpOnHealthCheckRestart enabled.");
-							await CreateDump(cancellationToken);
+							try
+							{
+								await CreateDump(cancellationToken);
+							}
+							catch (JobException ex)
+							{
+								Logger.LogWarning(ex, "Creating dump failed!");
+							}
+							catch (Win32Exception ex)
+							{
+								Logger.LogWarning(ex, "Creating dump failed!");
+							}
 						}
 						else
 							Logger.LogTrace("DumpOnHealthCheckRestart disabled.");


### PR DESCRIPTION
:cl:
Fixed a watchdog crash that could occur if `dumpOnHealthCheckRestart` was enabled and the DreamDaemon process aborts.
/:cl: