### PR TITLE
Deprecation notice for based meme removal

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -5,9 +5,9 @@
   <PropertyGroup>
     <TgsCoreVersion>5.14.0</TgsCoreVersion>
     <TgsConfigVersion>4.7.1</TgsConfigVersion>
-    <TgsApiVersion>9.11.1</TgsApiVersion>
+    <TgsApiVersion>9.12.0</TgsApiVersion>
     <TgsCommonLibraryVersion>6.0.0</TgsCommonLibraryVersion>
-    <TgsApiLibraryVersion>11.0.1</TgsApiLibraryVersion>
+    <TgsApiLibraryVersion>11.1.0</TgsApiLibraryVersion>
     <TgsClientVersion>12.0.1</TgsClientVersion>
     <TgsDmapiVersion>6.5.2</TgsDmapiVersion>
     <TgsInteropVersion>5.6.1</TgsInteropVersion>

--- a/src/Tgstation.Server.Api/Models/DiscordConnectionStringBuilder.cs
+++ b/src/Tgstation.Server.Api/Models/DiscordConnectionStringBuilder.cs
@@ -22,6 +22,7 @@ namespace Tgstation.Server.Api.Models
 		/// <summary>
 		/// <see cref="bool"/> to enable based mode. Will auto reply with a youtube link to a video that says "based on the hardware that's installed in it" to anyone saying 'based on what?' case-insensitive.
 		/// </summary>
+		[Obsolete("Will be removed in next major TGS version")]
 		public bool BasedMeme { get; set; }
 
 		/// <summary>
@@ -39,7 +40,6 @@ namespace Tgstation.Server.Api.Models
 		/// </summary>
 		public DiscordConnectionStringBuilder()
 		{
-			BasedMeme = true;
 		}
 
 		/// <summary>
@@ -60,9 +60,10 @@ namespace Tgstation.Server.Api.Models
 			DMOutputDisplay = dMOutputDisplayType;
 
 			if (splits.Length > 2 && Int32.TryParse(splits[2], out Int32 basedMeme))
+#pragma warning disable CS0618 // Type or member is obsolete
 				BasedMeme = Convert.ToBoolean(basedMeme);
 			else
-				BasedMeme = true; // oranges said this needs to be true by default :pensive:
+				BasedMeme = false; // oranges said this needs to be true by default :pensive:
 
 			if (splits.Length > 3 && Int32.TryParse(splits[3], out Int32 branding))
 				DeploymentBranding = Convert.ToBoolean(branding);
@@ -72,5 +73,6 @@ namespace Tgstation.Server.Api.Models
 
 		/// <inheritdoc />
 		public override string ToString() => $"{BotToken};{(int)DMOutputDisplay};{Convert.ToInt32(BasedMeme)};{Convert.ToInt32(DeploymentBranding)}";
+#pragma warning restore CS0618 // Type or member is obsolete
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordProvider.cs
@@ -199,7 +199,9 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 
 			var csb = new DiscordConnectionStringBuilder(chatBot.ConnectionString);
 			var botToken = csb.BotToken;
+#pragma warning disable CS0618 // Type or member is obsolete
 			basedMeme = csb.BasedMeme;
+#pragma warning restore CS0618 // Type or member is obsolete
 			outputDisplayType = csb.DMOutputDisplay;
 			deploymentBranding = csb.DeploymentBranding;
 

--- a/tests/Tgstation.Server.Tests/Live/Instance/ChatTest.cs
+++ b/tests/Tgstation.Server.Tests/Live/Instance/ChatTest.cs
@@ -149,7 +149,6 @@ namespace Tgstation.Server.Tests.Live.Instance
 				// needs to just be valid
 				connectionString = new DiscordConnectionStringBuilder
 				{
-					BasedMeme = true,
 					BotToken = "some_token",
 					DeploymentBranding = true,
 					DMOutputDisplay = DiscordDMOutputDisplayType.Never,

--- a/tests/Tgstation.Server.Tests/Live/Instance/InstanceTest.cs
+++ b/tests/Tgstation.Server.Tests/Live/Instance/InstanceTest.cs
@@ -97,7 +97,6 @@ namespace Tgstation.Server.Tests.Live.Instance
 				// needs to just be valid
 				connectionString = new DiscordConnectionStringBuilder
 				{
-					BasedMeme = true,
 					BotToken = "some_token",
 					DeploymentBranding = true,
 					DMOutputDisplay = DiscordDMOutputDisplayType.Always,

--- a/tools/Tgstation.Server.Migrator.Comms/Program.cs
+++ b/tools/Tgstation.Server.Migrator.Comms/Program.cs
@@ -168,7 +168,6 @@ static class Program
 					var discordSetupInfo = new DiscordSetupInfo(providerInfo);
 					csb = new DiscordConnectionStringBuilder
 					{
-						BasedMeme = false,
 						DMOutputDisplay = DiscordDMOutputDisplayType.Always,
 						BotToken = discordSetupInfo.BotToken
 					};


### PR DESCRIPTION
:cl: HTTP API
The flag in Discord chat bot connection strings for the based meme is now deprecated and defaults to `0`.
/:cl:

See #1628 

Merging with `[APIDeploy]`