### PR TITLE
v5.15.1. Fix winget deployments

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -1508,6 +1508,12 @@ jobs:
         $tgsVersion = $versionXML.Project.PropertyGroup.TgsCoreVersion
         echo "TGS_VERSION=$tgsVersion" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
 
+    - name: Upload .msi
+      uses: actions/upload-artifact@v3
+      with:
+        name: packaging-windows-raw-msi
+        path: build/package/winget/Tgstation.Server.Host.Service.Wix/bin/x86/Release/en-US/tgstation-server.msi
+
     - name: Retrieve Server Service
       uses: actions/download-artifact@v3
       with:
@@ -1721,6 +1727,12 @@ jobs:
       run: |
         $Env:TGS_HOST_NO_WEBPANEL=true
         dotnet build -c Release tools/Tgstation.Server.ReleaseNotes
+
+    - name: Retrieve Server Service
+      uses: actions/download-artifact@v3
+      with:
+        name: packaging-windows-raw-msi
+        path: artifacts
 
     - name: Execute Push Script
       shell: powershell

--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>5.15.0</TgsCoreVersion>
+    <TgsCoreVersion>5.15.1</TgsCoreVersion>
     <TgsConfigVersion>4.7.1</TgsConfigVersion>
     <TgsApiVersion>9.12.0</TgsApiVersion>
     <TgsCommonLibraryVersion>6.0.1</TgsCommonLibraryVersion>

--- a/build/package/winget/push_manifest.ps1
+++ b/build/package/winget/push_manifest.ps1
@@ -15,6 +15,7 @@ try
 }
 
 $installerHash = Get-FileHash -Path "artifacts/tgstation-server-installer.exe" -ErrorAction Stop # SHA256 is the default
+$msiPath = [System.IO.Path]::Combine($pwd, "artifacts/tgstation-server.msi").Replace("/", "\");
 
 Push-Location build/package/winget
 try
@@ -24,7 +25,6 @@ try
     $devReleaseDate = '2023-06-24'
     $devProductCode = "{D24887FA-3228-4509-B5F3-4E07E349F278}"
 
-    $msiPath = [System.IO.Path]::Combine($pwd, "Tgstation.Server.Host.Service.Wix/bin/x86/Release/en-US/tgstation-server.msi").Replace("/", "\");
     Set-Location manifest
     Convert-Path -ErrorAction Stop -LiteralPath $msiPath
     $windowsInstaller = New-Object -ComObject WindowsInstaller.Installer


### PR DESCRIPTION
:cl:
This is a non-functional release due to 5.15.0's CD pipeline not being able to deploy to winget.
/:cl:

Merging with `[TGSDeploy]`. Intentionally not labeling as `Fix` to not raise urgency of debian package.

Fixes #1640