### PR TITLE
Fix systemd restart policy

### DIFF
--- a/build/tgstation-server.service
+++ b/build/tgstation-server.service
@@ -12,7 +12,7 @@ NotifyAccess=all
 WorkingDirectory=/opt/tgstation-server
 ExecStart=/usr/bin/dotnet Tgstation.Server.Host.Console.dll --appsettings-base-path=/etc/tgstation-server --General:SetupWizardMode=Never --Internal:UsingSystemD=true
 TimeoutStartSec=600
-Restart=Always
+Restart=always
 KillMode=process
 ReloadSignal=SIGUSR2
 RestartKillSignal=SIGUSR2


### PR DESCRIPTION
SystemD enum values are case sensitive. Setting this to `Always` was doing nothing, it has to be `always`

[Release Notes]: 

:cl: Host Watchdog
Fix capitalization issue in systemd unit file that was keeping systemd from restarting tgs in certain cases.
/:cl:

[Why]: This not being `always` killed campbell when systemd killed the tgs service for OOM.
