### PR TITLE
v5.17.1 Fixes

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -8,7 +8,7 @@
     <TgsApiVersion>9.13.0</TgsApiVersion>
     <TgsCommonLibraryVersion>7.0.0</TgsCommonLibraryVersion>
     <TgsApiLibraryVersion>12.0.0</TgsApiLibraryVersion>
-    <TgsClientVersion>14.0.0</TgsClientVersion>
+    <TgsClientVersion>14.1.0</TgsClientVersion>
     <TgsDmapiVersion>6.6.2</TgsDmapiVersion>
     <TgsInteropVersion>5.6.2</TgsInteropVersion>
     <TgsHostWatchdogVersion>1.4.0</TgsHostWatchdogVersion>

--- a/src/Tgstation.Server.Client/ApiClient.cs
+++ b/src/Tgstation.Server.Client/ApiClient.cs
@@ -372,13 +372,15 @@ namespace Tgstation.Server.Client
 
 			retryPolicy ??= new InfiniteThirtySecondMaxRetryPolicy();
 
+			var wrappedPolicy = new ApiClientTokenRefreshRetryPolicy(this, retryPolicy);
+
 			HubConnection? hubConnection = null;
 			var hubConnectionBuilder = new HubConnectionBuilder()
 				.AddNewtonsoftJsonProtocol(options =>
 				{
 					options.PayloadSerializerSettings = SerializerSettings;
 				})
-				.WithAutomaticReconnect(retryPolicy)
+				.WithAutomaticReconnect(wrappedPolicy)
 				.WithUrl(
 					new Uri(Url, Routes.JobsHub),
 					HttpTransportType.ServerSentEvents,

--- a/src/Tgstation.Server.Client/ApiClientTokenRefreshRetryPolicy.cs
+++ b/src/Tgstation.Server.Client/ApiClientTokenRefreshRetryPolicy.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Threading;
+
+using Microsoft.AspNetCore.SignalR.Client;
+
+namespace Tgstation.Server.Client
+{
+	/// <summary>
+	/// A <see cref="IRetryPolicy"/> that attempts to refresh a given <see cref="apiClient"/>'s token on the first disconnect.
+	/// </summary>
+	sealed class ApiClientTokenRefreshRetryPolicy : IRetryPolicy
+	{
+		/// <summary>
+		/// The backing <see cref="ApiClient"/>.
+		/// </summary>
+		readonly ApiClient apiClient;
+
+		/// <summary>
+		/// The wrapped <see cref="IRetryPolicy"/>.
+		/// </summary>
+		readonly IRetryPolicy wrappedPolicy;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ApiClientTokenRefreshRetryPolicy"/> class.
+		/// </summary>
+		/// <param name="apiClient">The value of <see cref="apiClient"/>.</param>
+		/// <param name="wrappedPolicy">The value of <see cref="wrappedPolicy"/>.</param>
+		public ApiClientTokenRefreshRetryPolicy(ApiClient apiClient, IRetryPolicy wrappedPolicy)
+		{
+			this.apiClient = apiClient ?? throw new ArgumentNullException(nameof(apiClient));
+			this.wrappedPolicy = wrappedPolicy ?? throw new ArgumentNullException(nameof(wrappedPolicy));
+		}
+
+		/// <inheritdoc />
+		public TimeSpan? NextRetryDelay(RetryContext retryContext)
+		{
+			if (retryContext == null)
+				throw new ArgumentNullException(nameof(retryContext));
+
+			if (retryContext.PreviousRetryCount == 0)
+				AttemptTokenRefresh();
+
+			return wrappedPolicy.NextRetryDelay(retryContext);
+		}
+
+		/// <summary>
+		/// Attempt to refresh the <see cref="apiClient"/>s token asynchronously.
+		/// </summary>
+		async void AttemptTokenRefresh()
+		{
+			await apiClient.RefreshToken(CancellationToken.None);
+		}
+	}
+}

--- a/src/Tgstation.Server.Host/Core/Application.cs
+++ b/src/Tgstation.Server.Host/Core/Application.cs
@@ -404,7 +404,9 @@ namespace Tgstation.Server.Host.Core
 			services.AddSingleton<IJobService>(provider => provider.GetRequiredService<JobService>());
 			services.AddSingleton<IJobsHubUpdater>(provider => provider.GetRequiredService<JobService>());
 			services.AddSingleton<IJobManager>(x => x.GetRequiredService<IJobService>());
-			services.AddSingleton<IPermissionsUpdateNotifyee, JobsHubGroupMapper>();
+			services.AddSingleton<JobsHubGroupMapper>();
+			services.AddSingleton<IPermissionsUpdateNotifyee>(provider => provider.GetRequiredService<JobsHubGroupMapper>());
+			services.AddSingleton<IHostedService>(x => x.GetRequiredService<JobsHubGroupMapper>()); // bit of a hack, but we need this to load immediated
 
 			services.AddSingleton<InstanceManager>();
 			services.AddSingleton<IBridgeDispatcher>(x => x.GetRequiredService<InstanceManager>());

--- a/src/Tgstation.Server.Host/Jobs/JobsHubGroupMapper.cs
+++ b/src/Tgstation.Server.Host/Jobs/JobsHubGroupMapper.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 using Tgstation.Server.Api.Hubs;
@@ -19,7 +20,7 @@ namespace Tgstation.Server.Host.Jobs
 	/// <summary>
 	/// Handles mapping groups for the <see cref="JobsHub"/>.
 	/// </summary>
-	sealed class JobsHubGroupMapper : IPermissionsUpdateNotifyee
+	sealed class JobsHubGroupMapper : IPermissionsUpdateNotifyee, IHostedService
 	{
 		/// <summary>
 		/// The <see cref="IHubContext"/> for the <see cref="JobsHub"/>.
@@ -95,6 +96,12 @@ namespace Tgstation.Server.Host.Jobs
 				permissionSet.Id ?? throw new InvalidOperationException("permissionSet?.Id was null!"),
 				cancellationToken);
 		}
+
+		/// <inheritdoc />
+		public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+		/// <inheritdoc />
+		public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
 		/// <summary>
 		/// Implementation of <see cref="IConnectionMappedHubContext{THub, THubMethods}.OnConnectionMapGroups"/>.

--- a/src/Tgstation.Server.Host/Utils/SignalR/ComprehensiveHubContext.cs
+++ b/src/Tgstation.Server.Host/Utils/SignalR/ComprehensiveHubContext.cs
@@ -83,12 +83,13 @@ namespace Tgstation.Server.Host.Utils.SignalR
 				userId,
 				context.ConnectionId);
 
-			var mappingTask = OnConnectionMapGroups(
+			var mappingTask = OnConnectionMapGroups?.Invoke(
 				authenticationContext,
 				mappedGroups => Task.WhenAll(
 					mappedGroups.Select(
 						group => hub.Groups.AddToGroupAsync(context.ConnectionId, group, cancellationToken))),
-				cancellationToken);
+				cancellationToken)
+				?? ValueTask.CompletedTask;
 			userConnections.AddOrUpdate(
 				userId,
 				_ => new Dictionary<string, HubCallerContext>


### PR DESCRIPTION
:cl:
Fixed an issue where SignalR connections may not be mapped into their appropriate groups for receiving jobs.
/:cl:

:cl: Nuget: Client
Added a best effort automatic JWT refresh if SignalR connections attempt a reconnect. This might issue multiple login requests if there are multiple active job subscriptions.
/:cl: