### PR TITLE
Fix .deb `postinst` conditional.

### DIFF
--- a/build/package/deb/debian/postinst
+++ b/build/package/deb/debian/postinst
@@ -2,7 +2,7 @@
 
 #DEBHELPER#
 
-if [ "$1" = "configure" ]; then
+if [ -z "$2" ]; then
 	chmod 600 /etc/tgstation-server
 	deb-systemd-helper stop 'tgstation-server.service' >/dev/null || true
 


### PR DESCRIPTION
:cl:
Fixed upgrading on Debian/Ubuntu via `apt` always running first install steps.
/:cl: