### PR TITLE
v5.13.7: Fix config listing 500 error

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>5.13.6</TgsCoreVersion>
+    <TgsCoreVersion>5.13.7</TgsCoreVersion>
     <TgsConfigVersion>4.7.1</TgsConfigVersion>
     <TgsApiVersion>9.11.0</TgsApiVersion>
     <TgsCommonLibraryVersion>6.0.0</TgsCommonLibraryVersion>

--- a/src/Tgstation.Server.Host/Components/StaticFiles/IConfiguration.cs
+++ b/src/Tgstation.Server.Host/Components/StaticFiles/IConfiguration.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -38,8 +38,8 @@ namespace Tgstation.Server.Host.Components.StaticFiles
 		/// <param name="configurationRelativePath">The relative path in the Configuration directory.</param>
 		/// <param name="systemIdentity">The <see cref="ISystemIdentity"/> for the operation. If <see langword="null"/>, the operation will be performed as the user of the <see cref="Core.Application"/>.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
-		/// <returns>A <see cref="Task{TResult}"/> resulting in the <see cref="ConfigurationFileResponse"/>s for the items in the directory. <see cref="FileTicketResponse.FileTicket"/> and <see cref="IConfigurationFile.LastReadHash"/> will both be <see langword="null"/>. <see langword="null"/> will be returned if the operation failed due to access contention.</returns>
-		Task<IReadOnlyList<ConfigurationFileResponse>> ListDirectory(string configurationRelativePath, ISystemIdentity systemIdentity, CancellationToken cancellationToken);
+		/// <returns>A <see cref="Task{TResult}"/> resulting in an <see cref="IOrderedQueryable{T}"/> of the <see cref="ConfigurationFileResponse"/>s for the items in the directory. <see cref="FileTicketResponse.FileTicket"/> and <see cref="IConfigurationFile.LastReadHash"/> will both be <see langword="null"/>. <see langword="null"/> will be returned if the operation failed due to access contention.</returns>
+		Task<IOrderedQueryable<ConfigurationFileResponse>> ListDirectory(string configurationRelativePath, ISystemIdentity systemIdentity, CancellationToken cancellationToken);
 
 		/// <summary>
 		/// Reads a given <paramref name="configurationRelativePath"/>.

--- a/src/Tgstation.Server.Host/Controllers/ConfigurationController.cs
+++ b/src/Tgstation.Server.Host/Controllers/ConfigurationController.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -190,10 +189,7 @@ namespace Tgstation.Server.Host.Controllers
 								return new PaginatableResult<ConfigurationFileResponse>(
 									Conflict(new ErrorMessageResponse(ErrorCode.ConfigurationContendedAccess)));
 
-							return new PaginatableResult<ConfigurationFileResponse>(
-								result
-									.AsQueryable()
-									.OrderBy(x => x)); // ordering performed by IConfiguration
+							return new PaginatableResult<ConfigurationFileResponse>(result);
 						}
 						catch (NotImplementedException ex)
 						{

--- a/tests/Tgstation.Server.Host.Tests/Components/StaticFiles/TestConfiguration.cs
+++ b/tests/Tgstation.Server.Host.Tests/Components/StaticFiles/TestConfiguration.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -57,7 +58,7 @@ namespace Tgstation.Server.Host.Components.StaticFiles.Tests
 
 				await configuration.StartAsync(CancellationToken.None);
 
-				var listResponse = await configuration.ListDirectory(".", null, CancellationToken.None);
+				var listResponse = (await configuration.ListDirectory(".", null, CancellationToken.None)).ToList();
 				Assert.AreEqual(9, listResponse.Count);
 				Assert.AreEqual("a", listResponse[0].Path[2..]);
 				Assert.AreEqual("c", listResponse[1].Path[2..]);
@@ -76,7 +77,7 @@ namespace Tgstation.Server.Host.Components.StaticFiles.Tests
 				await ioManager.WriteAllBytes("GameStaticFiles/config/unbuyableshuttles.txt", Array.Empty<byte>(), CancellationToken.None);
 				await ioManager.WriteAllBytes("GameStaticFiles/config/spaceruinblacklist.txt", Array.Empty<byte>(), CancellationToken.None);
 
-				listResponse = await configuration.ListDirectory("GameStaticFiles/config", null, CancellationToken.None);
+				listResponse = (await configuration.ListDirectory("GameStaticFiles/config", null, CancellationToken.None)).ToList();
 				var substringStart = "GameStaticFiles/config".Length + 1;
 				Assert.AreEqual(6, listResponse.Count);
 				Assert.AreEqual("title_music", listResponse[0].Path[substringStart..]);


### PR DESCRIPTION
:cl:
Fixed a 500 error when listing `/Configuration` directories.
/:cl: