### PR TITLE
More Windows installation UX improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Create an `appsettings.Production.yml` file next to `appsettings.yml`. This will
 
 - `Session:LowPriorityDeploymentProcesses `: Boolean controlling if DreamMaker and API validation DreamDaemon instances get set to below normal priority processes.
 
-- `FileLogging:Directory`: Override the default directory where server logs are stored. Default is C:/ProgramData/tgstation-server/logs on Windows, /usr/share/tgstation-server/logs otherwise
+- `FileLogging:Directory`: Override the default directory where server logs are stored. Default is `C:/ProgramData/tgstation-server/logs` on Windows, `/usr/share/tgstation-server/logs` otherwise
 
 - `FileLogging:LogLevel`: Can be one of `Trace`, `Debug`, `Information`, `Warning`, `Error`, or `Critical`. Restricts what is put into the log files. Currently `Debug` is reccommended for help with error reporting.
 

--- a/build/Version.props
+++ b/build/Version.props
@@ -18,6 +18,8 @@
     <TgsNetMajorVersion>6</TgsNetMajorVersion>
     <!-- Update this frequently with dotnet runtime patches. MAJOR MUST MATCH ABOVE! -->
     <TgsDotnetRedistUrl>https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/6.0.20/dotnet-hosting-6.0.20-win.exe</TgsDotnetRedistUrl>
+    <TgsMariaDBRedistVersion>11.0.2</TgsMariaDBRedistVersion>
+    <!-- The two versions must match above, this is referenced by scripts so we can't use an MSBuild property reference -->
     <TgsMariaDBRedistUrl>https://ftp.osuosl.org/pub/mariadb/mariadb-11.0.2/winx64-packages/mariadb-11.0.2-winx64.msi</TgsMariaDBRedistUrl>
   </PropertyGroup>
 </Project>

--- a/build/Version.props
+++ b/build/Version.props
@@ -11,7 +11,7 @@
     <TgsClientVersion>12.0.0</TgsClientVersion>
     <TgsDmapiVersion>6.5.2</TgsDmapiVersion>
     <TgsInteropVersion>5.6.1</TgsInteropVersion>
-    <TgsHostWatchdogVersion>1.3.0</TgsHostWatchdogVersion>
+    <TgsHostWatchdogVersion>1.4.0</TgsHostWatchdogVersion>
     <TgsContainerScriptVersion>1.2.1</TgsContainerScriptVersion>
     <TgsMigratorVersion>1.0.2</TgsMigratorVersion>
     <TgsNugetNetFramework>netstandard2.0</TgsNugetNetFramework>

--- a/build/package/winget/Tgstation.Server.Host.Service.Wix.Bundle/Bundle.wxs
+++ b/build/package/winget/Tgstation.Server.Host.Service.Wix.Bundle/Bundle.wxs
@@ -1,7 +1,7 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:bal="http://wixtoolset.org/schemas/v4/wxs/bal" xmlns:netfx="http://wixtoolset.org/schemas/v4/wxs/netfx">
   <Bundle Name="tgstation-server" Manufacturer="/tg/station 13" Version="$(var.ProductVersion)" AboutUrl="https://github.com/tgstation/tgstation-server/blob/tgstation-server-v$(var.ProductVersion)/LICENSE" IconSourceFile="../../../tgs.ico" HelpUrl="https://github.com/tgstation/tgstation-server/discussions/categories/q-a" UpdateUrl="https://github.com/tgstation/tgstation-server/releases/latest" UpgradeCode="542535f4-49ad-45c4-9b96-6d8235ed8b87">
     <BootstrapperApplication>
-      <bal:WixStandardBootstrapperApplication LicenseUrl="https://github.com/tgstation/tgstation/tree/tgstation-server-v$(var.ProductVersion)" LocalizationFile="Theme.wxl" Theme="hyperlinkLicense" LogoFile="../../../tgs.ico" ShowVersion="yes" SuppressOptionsUI="yes" ThemeFile="Theme.xml" />
+      <bal:WixStandardBootstrapperApplication LicenseUrl="https://github.com/tgstation/tgstation/tree/tgstation-server-v$(var.ProductVersion)" LocalizationFile="Theme.wxl" Theme="hyperlinkLicense" LogoFile="../../../tgs.ico" ShowVersion="yes" SuppressOptionsUI="yes" ThemeFile="Theme.xml" LaunchTarget="http://127.0.0.1:5000" />
     </BootstrapperApplication>
 
     <netfx:DotNetCoreSearch RuntimeType="aspnet" Platform="x64" MajorVersion="$(var.NetMajorVersion)" Variable="AspNetCorex64Status" />
