### PR TITLE
v5.13.6: Fix windows console watchdog, missing BYOND version, and configuration listing

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -1612,7 +1612,7 @@ jobs:
         GITHUB_TOKEN: ${{ env.WINGET_PUSH_TOKEN }}
 
     - name: Install wingetcreate
-      run: winget install wingetcreate --disable-interactivity --accept-source-agreements
+      run: winget install wingetcreate --version 1.2.8.0 --disable-interactivity --accept-source-agreements # Pinned due to https://github.com/microsoft/winget-create/issues/429
 
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -111,6 +111,14 @@ jobs:
             VERSIONS=$(curl https://www.byond.com/download/version.txt)
             FULL_VERSION=$(echo "$VERSIONS" | tail -n1)
             echo "EDGE version evaluated to $FULL_VERSION"
+
+            # Also needs updating in ByondTest.cs
+            declare -A missing_linux_releases=([515.1612]="515.1611")
+
+            if [[ -n "${missing_linux_releases[$FULL_VERSION]}" ]] ; then
+                echo "$FULL_VERSION does not have a linux zip, falling back to ${missing_linux_releases[$FULL_VERSION]}"
+                FULL_VERSION=${missing_linux_releases[$FULL_VERSION]}
+            fi
         fi
         if [[ ! -f $HOME/byond-zips-cache/linux/$FULL_VERSION.zip ]] ; then
             BYOND_MAJOR=${FULL_VERSION%.*}

--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>5.13.5</TgsCoreVersion>
+    <TgsCoreVersion>5.13.6</TgsCoreVersion>
     <TgsConfigVersion>4.7.1</TgsConfigVersion>
     <TgsApiVersion>9.11.0</TgsApiVersion>
     <TgsCommonLibraryVersion>6.0.0</TgsCommonLibraryVersion>

--- a/src/Tgstation.Server.Host.Console/Program.cs
+++ b/src/Tgstation.Server.Host.Console/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -71,8 +72,10 @@ namespace Tgstation.Server.Host.Console
 				};
 
 				var watchdog = WatchdogFactory.CreateWatchdog(
-					new PosixSignalChecker(
-						loggerFactory.CreateLogger<PosixSignalChecker>()),
+					RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+						? new NoopSignalChecker()
+						: new PosixSignalChecker(
+							loggerFactory.CreateLogger<PosixSignalChecker>()),
 					loggerFactory);
 
 				return await watchdog.RunAsync(false, arguments.ToArray(), cts.Token)

--- a/src/Tgstation.Server.Host.Watchdog/NoopSignalChecker.cs
+++ b/src/Tgstation.Server.Host.Watchdog/NoopSignalChecker.cs
@@ -2,18 +2,17 @@
 using System.Threading;
 using System.Threading.Tasks;
 
-using Tgstation.Server.Host.Watchdog;
-
-namespace Tgstation.Server.Host.Service
+namespace Tgstation.Server.Host.Watchdog
 {
 	/// <summary>
 	/// No-op <see cref="ISignalChecker"/>.
 	/// </summary>
-	sealed class NoopSignalChecker : ISignalChecker
+	public sealed class NoopSignalChecker : ISignalChecker
 	{
 		/// <inheritdoc />
 		public Task CheckSignals(Func<string, (int, Task)> startChild, CancellationToken cancellationToken)
 		{
+			ArgumentNullException.ThrowIfNull(startChild);
 			startChild(null);
 			return Task.CompletedTask;
 		}

--- a/src/Tgstation.Server.Host/Controllers/ConfigurationController.cs
+++ b/src/Tgstation.Server.Host/Controllers/ConfigurationController.cs
@@ -193,7 +193,7 @@ namespace Tgstation.Server.Host.Controllers
 							return new PaginatableResult<ConfigurationFileResponse>(
 								result
 									.AsQueryable()
-									.OrderBy(x => x.Path));
+									.OrderBy(x => x)); // ordering performed by IConfiguration
 						}
 						catch (NotImplementedException ex)
 						{

--- a/tests/Tgstation.Server.Host.Tests/Components/StaticFiles/TestConfiguration.cs
+++ b/tests/Tgstation.Server.Host.Tests/Components/StaticFiles/TestConfiguration.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Moq;
+
+using Tgstation.Server.Host.Configuration;
+using Tgstation.Server.Host.IO;
+using Tgstation.Server.Host.System;
+using Tgstation.Server.Host.Transfer;
+
+namespace Tgstation.Server.Host.Components.StaticFiles.Tests
+{
+	[TestClass]
+	public sealed class TestConfiguration
+	{
+		/// <summary>
+		/// Regression test for https://github.com/tgstation/tgstation-server/issues/1617.
+		/// </summary>
+		[TestMethod]
+		public async Task TestListOrdering()
+		{
+			using var loggerFactory = LoggerFactory.Create(builder =>
+			{
+				builder.AddConsole();
+				builder.SetMinimumLevel(LogLevel.Trace);
+			});
+
+			var tempPath = Path.GetTempFileName();
+			File.Delete(tempPath);
+			var ioManager = new ResolvingIOManager(new DefaultIOManager(), tempPath);
+			await ioManager.CreateDirectory(".", CancellationToken.None);
+			try
+			{
+				await ioManager.WriteAllBytes("a.txt", Array.Empty<byte>(), CancellationToken.None);
+				await ioManager.WriteAllBytes("c.txt", Array.Empty<byte>(), CancellationToken.None);
+				await ioManager.WriteAllBytes("d.txt", Array.Empty<byte>(), CancellationToken.None);
+				await ioManager.CreateDirectory("a", CancellationToken.None);
+				await ioManager.CreateDirectory("c", CancellationToken.None);
+				await ioManager.CreateDirectory("d", CancellationToken.None);
+
+				var configuration = new Configuration(
+					ioManager,
+					new SynchronousIOManager(),
+					Mock.Of<ISymlinkFactory>(),
+					Mock.Of<IProcessExecutor>(),
+					Mock.Of<IPostWriteHandler>(),
+					Mock.Of<IPlatformIdentifier>(),
+					Mock.Of<IFileTransferTicketProvider>(),
+					loggerFactory.CreateLogger<Configuration>(),
+					new GeneralConfiguration(),
+					new SessionConfiguration());
+
+				await configuration.StartAsync(CancellationToken.None);
+
+				var listResponse = await configuration.ListDirectory(".", null, CancellationToken.None);
+				Assert.AreEqual(9, listResponse.Count);
+				Assert.AreEqual("a", listResponse[0].Path[2..]);
+				Assert.AreEqual("c", listResponse[1].Path[2..]);
+				Assert.AreEqual("CodeModifications", listResponse[2].Path[2..]);
+				Assert.AreEqual("d", listResponse[3].Path[2..]);
+				Assert.AreEqual("EventScripts", listResponse[4].Path[2..]);
+				Assert.AreEqual("GameStaticFiles", listResponse[5].Path[2..]);
+				Assert.AreEqual("a.txt", listResponse[6].Path[2..]);
+				Assert.AreEqual("c.txt", listResponse[7].Path[2..]);
+				Assert.AreEqual("d.txt", listResponse[8].Path[2..]);
+
+				await ioManager.CreateDirectory("GameStaticFiles/config/title_screens", CancellationToken.None);
+				await ioManager.CreateDirectory("GameStaticFiles/config/title_music", CancellationToken.None);
+				await ioManager.WriteAllBytes("GameStaticFiles/config/word_filter.toml", Array.Empty<byte>(), CancellationToken.None);
+				await ioManager.WriteAllBytes("GameStaticFiles/config/whitelist.txt", Array.Empty<byte>(), CancellationToken.None);
+				await ioManager.WriteAllBytes("GameStaticFiles/config/unbuyableshuttles.txt", Array.Empty<byte>(), CancellationToken.None);
+				await ioManager.WriteAllBytes("GameStaticFiles/config/spaceruinblacklist.txt", Array.Empty<byte>(), CancellationToken.None);
+
+				listResponse = await configuration.ListDirectory("GameStaticFiles/config", null, CancellationToken.None);
+				var substringStart = "GameStaticFiles/config".Length + 1;
+				Assert.AreEqual(6, listResponse.Count);
+				Assert.AreEqual("title_music", listResponse[0].Path[substringStart..]);
+				Assert.AreEqual("title_screens", listResponse[1].Path[substringStart..]);
+				Assert.AreEqual("spaceruinblacklist.txt", listResponse[2].Path[substringStart..]);
+				Assert.AreEqual("unbuyableshuttles.txt", listResponse[3].Path[substringStart..]);
+				Assert.AreEqual("whitelist.txt", listResponse[4].Path[substringStart..]);
+				Assert.AreEqual("word_filter.toml", listResponse[5].Path[substringStart..]);
+			}
+			finally
+			{
+				await ioManager.DeleteDirectory(tempPath, CancellationToken.None);
+			}
+		}
+	}
+}

--- a/tests/Tgstation.Server.Tests/Live/Instance/ByondTest.cs
+++ b/tests/Tgstation.Server.Tests/Live/Instance/ByondTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -58,7 +59,23 @@ namespace Tgstation.Server.Tests.Live.Instance
 			using var reader = new StreamReader(stream, Encoding.UTF8, false, -1, true);
 			var text = await reader.ReadToEndAsync();
 			var splits = text.Split('\n', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
-			return edgeVersion = Version.Parse(splits.Last());
+
+			var targetVersion = splits.Last();
+
+			var missingVersionMap = new PlatformIdentifier().IsWindows
+				? new Dictionary<string, string>()
+				{
+				}
+				// linux map also needs updating in CI
+				: new Dictionary<string, string>()
+				{
+					{ "515.1612", "515.1611" }
+				};
+
+			if (missingVersionMap.TryGetValue(targetVersion, out var remappedVersion))
+				targetVersion = remappedVersion;
+
+			return edgeVersion = Version.Parse(targetVersion);
 		}
 
 		async Task RunPartOne(CancellationToken cancellationToken)


### PR DESCRIPTION
:cl: HTTP API
Fix directories being intermingled with files in `/Configuration/List` responses. They now come first.
/:cl:

:cl: Host Watchdog
Fixed the console runner not working on Windows.
/:cl:
