### PR TITLE
Switch to using `Microsoft.Data.SqlClient`

### DIFF
--- a/src/Tgstation.Server.Host/Database/DatabaseConnectionFactory.cs
+++ b/src/Tgstation.Server.Host/Database/DatabaseConnectionFactory.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Data.Common;
-using System.Data.SqlClient;
 
+using Microsoft.Data.SqlClient;
 using Microsoft.Data.Sqlite;
 
 using MySqlConnector;

--- a/src/Tgstation.Server.Host/Database/SqlServerDatabaseContext.cs
+++ b/src/Tgstation.Server.Host/Database/SqlServerDatabaseContext.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using System.Data.SqlClient;
 
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 
 using Tgstation.Server.Host.Configuration;

--- a/src/Tgstation.Server.Host/Setup/SetupWizard.cs
+++ b/src/Tgstation.Server.Host/Setup/SetupWizard.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data.Common;
-using System.Data.SqlClient;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -11,6 +10,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Microsoft.Data.SqlClient;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;

--- a/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
+++ b/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
@@ -110,8 +110,6 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <!-- Usage: Newtonsoft.Json plugin for OpenAPI spec generator -->
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.5.0" />
-    <!-- Usage: Access to raw database connectors primarily for setup wizard -->
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
     <!-- Usage: Windows authentication plugin allowing searching for users by name -->
     <PackageReference Include="System.DirectoryServices.AccountManagement" Version="7.0.0" />
     <!-- Usage: JWT plugin needed to undo some Microsoft meddling in the HTTP pipeline -->

--- a/tests/Tgstation.Server.Host.Tests/Database/TestDatabaseConnectionFactory.cs
+++ b/tests/Tgstation.Server.Host.Tests/Database/TestDatabaseConnectionFactory.cs
@@ -1,9 +1,9 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System;
+
+using Microsoft.Data.SqlClient;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using MySqlConnector;
-
-using System;
-using System.Data.SqlClient;
 
 using Tgstation.Server.Host.Configuration;
 

--- a/tests/Tgstation.Server.Tests/Live/TestLiveServer.cs
+++ b/tests/Tgstation.Server.Tests/Live/TestLiveServer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -14,6 +13,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;


### PR DESCRIPTION
Nothing crazy, we don't really use the library directly.

Mainly just gets rid of the redundant `System.Data.SqlClient.dll`.