@@ -11,13 +11,21 @@
     <netfx:DotNetCoreSearch RuntimeType="core" Platform="x86" MajorVersion="$(var.NetMajorVersion)" Variable="NetCorex86Status" />
 
     <WixVariable Id="AspNetCoreDetectCondition" Value="(NetCorex64Status AND AspNetCorex64Status) OR (NetCorex86Status AND AspNetCorex86Status)" />
+    <Variable Name="DefaultConfigurationCheckbox" Type="numeric" Value="1" />
+    <Variable Name="InstallMariaDBPassword" Value="DreamsOfCheese" />
 
     <Chain>
-      <MsiPackage InstallCondition="InstallMariaDBCheckbox=1" RepairCondition="FALSE" Visible="yes" Permanent="yes" DownloadUrl="$(var.MariaDBRedistUrl)" Compressed="no" SourceFile="mariadb.msi" bal:DisplayInternalUICondition="1" />
+      <MsiPackage InstallCondition="InstallMariaDBCheckbox=1" RepairCondition="FALSE" Visible="yes" Permanent="yes" DownloadUrl="$(var.MariaDBRedistUrl)" Compressed="no" SourceFile="mariadb.msi" Cache="remove" bal:DisplayInternalUICondition="DefaultConfigurationCheckbox=0" ForcePerMachine="yes">
+        <MsiProperty Name="HEIDISQLINSTALLED" Value="1" Condition="DefaultConfigurationCheckbox=1" /> <!-- Prevents HeidiSQL installation -->
+        <MsiProperty Name="PASSWORD" Value="[InstallMariaDBPassword]" Condition="DefaultConfigurationCheckbox=1" />
+        <MsiProperty Name="UTF8" Value="1" />
+        <MsiProperty Name="SERVICENAME" Value="MariaDB" />
+      </MsiPackage>
       <ExePackage PerMachine="yes" DetectCondition="!(wix.AspNetCoreDetectCondition)" Permanent="yes" Protocol="burn" InstallArguments="/install /quiet /norestart /log [HOSTING_BUNDLE_LOG_PATH]" RepairArguments="/repair /quiet /norestart /log [HOSTING_BUNDLE_LOG_PATH]" UninstallArguments="/uninstall /quiet /norestart /log [HOSTING_BUNDLE_LOG_PATH]" Cache="remove" LogPathVariable="HOSTING_BUNDLE_LOG_PATH" RepairCondition="FALSE" DownloadUrl="$(var.DotnetRedistUrl)" SourceFile="hosting-bundle.exe" Compressed="no" />
       <MsiPackage SourceFile="$(var.Tgstation.Server.Host.Service.Wix.TargetPath)">
         <MsiProperty Name="WIX_BOOTSTRAPPER_UILEVEL" Value="[WixBundleUILevel]" />
         <MsiProperty Name="MARIADB_INSTALLED" Value="TRUE" Condition="InstallMariaDBCheckbox=1" />
+        <MsiProperty Name="MARIADB_PASSWORD" Value="[InstallMariaDBPassword]" Condition="InstallMariaDBCheckbox=1 AND DefaultConfigurationCheckbox=1" />
       </MsiPackage>
     </Chain>
 

--- a/build/package/winget/Tgstation.Server.Host.Service.Wix.Bundle/Theme.wxl
+++ b/build/package/winget/Tgstation.Server.Host.Service.Wix.Bundle/Theme.wxl
@@ -1,7 +1,9 @@
 <!-- https://github.com/wixtoolset/wix/blob/e0641f1479c6f67f6ec119d448b66a74ad5d6b88/src/ext/Bal/wixstdba/Resources/HyperlinkTheme.wxl -->
 
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://wixtoolset.org/schemas/v4/wxl">
-  <String Id="MariaDBCheckbox" Value="Install MariaDB for use as the TGS backing database. x64 only. Works well with SS13 servers."/>
+  <String Id="MariaDBCheckbox" Value="Install MariaDB for use as the TGS backing database. x64 only. (Recommended)"/>
+  <String Id="DefaultConfigurationCheckbox" Value="Use default configuration settings. (Port 5000, Database: tgs)" />
+  <String Id="MariaDBPassword" Value="MariaDB root password (Default: DreamsOfCheese):" />
   <String Id="Title" Value="[WixBundleName] v[WixBundleVersion]" />
 
   <String Id="Caption" Value="[WixBundleName] Setup" />

--- a/build/package/winget/Tgstation.Server.Host.Service.Wix.Bundle/Theme.xml
+++ b/build/package/winget/Tgstation.Server.Host.Service.Wix.Bundle/Theme.xml
@@ -23,9 +23,12 @@
         </Page>
         <Page Name="Install">
             <Hypertext Name="EulaHyperlink" X="11" Y="121" Width="-11" Height="25" TabStop="yes" FontId="3" HideWhenDisabled="yes">#(loc.InstallLicenseLinkText)</Hypertext>
-            <Checkbox Name="InstallMariaDBCheckbox" X="11" Y="146" Width="500" Height="26" TabStop="yes" FontId="3">#(loc.MariaDBCheckbox)</Checkbox>
             <Checkbox Name="EulaAcceptCheckbox" X="-11" Y="-41" Width="260" Height="17" TabStop="yes" FontId="3" HideWhenDisabled="yes">#(loc.InstallAcceptCheckbox)</Checkbox>
-            <Button Name="InstallUpdateButton" X="11" Y="-11" Width="200" Height="23" TabStop="yes" FontId="0" EnableCondition="WixStdBAUpdateAvailable" HideWhenDisabled="yes">#(loc.UpdateButton)</Button>
+            <Label X="11" Y="80" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.OptionsHeader)</Label>
+            <Checkbox Name="InstallMariaDBCheckbox" X="11" Y="146" Width="500" Height="17" TabStop="yes" FontId="3">#(loc.MariaDBCheckbox)</Checkbox>
+            <Checkbox Name="DefaultConfigurationCheckbox" X="11" Y="163" Width="500" Height="17" TabStop="yes" FontId="3" HideWhenDisabled="yes" EnableCondition="InstallMariaDBCheckbox=1">#(loc.DefaultConfigurationCheckbox)</Checkbox>
+            <Label X="11" Y="185" Width="500" Height="17" FontId="3" DisablePrefix="yes" HideWhenDisabled="yes" EnableCondition="InstallMariaDBCheckbox=1 AND DefaultConfigurationCheckbox=1">#(loc.MariaDBPassword)</Label>
+            <Editbox Name="InstallMariaDBPassword" X="11" Y="203" Width="200" Height="17" TabStop="yes" FontId="3" HideWhenDisabled="yes" EnableCondition="InstallMariaDBCheckbox=1 AND DefaultConfigurationCheckbox=1" HexStyle="20">#(loc.MariaDBPassword)</Editbox>
             <Button Name="InstallButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.InstallInstallButton)</Button>
             <Button Name="InstallCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">
                 <Text>#(loc.InstallCancelButton)</Text>
@@ -60,7 +63,7 @@
                 <Text Condition="WixBundleAction = 7">#(loc.SuccessModifyHeader)</Text>
                 <Text Condition="WixBundleAction = 8">#(loc.SuccessRepairHeader)</Text>
             </Label>
-            <Button Name="LaunchButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.SuccessLaunchButton)</Button>
+            <Button Name="LaunchButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes" EnableCondition="InstallMariaDBCheckbox=1 AND DefaultConfigurationCheckbox=1">#(loc.SuccessLaunchButton)</Button>
             <Label X="-11" Y="-51" Width="400" Height="34" FontId="3" DisablePrefix="yes" VisibleCondition="WixStdBARestartRequired">
                 <Text>#(loc.SuccessRestartText)</Text>
                 <Text Condition="WixBundleAction = 3">#(loc.SuccessUninstallRestartText)</Text>

--- a/build/package/winget/Tgstation.Server.Host.Service.Wix.Extensions/InstallationExtensions.cs
+++ b/build/package/winget/Tgstation.Server.Host.Service.Wix.Extensions/InstallationExtensions.cs
@@ -46,7 +46,7 @@
 						return ActionResult.Success;
 					}
 
-					var commandId = PipeCommands.GetCommandId(
+					var commandId = PipeCommands.GetServiceCommandId(
 						PipeCommands.CommandDetachingShutdown)
 						.Value;
 

--- a/build/package/winget/Tgstation.Server.Host.Service.Wix.Extensions/InstallationExtensions.cs
+++ b/build/package/winget/Tgstation.Server.Host.Service.Wix.Extensions/InstallationExtensions.cs
@@ -1,6 +1,7 @@
 ﻿namespace Tgstation.Server.Host.Service.Wix.Extensions
 {
 	using System;
+	using System.IO;
 	using System.ServiceProcess;
 
 	using Tgstation.Server.Host.Common;
@@ -12,6 +13,12 @@
 	/// </summary>
 	public static class InstallationExtensions
 	{
+		/// <summary>
+		/// Package name
+		/// </summary>
+		/// <remarks>As much as I'd like to use Tgstation.Server.Common.Constants.CanonicalPackageName here, attempting to reference it makes Tgstation.Server.Migrator.Comms fail due to referencing the net2.0 version of that library. EVEN THOUGH IT'S A TRANSITIVE DEPENDENCY OF Tgstation.Server.Client!!!!! If that dead-ass tool has been removed, feel free to do this.</remarks>
+		const string CanonicalPackageName = "tgstation-server";
+
 		/// <summary>
 		/// Attempts to detach stop the existing tgstation-server service if it exists.
 		/// </summary>
@@ -28,9 +35,6 @@
 				session.Log("Begin DetachStopTgsServiceIfRunning");
 				ServiceController serviceController = null;
 
-				// As much as I'd like to use Tgstation.Server.Common.Constants.CanonicalPackageName here, attempting to reference it make Tgstation.Server.Migrator.Comms fail due to referencing the net2.0 version of that library. EVEN THOUGH IT'S A TRANSITIVE DEPENDENCY OF Tgstation.Server.Client!!!!!
-				// If that dead-ass tool has been removed, feel free to do this
-				const string CanonicalPackageName = "tgstation-server";
 				session.Log($"Searching for {CanonicalPackageName} service...");
 				try
 				{
@@ -73,6 +77,56 @@
 			catch (Exception ex)
 			{
 				session.Log($"Exception in DetachStopTgsServiceIfRunning:{Environment.NewLine}{ex}");
+				return ActionResult.Failure;
+			}
+		}
+
+		/// <summary>
+		/// Attempts to copy the initial config to the production config if necessary.
+		/// </summary>
+		/// <param name="session">The installer <see cref="Session"/>.</param>
+		/// <returns>The <see cref="ActionResult"/> of the custom action.</returns>
+		[CustomAction]
+		public static ActionResult ApplyProductionAppsettingsIfNonExistant(Session session)
+		{
+			if (session == null)
+				throw new ArgumentNullException(nameof(session));
+
+			try
+			{
+				session.Log("Begin ApplyProductionAppsettingsIfNonExistant");
+				var programDataDirectory = Path.Combine(
+					Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+					CanonicalPackageName);
+				var initialAppSettingsPath = Path.Combine(programDataDirectory, "appsettings.Initial.yml");
+				var productionAppSettingsPath = Path.Combine(programDataDirectory, "appsettings.Production.yml");
+
+				var initialAppSettingsExists = File.Exists(initialAppSettingsPath);
+				var productionAppSettingsExists = File.Exists(productionAppSettingsPath);
+
+				if (productionAppSettingsExists)
+					session.Log("appsettings.Production.yml present");
+				else
+					session.Log("appsettings.Production.yml NOT present");
+
+				if (!initialAppSettingsExists)
+					session.Log("appsettings.Initial.yml NOT present!");
+				else
+				{
+					session.Log("appsettings.Initial.yml present");
+					if (!productionAppSettingsExists)
+					{
+						session.Log("Copying initial settings to production settings...");
+						File.Copy(initialAppSettingsPath, productionAppSettingsPath);
+						return ActionResult.Success;
+					}
+				}
+
+				return ActionResult.NotExecuted;
+			}
+			catch (Exception ex)
+			{
+				session.Log($"Exception in ApplyProductionAppsettingsIfNonExistant:{Environment.NewLine}{ex}");
 				return ActionResult.Failure;
 			}
 		}

--- a/build/package/winget/Tgstation.Server.Host.Service.Wix/Package.wxs
+++ b/build/package/winget/Tgstation.Server.Host.Service.Wix/Package.wxs
@@ -7,6 +7,7 @@
     <Binary Id="InstallerExtensionsBinary" SourceFile="$(var.Tgstation.Server.Host.Service.Wix.Extensions.TargetName).CA.dll" />
 
     <CustomAction Id="DetachStopTgsServiceIfRunningAction" BinaryRef="InstallerExtensionsBinary" DllEntry="DetachStopTgsServiceIfRunning" Execute="deferred" />
+    <CustomAction Id="ApplyProductionAppsettingsIfNonExistantAction" BinaryRef="InstallerExtensionsBinary" DllEntry="ApplyProductionAppsettingsIfNonExistant" Execute="deferred" />
     <CustomAction Id="RunTgsConfigure" Execute="deferred" FileRef="ServiceExecutableFile" ExeCommand="-c -p=--appsettings-base-path=[APPLICATIONDATADIRECTORY]" />
     <CustomAction Id="RunTgsConfigureMariaDB" Execute="deferred" FileRef="ServiceExecutableFile" ExeCommand="-c -p=&quot;--appsettings-base-path=[APPLICATIONDATADIRECTORY] --Internal:MariaDBSetup=true --Internal:MariaDBDefaultRootPassword=\&quot;[MARIADB_PASSWORD]\&quot;&quot;" />
 
@@ -16,6 +17,7 @@
 
     <InstallExecuteSequence>
       <Custom Action="DetachStopTgsServiceIfRunningAction" Condition="UPGRADINGPRODUCTCODE OR REINSTALL" Before="StopServices" />
+      <Custom Action="ApplyProductionAppsettingsIfNonExistantAction" Condition="NOT ((NOT REMOVE~=&quot;ALL&quot;) AND (NOT PRODUCTIONAPPSETTINGSPRESENT) AND ((WIX_BOOTSTRAPPER_UILEVEL >= 4) OR (UILevel >= 4)))" Before="StartServices" />
       <Custom Action="RunTgsConfigure" Before="StartServices" Condition="(NOT MARIADB_INSTALLED) AND (NOT REMOVE~=&quot;ALL&quot;) AND (NOT PRODUCTIONAPPSETTINGSPRESENT) AND ((WIX_BOOTSTRAPPER_UILEVEL >= 4) OR (UILevel >= 4))"/>
       <Custom Action="RunTgsConfigureMariaDB" Before="StartServices" Condition="MARIADB_INSTALLED AND (NOT REMOVE~=&quot;ALL&quot;) AND (NOT PRODUCTIONAPPSETTINGSPRESENT) AND ((WIX_BOOTSTRAPPER_UILEVEL >= 4) OR (UILevel >= 4))"/>
       <StartServices Condition="(NOT REMOVE~=&quot;ALL&quot;) AND ((WIX_BOOTSTRAPPER_UILEVEL >= 4) OR (UILevel >= 4) OR PRODUCTIONAPPSETTINGSPRESENT)"/>
@@ -79,7 +81,7 @@
           <File Source="../../../../src/Tgstation.Server.Host/appsettings.yml" />
         </Component>
         <Component Id="ProductionAppSettingsComponent" Guid="" NeverOverwrite="yes">
-          <File Source="../../appsettings.Initial.yml" Name="appsettings.Production.yml">
+          <File Source="../../appsettings.Initial.yml">
             <PermissionEx Sddl="D:PAI(A;;FA;;;SY)(A;;FA;;;BA)" />
           </File>
         </Component>

--- a/build/package/winget/Tgstation.Server.Host.Service.Wix/Package.wxs
+++ b/build/package/winget/Tgstation.Server.Host.Service.Wix/Package.wxs
@@ -8,7 +8,7 @@
 
     <CustomAction Id="DetachStopTgsServiceIfRunningAction" BinaryRef="InstallerExtensionsBinary" DllEntry="DetachStopTgsServiceIfRunning" Execute="deferred" />
     <CustomAction Id="RunTgsConfigure" Execute="deferred" FileRef="ServiceExecutableFile" ExeCommand="-c -p=--appsettings-base-path=[APPLICATIONDATADIRECTORY]" />
-    <CustomAction Id="RunTgsConfigureMariaDB" Execute="deferred" FileRef="ServiceExecutableFile" ExeCommand="-c -p=&quot;--appsettings-base-path=[APPLICATIONDATADIRECTORY] --Internal:MariaDBSetup=true&quot;" />
+    <CustomAction Id="RunTgsConfigureMariaDB" Execute="deferred" FileRef="ServiceExecutableFile" ExeCommand="-c -p=&quot;--appsettings-base-path=[APPLICATIONDATADIRECTORY] --Internal:MariaDBSetup=true --Internal:MariaDBDefaultRootPassword=\&quot;[MARIADB_PASSWORD]\&quot;&quot;" />
 
     <Icon Id="tgs.ico" SourceFile="../../../tgs.ico" />
 

--- a/src/Tgstation.Server.Host.Common/PipeCommands.cs
+++ b/src/Tgstation.Server.Host.Common/PipeCommands.cs
@@ -20,6 +20,11 @@
 		/// </summary>
 		public const string CommandDetachingShutdown = "detach";
 
+		/// <summary>
+		/// Indicates that the host has finished initializing.
+		/// </summary>
+		public const string CommandStartupComplete = "times_up_lets_do_this";
+
 #if NET6_0_OR_GREATER
 		/// <summary>
 		/// All of the <see cref="PipeCommands"/> represented as a <see cref="System.Collections.Generic.IReadOnlyList{T}"/>.
@@ -29,6 +34,7 @@
 			CommandStop,
 			CommandGracefulShutdown,
 			CommandDetachingShutdown,
+			CommandStartupComplete,
 		};
 #endif
 
@@ -36,14 +42,14 @@
 		/// Gets the <see cref="int"/> value of a given <paramref name="command"/>.
 		/// </summary>
 		/// <param name="command">The <see cref="PipeCommands"/>.</param>
-		/// <returns>The <see cref="int"/> value of the command or <see langword="null"/> if it was unrecognized.</returns>
-		public static int? GetCommandId(string command)
+		/// <returns>The <see cref="int"/> value of the command or <see langword="null"/> if it was unrecognized service command.</returns>
+		public static int? GetServiceCommandId(string command)
 			=> command switch
 			{
 				CommandStop => 128, // Windows only allows commands 128-256: https://stackoverflow.com/a/62858106
 				CommandGracefulShutdown => 129,
 				CommandDetachingShutdown => 130,
-				_ => null,
+				CommandStartupComplete or _ => null,
 			};
 	}
 }

