### PR TITLE
Fix that weirdass DMAPI bug relating to `del(world)`

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -9,7 +9,7 @@
     <TgsCommonLibraryVersion>7.0.0</TgsCommonLibraryVersion>
     <TgsApiLibraryVersion>11.1.2</TgsApiLibraryVersion>
     <TgsClientVersion>13.0.0</TgsClientVersion>
-    <TgsDmapiVersion>6.6.0</TgsDmapiVersion>
+    <TgsDmapiVersion>6.6.1</TgsDmapiVersion>
     <TgsInteropVersion>5.6.2</TgsInteropVersion>
     <TgsHostWatchdogVersion>1.4.0</TgsHostWatchdogVersion>
     <TgsContainerScriptVersion>1.2.1</TgsContainerScriptVersion>

--- a/src/DMAPI/tgs.dm
+++ b/src/DMAPI/tgs.dm
@@ -1,6 +1,6 @@
 // tgstation-server DMAPI
 
-#define TGS_DMAPI_VERSION "6.6.0"
+#define TGS_DMAPI_VERSION "6.6.1"
 
 // All functions and datums outside this document are subject to change with any version and should not be relied on.
 

--- a/src/DMAPI/tgs/core/datum.dm
+++ b/src/DMAPI/tgs/core/datum.dm
@@ -11,6 +11,10 @@ TGS_DEFINE_AND_SET_GLOBAL(tgs, null)
 	src.event_handler = event_handler
 	src.version = version
 
+/datum/tgs_api/proc/TerminateWorld()
+	del(world)
+	sleep(1) // https://www.byond.com/forum/post/2894866
+
 /datum/tgs_api/latest
 	parent_type = /datum/tgs_api/v5
 

--- a/src/DMAPI/tgs/v4/api.dm
+++ b/src/DMAPI/tgs/v4/api.dm
@@ -73,7 +73,7 @@
 	if(cached_json["apiValidateOnly"])
 		TGS_INFO_LOG("Validating API and exiting...")
 		Export(TGS4_COMM_VALIDATE, list(TGS4_PARAMETER_DATA = "[minimum_required_security_level]"))
-		del(world)
+		TerminateWorld()
 
 	security_level = cached_json["securityLevel"]
 	chat_channels_json_path = cached_json["chatChannelsJson"]
@@ -188,7 +188,7 @@
 		requesting_new_port = TRUE
 		if(!world.OpenPort(0)) //open any port
 			TGS_ERROR_LOG("Unable to open random port to retrieve new port![TGS4_PORT_CRITFAIL_MESSAGE]")
-			del(world)
+			TerminateWorld()
 
 		//request a new port
 		export_lock = FALSE
@@ -196,16 +196,16 @@
 
 		if(!new_port_json)
 			TGS_ERROR_LOG("No new port response from server![TGS4_PORT_CRITFAIL_MESSAGE]")
-			del(world)
+			TerminateWorld()
 
 		var/new_port = new_port_json[TGS4_PARAMETER_DATA]
 		if(!isnum(new_port) || new_port <= 0)
 			TGS_ERROR_LOG("Malformed new port json ([json_encode(new_port_json)])![TGS4_PORT_CRITFAIL_MESSAGE]")
-			del(world)
+			TerminateWorld()
 
 		if(new_port != world.port && !world.OpenPort(new_port))
 			TGS_ERROR_LOG("Unable to open port [new_port]![TGS4_PORT_CRITFAIL_MESSAGE]")
-			del(world)
+			TerminateWorld()
 		requesting_new_port = FALSE
 
 	while(export_lock)

--- a/src/DMAPI/tgs/v5/api.dm
+++ b/src/DMAPI/tgs/v5/api.dm
@@ -51,7 +51,7 @@
 
 	if(runtime_information[DMAPI5_RUNTIME_INFORMATION_API_VALIDATE_ONLY])
 		TGS_INFO_LOG("DMAPI validation, exiting...")
-		del(world)
+		TerminateWorld()
 
 	version = new /datum/tgs_version(runtime_information[DMAPI5_RUNTIME_INFORMATION_SERVER_VERSION])
 	security_level = runtime_information[DMAPI5_RUNTIME_INFORMATION_SECURITY_LEVEL]

--- a/src/Tgstation.Server.Host/Components/Session/SessionController.cs
+++ b/src/Tgstation.Server.Host/Components/Session/SessionController.cs
@@ -784,8 +784,6 @@ namespace Tgstation.Server.Host.Components.Session
 				case BridgeCommandType.Startup:
 					apiValidationStatus = ApiValidationStatus.BadValidationRequest;
 
-					// This business is is cancelled until this BYOND bug is resolved: https://www.byond.com/forum/post/2894866
-#if FALSE
 					if (apiValidationSession)
 					{
 						var proceedTcs = new TaskCompletionSource<bool>();
@@ -795,9 +793,6 @@ namespace Tgstation.Server.Host.Components.Session
 						if (!firstValidationRequest)
 							return BridgeError("Startup bridge request was repeated!");
 					}
-#else
-					postValidationShutdownTask = Task.CompletedTask;
-#endif
 
 					if (parameters.Version == null)
 						return BridgeError("Missing dmApiVersion field!");

--- a/tests/DMAPI/test_setup.dm
+++ b/tests/DMAPI/test_setup.dm
@@ -32,3 +32,4 @@
 	text2file(reason, "test_fail_reason.txt")
 	world.log << "Terminating..."
 	del(world)
+	sleep(1) // https://www.byond.com/forum/post/2894866


### PR DESCRIPTION
:cl:
Reduces time out for deployment DMAPI validation to 10s after receiving the initial bridge request. This should never be hit, as the DMAPI is meant to stop the world immediately after this.
/:cl:

:cl: DreamMaker API
Added workaround for `del(world)` not doing anything until the end of the tick. See https://www.byond.com/forum/post/2894866.
/:cl:

Merging with `[DMDeploy]`
