### PR TITLE
v5.15.1: Fix .msi upload during deployment

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -1512,7 +1512,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: packaging-windows-raw-msi
-        path: build/package/winget/Tgstation.Server.Host.Service.Wix/bin/x86/Release/en-US/tgstation-server.msi
+        path: build/package/winget/Tgstation.Server.Host.Service.Wix/bin/Release/en-US/tgstation-server.msi
 
     - name: Retrieve Server Service
       uses: actions/download-artifact@v3


### PR DESCRIPTION
cl in #1642. Again not adding `Fix` label` to prevent debian package priority from boosting