### PR TITLE
Release ValueTask converted client package

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -6,9 +6,9 @@
     <TgsCoreVersion>5.16.2</TgsCoreVersion>
     <TgsConfigVersion>4.7.1</TgsConfigVersion>
     <TgsApiVersion>9.12.0</TgsApiVersion>
-    <TgsCommonLibraryVersion>6.0.1</TgsCommonLibraryVersion>
+    <TgsCommonLibraryVersion>7.0.0</TgsCommonLibraryVersion>
     <TgsApiLibraryVersion>11.1.2</TgsApiLibraryVersion>
-    <TgsClientVersion>12.1.2</TgsClientVersion>
+    <TgsClientVersion>13.0.0</TgsClientVersion>
     <TgsDmapiVersion>6.5.3</TgsDmapiVersion>
     <TgsInteropVersion>5.6.1</TgsInteropVersion>
     <TgsHostWatchdogVersion>1.4.0</TgsHostWatchdogVersion>

--- a/src/Tgstation.Server.Client/Tgstation.Server.Client.csproj
+++ b/src/Tgstation.Server.Client/Tgstation.Server.Client.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Tgstation.Server.Api\Tgstation.Server.Api.csproj" />
+    <ProjectReference Include="..\Tgstation.Server.Common\Tgstation.Server.Common.csproj" /> <!-- Needed for explicit nuget versioning -->
   </ItemGroup>
 
 </Project>

--- a/tests/Tgstation.Server.Tests/Live/TestLiveServer.cs
+++ b/tests/Tgstation.Server.Tests/Live/TestLiveServer.cs
@@ -1027,7 +1027,7 @@ namespace Tgstation.Server.Tests.Live
 							if (postWriteHandler.NeedsPostWrite(src))
 								postWriteHandler.HandleWrite(dest);
 
-							return Task.CompletedTask;
+							return ValueTask.CompletedTask;
 						},
 						ioManager.ConcatPath(
 							localRepoPath,
@@ -1080,7 +1080,7 @@ namespace Tgstation.Server.Tests.Live
 					jobWaitTask = jobsTest.WaitForJob(repoResponse.ActiveJob, 300, false, null, cancellationToken);
 				}
 
-				await Task.WhenAll(jobWaitTask, ddUpdateTask, dmUpdateTask);
+				await Task.WhenAll(jobWaitTask, ddUpdateTask.AsTask(), dmUpdateTask.AsTask());
 
 				var depsBytesTask = ioManager.ReadAllBytes(
 					ioManager.ConcatPath(repoPath, "dependencies.sh"),
@@ -1093,7 +1093,7 @@ namespace Tgstation.Server.Tests.Live
 						if (postWriteHandler.NeedsPostWrite(src))
 							postWriteHandler.HandleWrite(dest);
 
-						return Task.CompletedTask;
+						return ValueTask.CompletedTask;
 					},
 					ioManager.ConcatPath(
 						repoPath,
@@ -1120,7 +1120,7 @@ namespace Tgstation.Server.Tests.Live
 
 				var byondJobTask = jobsTest.WaitForJob(byondJob.InstallJob, 60, false, null, cancellationToken);
 
-				await Task.WhenAll(scriptsCopyTask, byondJobTask);
+				await Task.WhenAll(scriptsCopyTask.AsTask(), byondJobTask);
 
 				var compileJob = await instanceClient.DreamMaker.Compile(cancellationToken);
 


### PR DESCRIPTION
Also fix build errors caused by the last master merge

:cl: Nuget: Client
Replaced most usages of `Task` with `ValueTask`.
/:cl:

:cl: Nuget: Common
Added `ValueTask` `WhenAll` helpers.
Changed return type of `CachedResponseStream.Create` from `Task<T>` to `ValueTask<T>`
/:cl: