### PR TITLE
Add deployment stage awareness to Discord embeds

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -5,10 +5,10 @@
   <PropertyGroup>
     <TgsCoreVersion>5.14.0</TgsCoreVersion>
     <TgsConfigVersion>4.7.1</TgsConfigVersion>
-    <TgsApiVersion>9.11.0</TgsApiVersion>
+    <TgsApiVersion>9.11.1</TgsApiVersion>
     <TgsCommonLibraryVersion>6.0.0</TgsCommonLibraryVersion>
-    <TgsApiLibraryVersion>11.0.0</TgsApiLibraryVersion>
-    <TgsClientVersion>12.0.0</TgsClientVersion>
+    <TgsApiLibraryVersion>11.0.1</TgsApiLibraryVersion>
+    <TgsClientVersion>12.0.1</TgsClientVersion>
     <TgsDmapiVersion>6.5.2</TgsDmapiVersion>
     <TgsInteropVersion>5.6.1</TgsInteropVersion>
     <TgsHostWatchdogVersion>1.4.0</TgsHostWatchdogVersion>

--- a/src/Tgstation.Server.Api/Models/ErrorCode.cs
+++ b/src/Tgstation.Server.Api/Models/ErrorCode.cs
@@ -486,7 +486,7 @@ namespace Tgstation.Server.Api.Models
 		DreamDaemonPortInUse,
 
 		/// <summary>
-		/// Failed to post GitHub comments, send chat message, or send TGS event.
+		/// Failed to post GitHub comments, or send TGS event.
 		/// </summary>
 		[Description("The deployment succeeded but one or more notification events failed!")]
 		PostDeployFailure,

--- a/src/Tgstation.Server.Host/Components/Chat/IChatManager.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/IChatManager.cs
@@ -66,8 +66,8 @@ namespace Tgstation.Server.Host.Components.Chat
 		/// <param name="gitHubOwner">The repository GitHub owner, if any.</param>
 		/// <param name="gitHubRepo">The repository GitHub name, if any.</param>
 		/// <param name="localCommitPushed"><see langword="true"/> if the local deployment commit was pushed to the remote repository.</param>
-		/// <returns>An <see cref="Action{T1, T2}"/> to call to update the message at the deployment's conclusion. Parameters: Error message if any, DreamMaker output if any.</returns>
-		Action<string, string> QueueDeploymentMessage(
+		/// <returns>A <see cref="Func{T1, T2, TResult}"/> to call to update the message at the deployment's conclusion. Parameters: Error message if any, DreamMaker output if any. Returns an <see cref="Action"/> to call to mark the deployment as active/inactive. Parameter: If the deployment is being activated or inactivated.</returns>
+		Func<string, string, Action<bool>> QueueDeploymentMessage(
 			Models.RevisionInformation revisionInformation,
 			Version byondVersion,
 			DateTimeOffset? estimatedCompletionTime,

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/IProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/IProvider.cs
@@ -90,8 +90,8 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		/// <param name="channelId">The <see cref="ChannelRepresentation.RealId"/> to send to.</param>
 		/// <param name="localCommitPushed"><see langword="true"/> if the local deployment commit was pushed to the remote repository.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
-		/// <returns>A <see cref="Task{TResult}"/> resulting in a <see cref="Func{T1, T2, TResult}"/> to call to update the message at the deployment's conclusion. Parameters: Error message if any, DreamMaker output if any.</returns>
-		Task<Func<string, string, Task>> SendUpdateMessage(
+		/// <returns>A <see cref="Task{TResult}"/> resulting in a <see cref="Func{T1, T2, TResult}"/> to call to update the message at the deployment's conclusion. Parameters: Error message if any, DreamMaker output if any. Returns another callback which should be called to mark the deployment as active.</returns>
+		Task<Func<string, string, Task<Func<bool, Task>>>> SendUpdateMessage(
 			RevisionInformation revisionInformation,
 			Version byondVersion,
 			DateTimeOffset? estimatedCompletionTime,

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/IrcProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/IrcProvider.cs
@@ -218,7 +218,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		}
 
 		/// <inheritdoc />
-		public override async Task<Func<string, string, Task>> SendUpdateMessage(
+		public override async Task<Func<string, string, Task<Func<bool, Task>>>> SendUpdateMessage(
 			Models.RevisionInformation revisionInformation,
 			Version byondVersion,
 			DateTimeOffset? estimatedCompletionTime,
@@ -281,14 +281,19 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 				channelId,
 				cancellationToken);
 
-			return (errorMessage, dreamMakerOutput) => SendMessage(
-				null,
-				new MessageContent
-				{
-					Text = $"DM: Deployment {(errorMessage == null ? "complete" : "failed")}!",
-				},
-				channelId,
-				cancellationToken);
+			return async (errorMessage, dreamMakerOutput) =>
+			{
+				await SendMessage(
+					null,
+					new MessageContent
+					{
+						Text = $"DM: Deployment {(errorMessage == null ? "complete" : "failed")}!",
+					},
+					channelId,
+					cancellationToken);
+
+				return active => Task.CompletedTask;
+			};
 		}
 
 		/// <inheritdoc />

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/Provider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/Provider.cs
@@ -181,7 +181,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		public abstract Task SendMessage(Message replyTo, MessageContent message, ulong channelId, CancellationToken cancellationToken);
 
 		/// <inheritdoc />
-		public abstract Task<Func<string, string, Task>> SendUpdateMessage(
+		public abstract Task<Func<string, string, Task<Func<bool, Task>>>> SendUpdateMessage(
 			RevisionInformation revisionInformation,
 			Version byondVersion,
 			DateTimeOffset? estimatedCompletionTime,

--- a/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
@@ -117,7 +117,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 		/// <summary>
 		/// The active callback from <see cref="IChatManager.QueueDeploymentMessage"/>.
 		/// </summary>
-		Action<string, string> currentChatCallback;
+		Func<string, string, Action<bool>> currentChatCallback;
 
 		/// <summary>
 		/// Cached for <see cref="currentChatCallback"/>.
@@ -355,7 +355,8 @@ namespace Tgstation.Server.Host.Components.Deployment
 							logger.LogTrace("Created CompileJob {compileJobId}", compileJob.Id);
 							try
 							{
-								await compileJobConsumer.LoadCompileJob(compileJob, cancellationToken);
+								var chatNotificationAction = currentChatCallback(null, compileJob.Output);
+								await compileJobConsumer.LoadCompileJob(compileJob, chatNotificationAction, cancellationToken);
 							}
 							catch
 							{
@@ -389,8 +390,6 @@ namespace Tgstation.Server.Host.Components.Deployment
 
 				try
 				{
-					currentChatCallback(null, compileJob.Output);
-
 					await Task.WhenAll(commentsTask, eventTask);
 				}
 				catch (Exception ex)

--- a/src/Tgstation.Server.Host/Components/Deployment/ICompileJobSink.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/ICompileJobSink.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Tgstation.Server.Host.Models;
@@ -14,8 +15,9 @@ namespace Tgstation.Server.Host.Components.Deployment
 		/// Load a new <paramref name="job"/> into the <see cref="ICompileJobSink"/>.
 		/// </summary>
 		/// <param name="job">The <see cref="CompileJob"/> to load.</param>
+		/// <param name="activationAction">An <see cref="Action{T1}"/> to be called when the <see cref="CompileJob"/> becomes active or is discarded with <see langword="true"/> or <see langword="false"/> respectively.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task"/> representing the running operation.</returns>
-		Task LoadCompileJob(CompileJob job, CancellationToken cancellationToken);
+		Task LoadCompileJob(CompileJob job, Action<bool> activationAction, CancellationToken cancellationToken);
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Deployment/Remote/GitLabRemoteDeploymentManager.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/Remote/GitLabRemoteDeploymentManager.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -25,8 +26,12 @@ namespace Tgstation.Server.Host.Components.Deployment.Remote
 		/// </summary>
 		/// <param name="logger">The <see cref="ILogger"/> for the <see cref="BaseRemoteDeploymentManager"/>.</param>
 		/// <param name="metadata">The <see cref="Api.Models.Instance"/> for the <see cref="BaseRemoteDeploymentManager"/>.</param>
-		public GitLabRemoteDeploymentManager(ILogger<GitLabRemoteDeploymentManager> logger, Api.Models.Instance metadata)
-			: base(logger, metadata)
+		/// <param name="activationCallbacks">The activation callback <see cref="ConcurrentDictionary{TKey, TValue}"/> for the <see cref="BaseRemoteDeploymentManager"/>.</param>
+		public GitLabRemoteDeploymentManager(
+			ILogger<GitLabRemoteDeploymentManager> logger,
+			Api.Models.Instance metadata,
+			ConcurrentDictionary<long, Action<bool>> activationCallbacks)
+			: base(logger, metadata, activationCallbacks)
 		{
 		}
 
@@ -95,28 +100,27 @@ namespace Tgstation.Server.Host.Components.Deployment.Remote
 		}
 
 		/// <inheritdoc />
-		public override Task ApplyDeployment(
-			CompileJob compileJob,
-			CompileJob oldCompileJob,
-			CancellationToken cancellationToken) => Task.CompletedTask;
-
-		/// <inheritdoc />
 		public override Task FailDeployment(
 			CompileJob compileJob,
 			string errorMessage,
 			CancellationToken cancellationToken) => Task.CompletedTask;
 
 		/// <inheritdoc />
-		public override Task MarkInactive(CompileJob compileJob, CancellationToken cancellationToken) => Task.CompletedTask;
-
-		/// <inheritdoc />
-		public override Task StageDeployment(CompileJob compileJob, CancellationToken cancellationToken) => Task.CompletedTask;
-
-		/// <inheritdoc />
 		public override Task StartDeployment(
 			Api.Models.Internal.IGitRemoteInformation remoteInformation,
 			CompileJob compileJob,
 			CancellationToken cancellationToken) => Task.CompletedTask;
+
+		/// <inheritdoc />
+		protected override Task ApplyDeploymentImpl(
+			CompileJob compileJob,
+			CancellationToken cancellationToken) => Task.CompletedTask;
+
+		/// <inheritdoc />
+		protected override Task StageDeploymentImpl(CompileJob compileJob, CancellationToken cancellationToken) => Task.CompletedTask;
+
+		/// <inheritdoc />
+		protected override Task MarkInactiveImpl(CompileJob compileJob, CancellationToken cancellationToken) => Task.CompletedTask;
 
 		/// <inheritdoc />
 		protected override async Task CommentOnTestMergeSource(

--- a/src/Tgstation.Server.Host/Components/Deployment/Remote/IRemoteDeploymentManager.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/Remote/IRemoteDeploymentManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -28,20 +29,21 @@ namespace Tgstation.Server.Host.Components.Deployment.Remote
 		/// Stage a given <paramref name="compileJob"/>'s deployment.
 		/// </summary>
 		/// <param name="compileJob">The staged <see cref="CompileJob"/>.</param>
+		/// <param name="activationCallback">An optional <see cref="Action{T1}"/> to be called when the <see cref="CompileJob"/> becomes active or is discarded with <see langword="true"/> or <see langword="false"/> respectively.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task"/> representing the running operation.</returns>
 		Task StageDeployment(
 			CompileJob compileJob,
+			Action<bool> activationCallback,
 			CancellationToken cancellationToken);
 
 		/// <summary>
 		/// Stage a given <paramref name="compileJob"/>'s deployment.
 		/// </summary>
 		/// <param name="compileJob">The <see cref="CompileJob"/> being applied.</param>
-		/// <param name="oldCompileJob">The currently active <see cref="CompileJob"/>, if any.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task"/> representing the running operation.</returns>
-		Task ApplyDeployment(CompileJob compileJob, CompileJob oldCompileJob, CancellationToken cancellationToken);
+		Task ApplyDeployment(CompileJob compileJob, CancellationToken cancellationToken);
 
 		/// <summary>
 		/// Fail a deployment for a given <paramref name="compileJob"/>.

--- a/src/Tgstation.Server.Host/Components/Deployment/Remote/IRemoteDeploymentManagerFactory.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/Remote/IRemoteDeploymentManagerFactory.cs
@@ -1,4 +1,6 @@
-﻿using Tgstation.Server.Api.Models;
+﻿using System.Collections.Generic;
+
+using Tgstation.Server.Api.Models;
 
 namespace Tgstation.Server.Host.Components.Deployment.Remote
 {
@@ -22,5 +24,11 @@ namespace Tgstation.Server.Host.Components.Deployment.Remote
 		/// <param name="compileJob">The <see cref="Models.CompileJob"/> containing the <see cref="Api.Models.Response.CompileJobResponse.RepositoryOrigin"/> to use.</param>
 		/// <returns>A new <see cref="IRemoteDeploymentManager"/>.</returns>
 		IRemoteDeploymentManager CreateRemoteDeploymentManager(Api.Models.Instance metadata, Models.CompileJob compileJob);
+
+		/// <summary>
+		/// Cause the <see cref="IRemoteDeploymentManagerFactory"/> to drop any local state is has for the given <paramref name="compileJobsIds"/>.
+		/// </summary>
+		/// <param name="compileJobsIds">An <see cref="IEnumerable{T}"/> of <see cref="Models.CompileJob"/> <see cref="EntityId.Id"/>s.</param>
+		void ForgetLocalStateForCompileJobs(IEnumerable<long> compileJobsIds);
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Deployment/Remote/NoOpRemoteDeploymentManager.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/Remote/NoOpRemoteDeploymentManager.cs
@@ -1,8 +1,12 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Microsoft.Extensions.Logging;
+
+using Tgstation.Server.Api.Models.Internal;
 using Tgstation.Server.Host.Components.Repository;
 using Tgstation.Server.Host.Models;
 
@@ -11,48 +15,66 @@ namespace Tgstation.Server.Host.Components.Deployment.Remote
 	/// <summary>
 	/// No-op implementation of <see cref="IRemoteDeploymentManager"/>.
 	/// </summary>
-	sealed class NoOpRemoteDeploymentManager : IRemoteDeploymentManager
+	sealed class NoOpRemoteDeploymentManager : BaseRemoteDeploymentManager
 	{
-		/// <inheritdoc />
-		public Task ApplyDeployment(
-			CompileJob compileJob,
-			CompileJob oldCompileJob,
-			CancellationToken cancellationToken) => Task.CompletedTask;
+		/// <summary>
+		/// Initializes a new instance of the <see cref="NoOpRemoteDeploymentManager"/> class.
+		/// </summary>
+		/// <param name="logger">The value of <see cref="BaseRemoteDeploymentManager.Logger"/>.</param>
+		/// <param name="metadata">The value of <see cref="BaseRemoteDeploymentManager.Metadata"/>.</param>
+		/// <param name="activationCallbacks">The activation callback <see cref="ConcurrentDictionary{TKey, TValue}"/> for the <see cref="BaseRemoteDeploymentManager"/>.</param>
+		public NoOpRemoteDeploymentManager(
+			ILogger<NoOpRemoteDeploymentManager> logger,
+			Api.Models.Instance metadata,
+			ConcurrentDictionary<long, Action<bool>> activationCallbacks)
+			: base(logger, metadata, activationCallbacks)
+		{
+		}
 
 		/// <inheritdoc />
-		public Task FailDeployment(
-			CompileJob compileJob,
-			string errorMessage,
-			CancellationToken cancellationToken) => Task.CompletedTask;
+		public override Task FailDeployment(Models.CompileJob compileJob, string errorMessage, CancellationToken cancellationToken)
+		{
+			throw new NotImplementedException();
+		}
 
 		/// <inheritdoc />
-		public Task MarkInactive(
-			CompileJob compileJob,
-			CancellationToken cancellationToken) => Task.CompletedTask;
+		public override Task<IReadOnlyCollection<TestMerge>> RemoveMergedTestMerges(IRepository repository, Models.RepositorySettings repositorySettings, Models.RevisionInformation revisionInformation, CancellationToken cancellationToken)
+			=> Task.FromResult<IReadOnlyCollection<TestMerge>>(Array.Empty<TestMerge>());
 
 		/// <inheritdoc />
-		public Task PostDeploymentComments(
-			CompileJob compileJob,
-			RevisionInformation previousRevisionInformation,
-			RepositorySettings repositorySettings,
-			string repoOwner,
-			string repoName,
-			CancellationToken cancellationToken) => Task.CompletedTask;
+		public override Task StartDeployment(IGitRemoteInformation remoteInformation, Models.CompileJob compileJob, CancellationToken cancellationToken)
+			=> Task.CompletedTask;
 
 		/// <inheritdoc />
-		public Task<IReadOnlyCollection<TestMerge>> RemoveMergedTestMerges(
-			IRepository repository,
-			RepositorySettings repositorySettings,
-			RevisionInformation revisionInformation,
-			CancellationToken cancellationToken) => Task.FromResult<IReadOnlyCollection<TestMerge>>(Array.Empty<TestMerge>());
+		protected override Task ApplyDeploymentImpl(Models.CompileJob compileJob, CancellationToken cancellationToken) => Task.CompletedTask;
 
 		/// <inheritdoc />
-		public Task StageDeployment(CompileJob compileJob, CancellationToken cancellationToken) => Task.CompletedTask;
+		protected override Task CommentOnTestMergeSource(
+			Models.RepositorySettings repositorySettings,
+			string remoteRepositoryOwner,
+			string remoteRepositoryName,
+			string comment,
+			int testMergeNumber,
+			CancellationToken cancellationToken)
+			=> Task.CompletedTask;
 
 		/// <inheritdoc />
-		public Task StartDeployment(
-			Api.Models.Internal.IGitRemoteInformation remoteInformation,
-			CompileJob compileJob,
-			CancellationToken cancellationToken) => Task.CompletedTask;
+		protected override string FormatTestMerge(
+			Models.RepositorySettings repositorySettings,
+			Models.CompileJob compileJob,
+			TestMerge testMerge,
+			string remoteRepositoryOwner,
+			string remoteRepositoryName,
+			bool updated)
+			=> String.Empty;
+
+		/// <inheritdoc />
+		protected override Task MarkInactiveImpl(Models.CompileJob compileJob, CancellationToken cancellationToken)
+		{
+			throw new NotImplementedException();
+		}
+
+		/// <inheritdoc />
+		protected override Task StageDeploymentImpl(Models.CompileJob compileJob, CancellationToken cancellationToken) => Task.CompletedTask;
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
@@ -680,7 +680,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 
 			try
 			{
-				await remoteDeploymentManager.ApplyDeployment(newCompileJob, ActiveCompileJob, cancellationToken);
+				await remoteDeploymentManager.ApplyDeployment(newCompileJob, cancellationToken);
 			}
 			catch (Exception ex)
 			{

--- a/tests/Tgstation.Server.Tests/Live/DummyChatProvider.cs
+++ b/tests/Tgstation.Server.Tests/Live/DummyChatProvider.cs
@@ -100,7 +100,7 @@ namespace Tgstation.Server.Tests.Live
 			return Task.CompletedTask;
 		}
 
-		public override Task<Func<string, string, Task>> SendUpdateMessage(RevisionInformation revisionInformation, Version byondVersion, DateTimeOffset? estimatedCompletionTime, string gitHubOwner, string gitHubRepo, ulong channelId, bool localCommitPushed, CancellationToken cancellationToken)
+		public override Task<Func<string, string, Task<Func<bool, Task>>>> SendUpdateMessage(RevisionInformation revisionInformation, Version byondVersion, DateTimeOffset? estimatedCompletionTime, string gitHubOwner, string gitHubRepo, ulong channelId, bool localCommitPushed, CancellationToken cancellationToken)
 		{
 			ArgumentNullException.ThrowIfNull(revisionInformation);
 			ArgumentNullException.ThrowIfNull(byondVersion);
@@ -115,7 +115,7 @@ namespace Tgstation.Server.Tests.Live
 			if (random.Next(0, 100) > 70)
 				throw new Exception("Random SendUpdateMessage failure!"); */
 
-			return Task.FromResult<Func<string, string, Task>>((_, _) =>
+			return Task.FromResult<Func<string, string, Task<Func<bool, Task>>>>((_, _) =>
 			{
 				cancellationToken.ThrowIfCancellationRequested();
 
@@ -123,7 +123,7 @@ namespace Tgstation.Server.Tests.Live
 				if (random.Next(0, 100) > 70)
 					throw new Exception("Random SendUpdateMessage failure!"); */
 
-				return Task.CompletedTask;
+				return Task.FromResult<Func<bool, Task>>(_ => Task.CompletedTask);
 			});
 		}
 

--- a/tgstation-server.sln
+++ b/tgstation-server.sln
@@ -10,7 +10,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 		.gitignore = .gitignore
 		LICENSE = LICENSE
-		omnisharp.json = omnisharp.json
 		README.md = README.md
 		SECURITY.md = SECURITY.md
 	EndProjectSection


### PR DESCRIPTION
:cl: HTTP API
ErrorCode 79 no longer occurs on failing to send a chat message. Will be logged as an error instead.
/:cl:

:cl:
Fixed GitHub environments staging not occurring if an instance was started with no pre-existing compile job.
Discord deployment embeds with now be coloured blue when pending, green when active, and grey when inactive. Restarting TGS will cause it to not update existing embeds.
/:cl:

Closes #1581 
![image](https://github.com/tgstation/tgstation-server/assets/8171642/25bf0a7a-95a5-42a6-8af4-ed20c70dee02)
![image](https://github.com/tgstation/tgstation-server/assets/8171642/0a8601ab-b477-41b6-8a2d-c86af7f52356)
![image](https://github.com/tgstation/tgstation-server/assets/8171642/871d8150-a1de-44cd-9f95-a36fae4fb45d)