--- a/src/Tgstation.Server.Host.Service/Program.cs
+++ b/src/Tgstation.Server.Host.Service/Program.cs
@@ -261,7 +261,7 @@ namespace Tgstation.Server.Host.Service
 			if (!stop)
 			{
 				serviceController.ExecuteCommand(
-					PipeCommands.GetCommandId(
+					PipeCommands.GetServiceCommandId(
 						PipeCommands.CommandDetachingShutdown)
 					.Value);
 				serviceController.WaitForStatus(ServiceControllerStatus.Stopped, TimeSpan.FromSeconds(30));

--- a/src/Tgstation.Server.Host.Watchdog/IWatchdog.cs
+++ b/src/Tgstation.Server.Host.Watchdog/IWatchdog.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Tgstation.Server.Host.Watchdog
@@ -8,6 +9,11 @@ namespace Tgstation.Server.Host.Watchdog
 	/// </summary>
 	public interface IWatchdog
 	{
+		/// <summary>
+		/// Gets the current version of the host process. Set once <see cref="RunAsync(bool, string[], CancellationToken)"/> begins and doesn't immediately return <see langword="false"/>.
+		/// </summary>
+		Version InitialHostVersion { get; }
+
 		/// <summary>
 		/// Run the <see cref="IWatchdog"/>.
 		/// </summary>

--- a/src/Tgstation.Server.Host.Watchdog/Watchdog.cs
+++ b/src/Tgstation.Server.Host.Watchdog/Watchdog.cs
@@ -19,6 +19,9 @@ namespace Tgstation.Server.Host.Watchdog
 	/// <remarks>This <see langword="class"/> is a HACK but it works. Try not to break it if you wish to change it. Remember, this code doesn't get updated with the rest of the server.</remarks>
 	sealed class Watchdog : IWatchdog
 	{
+		/// <inheritdoc />
+		public Version InitialHostVersion { get; private set; }
+
 		/// <summary>
 		/// The <see cref="ISignalChecker"/> for the <see cref="Watchdog"/>.
 		/// </summary>
@@ -108,6 +111,8 @@ namespace Tgstation.Server.Host.Watchdog
 					logger.LogCritical("Unable to locate host assembly!");
 					return false;
 				}
+
+				InitialHostVersion = Version.Parse(FileVersionInfo.GetVersionInfo(assemblyPath).FileVersion);
 
 				var watchdogVersion = executingAssembly.GetName().Version.Semver().ToString();
 

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordProvider.cs
@@ -3,9 +3,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Globalization;
 using System.Linq;
-using System.Reflection;
 using System.Threading;
-using System.Threading.Channels;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.DependencyInjection;
@@ -19,7 +17,6 @@ using Remora.Discord.API.Abstractions.Results;
 using Remora.Discord.API.Objects;
 using Remora.Discord.Gateway;
 using Remora.Discord.Gateway.Extensions;
-using Remora.Discord.Gateway.Services;
 using Remora.Rest.Core;
 using Remora.Rest.Results;
 using Remora.Results;
@@ -227,54 +224,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 
 			await base.DisposeAsync();
 
-			// https://github.com/Remora/Remora.Discord/issues/305
-			var responderDispatchService = serviceProvider.GetRequiredService<ResponderDispatchService>();
-			var serviceProviderDisposeTask = serviceProvider.DisposeAsync().AsTask();
-			var timeout = AsyncDelayer.Delay(TimeSpan.FromSeconds(10), default); // DCT: None available
-
-			await Task.WhenAny(timeout, serviceProviderDisposeTask);
-
-			if (!serviceProviderDisposeTask.IsCompleted)
-			{
-				// HACK HACK HACK, there's a potential deadlock in the ResponderDispatchService
-				Logger.LogWarning("ServiceProvider disposal stalled. Attempting workaround...");
-				var responderDispatchServiceType = responderDispatchService.GetType();
-				var dispatcherTask = (Task)responderDispatchServiceType.GetField("_dispatcher", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(responderDispatchService);
-				var finalizerTask = (Task)responderDispatchServiceType.GetField("_finalizer", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(responderDispatchService);
-
-				var dispatcherCompleted = dispatcherTask.IsCompleted;
-				var finalizerCompleted = finalizerTask.IsCompleted;
-				if (dispatcherCompleted && !finalizerCompleted)
-				{
-					// deadlocked, force close the channel
-					var channel = (Channel<Task<IReadOnlyList<Result>>>)responderDispatchServiceType.GetField("_respondersToFinalize", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(responderDispatchService);
-					if (!channel.Writer.TryComplete())
-						Logger.LogCritical("Workaround failed (channel already closed), you may be deadlocked!");
-					else
-					{
-						// drain the channel, fuck the results
-						// DCT: None available
-						await foreach (var result in channel.Reader.ReadAllAsync(CancellationToken.None))
-							try
-							{
-								await result;
-							}
-							catch (Exception ex)
-							{
-								Logger.LogDebug(ex, "Channel draining exception!");
-							}
-
-						Logger.LogInformation("Workaround seems successful. Awaiting ServiceProvider disposal...");
-					}
-				}
-				else
-					Logger.LogCritical(
-						"Workaround failed (_dispatcher: {dispatcherCompleted}, _finalizer: {finalizerCompleted}), you may be deadlocked!",
-						dispatcherCompleted,
-						finalizerCompleted);
-			}
-
-			await serviceProviderDisposeTask;
+			await serviceProvider.DisposeAsync();
 
 			Logger.LogTrace("ServiceProvider disposed");
 

--- a/src/Tgstation.Server.Host/Configuration/InternalConfiguration.cs
+++ b/src/Tgstation.Server.Host/Configuration/InternalConfiguration.cs
@@ -11,9 +11,14 @@
 		public const string Section = "Internal";
 
 		/// <summary>
-		/// The name of the pipe opened by the host watchdog, if any.
+		/// The name of the pipe opened by the host watchdog for sending commands, if any.
 		/// </summary>
 		public string CommandPipe { get; set; }
+
+		/// <summary>
+		/// The name of the pipe opened by the host watchdog for receiving commands, if any.
+		/// </summary>
+		public string ReadyPipe { get; set; }
 
 		/// <summary>
 		/// If the server is running under SystemD.

--- a/src/Tgstation.Server.Host/Configuration/InternalConfiguration.cs
+++ b/src/Tgstation.Server.Host/Configuration/InternalConfiguration.cs
@@ -29,5 +29,10 @@
 		/// Coerce the <see cref="Setup.SetupWizard"/> to select <see cref="DatabaseType.MariaDB"/>.
 		/// </summary>
 		public bool MariaDBSetup { get; set; }
+
+		/// <summary>
+		/// Generate default configuration using the given <see cref="DatabaseType.MariaDB"/> default password.
+		/// </summary>
+		public string MariaDBDefaultRootPassword { get; set; }
 	}
 }

--- a/src/Tgstation.Server.Host/Core/Application.cs
+++ b/src/Tgstation.Server.Host/Core/Application.cs
@@ -394,7 +394,7 @@ namespace Tgstation.Server.Host.Core
 			services.AddSingleton<ISynchronousIOManager, SynchronousIOManager>();
 			services.AddSingleton<IServerPortProvider, ServerPortProivder>();
 			services.AddSingleton<ITopicClientFactory, TopicClientFactory>();
-			services.AddHostedService<CommandPipeReader>();
+			services.AddHostedService<CommandPipeManager>();
 
 			services.AddFileDownloader();
 			services.AddGitHub();

--- a/src/Tgstation.Server.Host/Properties/MasterVersionsAttribute.cs
+++ b/src/Tgstation.Server.Host/Properties/MasterVersionsAttribute.cs
@@ -37,9 +37,9 @@ namespace Tgstation.Server.Host.Properties
 		public string RawHostWatchdogVersion { get; }
 
 		/// <summary>
-		/// The compile time default.
+		/// The <see cref="Version"/> <see cref="string"/> of the MariaDB server bundled with TGS installs.
 		/// </summary>
-		public string DefaultControlPanelChannel { get; }
+		public string RawMariaDBRedistVersion { get; }
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="MasterVersionsAttribute"/> class.
@@ -48,16 +48,19 @@ namespace Tgstation.Server.Host.Properties
 		/// <param name="rawInteropVersion">The value of <see cref="RawInteropVersion"/>.</param>
 		/// <param name="rawControlPanelVersion">The value of <see cref="RawControlPanelVersion"/>.</param>
 		/// <param name="rawHostWatchdogVersion">The value of <see cref="RawHostWatchdogVersion"/>.</param>
+		/// <param name="rawMariaDBRedistVersion">The value of <see cref="RawMariaDBRedistVersion"/>.</param>
 		public MasterVersionsAttribute(
 			string rawConfigurationVersion,
 			string rawInteropVersion,
 			string rawControlPanelVersion,
-			string rawHostWatchdogVersion)
+			string rawHostWatchdogVersion,
+			string rawMariaDBRedistVersion)
 		{
 			RawConfigurationVersion = rawConfigurationVersion ?? throw new ArgumentNullException(nameof(rawConfigurationVersion));
 			RawInteropVersion = rawInteropVersion ?? throw new ArgumentNullException(nameof(rawInteropVersion));
 			RawControlPanelVersion = rawControlPanelVersion ?? throw new ArgumentNullException(nameof(rawControlPanelVersion));
 			RawHostWatchdogVersion = rawHostWatchdogVersion ?? throw new ArgumentNullException(nameof(rawHostWatchdogVersion));
+			RawMariaDBRedistVersion = rawMariaDBRedistVersion ?? throw new ArgumentNullException(nameof(rawMariaDBRedistVersion));
 		}
 	}
 }

--- a/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
+++ b/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
@@ -45,6 +45,7 @@
         <_Parameter2>$(TgsInteropVersion)</_Parameter2>
         <_Parameter3>$(TgsControlPanelVersion)</_Parameter3>
         <_Parameter4>$(TgsHostWatchdogVersion)</_Parameter4>
+        <_Parameter5>$(TgsMariaDBRedistVersion)</_Parameter5>
       </AssemblyAttributes>
     </ItemGroup>
 

--- a/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
+++ b/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
@@ -95,7 +95,7 @@
     <!-- Usage: MYSQL/MariaDB ORM plugin -->
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="7.0.0" />
     <!-- Usage: Discord interop -->
-    <PackageReference Include="Remora.Discord" Version="2023.3.0" />
+    <PackageReference Include="Remora.Discord" Version="2023.4.0" />
     <!-- Usage: Rich logger builder -->
     <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0" />
     <!-- Usage: Async logging plugin -->

--- a/tools/Tgstation.Server.ReleaseNotes/Tgstation.Server.ReleaseNotes.csproj
+++ b/tools/Tgstation.Server.ReleaseNotes/Tgstation.Server.ReleaseNotes.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="octokit" Version="7.0.1" />
-    <PackageReference Include="Octokit.GraphQL" Version="0.2.0-beta" />
+    <PackageReference Include="Octokit.GraphQL" Version="0.2.1-beta" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
:cl:
The Windows installer now can fully configure TGS using default settings for ease of installation (Port 5000, root MariaDB user, database name: `tgs`).
/:cl:

:cl: Host Watchdog
The service runner now waits for TGS to fully initialize when starting.
/:cl: