### PR TITLE
v5.17.3: Fix hub user names

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -460,11 +460,32 @@ jobs:
         path: ~/byond-zips-cache
         key: byond-zips
 
-    - name: Run Live Tests
+    - name: Run Live Tests # Logging here is weird because printing massive amounts of text on Windows runners is SLOW AS SHIT!!!
+      id: live-tests
       run: |
         cd tests/Tgstation.Server.Tests
         Start-Sleep -Seconds 10
-        dotnet test -c ${{ matrix.configuration }} --no-build --filter TestCategory=RequiresDatabase --logger "GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true" --collect:"XPlat Code Coverage" --settings ../../build/ci.runsettings --results-directory ../../TestResults
+        $ErrorActionPreference="SilentlyContinue"
+        $test_output = dotnet test -c ${{ matrix.configuration }} --no-build --filter TestCategory=RequiresDatabase --logger "GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true" --collect:"XPlat Code Coverage" --settings ../../build/ci.runsettings --results-directory ../../TestResults
+        $succeeded = $?
+        $ErrorActionPreference="Stop"
+        cd ../..
+        $test_output | Out-File -FilePath ./test_output.txt
+        if (-Not $succeeded) {
+          echo "succeeded=NO" >> $env:GITHUB_OUTPUT
+        } else {
+          echo "succeeded=YES" >> $env:GITHUB_OUTPUT
+        }
+
+    - name: Store Live Tests Output
+      uses: actions/upload-artifact@v3
+      with:
+        name: windows-integration-test-logs-${{ matrix.configuration }}-${{ matrix.watchdog-type }}-${{ matrix.database-type }}
+        path: ./test_output.txt
+
+    - name: Fail if Live Tests Failed
+      if: ${{ steps.live-tests.outputs.succeeded != 'YES' }}
+      run: exit 1
 
     - name: Store Code Coverage
       uses: actions/upload-artifact@v3

--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="ControlPanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>5.17.2</TgsCoreVersion>
+    <TgsCoreVersion>5.17.3</TgsCoreVersion>
     <TgsConfigVersion>4.7.1</TgsConfigVersion>
     <TgsApiVersion>9.13.0</TgsApiVersion>
     <TgsCommonLibraryVersion>7.0.0</TgsCommonLibraryVersion>

--- a/src/Tgstation.Server.Host/Extensions/DatabaseCollectionExtensions.cs
+++ b/src/Tgstation.Server.Host/Extensions/DatabaseCollectionExtensions.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -15,19 +17,26 @@ namespace Tgstation.Server.Host.Extensions
 	static class DatabaseCollectionExtensions
 	{
 		/// <summary>
-		/// Gets the unattached, unpopulated <see cref="User"/> with the name <see cref="User.TgsSystemUserName"/>.
+		/// Gets <see cref="User"/> with the name <see cref="User.TgsSystemUserName"/>.
 		/// </summary>
+		/// <typeparam name="TResult">The transformed return <see cref="Type"/>.</typeparam>
 		/// <param name="databaseCollection">The <see cref="IDatabaseCollection{TModel}"/> of <see cref="User"/>s to operate on.</param>
+		/// <param name="selector">A selecting <see cref="Expression"/> for transforming the returned <see cref="User"/> into the <typeparamref name="TResult"/>.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task{TResult}"/> resulting in the unattached TGS <see cref="User"/> on success, <see langword="null"/> on failure.</returns>
-		public static Task<User> GetTgsUser(this IDatabaseCollection<User> databaseCollection, CancellationToken cancellationToken)
-			=> databaseCollection
+		public static Task<TResult> GetTgsUser<TResult>(
+			this IDatabaseCollection<User> databaseCollection,
+			Expression<Func<User, TResult>> selector,
+			CancellationToken cancellationToken)
+		{
+			ArgumentNullException.ThrowIfNull(databaseCollection);
+			ArgumentNullException.ThrowIfNull(selector);
+
+			return databaseCollection
 				.AsQueryable()
 				.Where(x => x.CanonicalName == User.CanonicalizeName(User.TgsSystemUserName))
-				.Select(x => new User
-				{
-					Id = x.Id,
-				})
+				.Select(selector)
 				.FirstAsync(cancellationToken);
+		}
 	}
 }

--- a/tests/Tgstation.Server.Tests/Live/Instance/JobsHubTests.cs
+++ b/tests/Tgstation.Server.Tests/Live/Instance/JobsHubTests.cs
@@ -53,6 +53,7 @@ namespace Tgstation.Server.Tests.Live.Instance
 				Assert.IsTrue(job.InstanceId.HasValue);
 				Assert.IsNotNull(job.StartedBy);
 				Assert.IsTrue(job.StartedBy.Id.HasValue);
+				Assert.IsNotNull(job.StartedBy.Name);
 				Assert.IsTrue(job.StartedAt.HasValue);
 				Assert.IsNotNull(job.Description);
 

--- a/tests/Tgstation.Server.Tests/Live/Instance/JobsRequiredTest.cs
+++ b/tests/Tgstation.Server.Tests/Live/Instance/JobsRequiredTest.cs
@@ -1,12 +1,15 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Tgstation.Server.Api.Hubs;
 using Tgstation.Server.Api.Models;
 using Tgstation.Server.Api.Models.Response;
+using Tgstation.Server.Client;
 using Tgstation.Server.Client.Components;
 
 namespace Tgstation.Server.Tests.Live.Instance
@@ -15,30 +18,72 @@ namespace Tgstation.Server.Tests.Live.Instance
 	{
 		protected IJobsClient JobsClient { get; }
 
+		readonly IApiClient apiClient;
+
 		public JobsRequiredTest(IJobsClient jobsClient)
 		{
-			JobsClient = jobsClient;
+			JobsClient = jobsClient ?? throw new ArgumentNullException(nameof(jobsClient));
+			apiClient = (IApiClient)jobsClient.GetType().GetProperty("ApiClient", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(jobsClient);
+		}
+
+		class JobReceiver : IJobsHub
+		{
+			public Action<JobResponse> Callback { get; set; }
+
+			public Task ReceiveJobUpdate(JobResponse job, CancellationToken cancellationToken)
+			{
+				Callback(job);
+				return Task.CompletedTask;
+			}
 		}
 
 		public async Task<JobResponse> WaitForJob(JobResponse originalJob, int timeout, bool? expectFailure, ErrorCode? expectedCode, CancellationToken cancellationToken)
 		{
 			Assert.IsNotNull(originalJob.Id);
 			Assert.IsNotNull(originalJob.JobCode);
-			var job = originalJob;
-			do
-			{
-				await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
-				job = await JobsClient.GetId(job, cancellationToken);
-				Assert.IsNotNull(job.Id);
-				Assert.IsNotNull(job.JobCode);
-				--timeout;
-			}
-			while (!job.StoppedAt.HasValue && timeout > 0);
 
+			var job = originalJob;
 			if (!job.StoppedAt.HasValue)
 			{
-				await JobsClient.Cancel(job, cancellationToken);
-				Assert.Fail($"Job ID {job.Id} \"{job.Description}\" timed out!");
+				var tcs = new TaskCompletionSource();
+				var receiver = new JobReceiver
+				{
+					Callback = updatedJob =>
+					{
+						if (updatedJob.Id != job.Id)
+							return;
+
+						job = updatedJob;
+						if (updatedJob.StoppedAt.HasValue)
+							tcs.TrySetResult();
+					},
+				};
+
+				JobResponse firstCheck;
+				await using (var hubConnection = await apiClient.CreateHubConnection<IJobsHub>(receiver, null, null, cancellationToken))
+				{
+					// initial GET after connecting
+					firstCheck = await JobsClient.GetId(job, cancellationToken);
+					if (!firstCheck.StoppedAt.HasValue)
+					{
+						firstCheck = null;
+						await Task.WhenAny(
+							tcs.Task,
+							Task.Delay(TimeSpan.FromSeconds(timeout), cancellationToken));
+					}
+				}
+
+				if (firstCheck != null)
+					job = firstCheck;
+				else if (!job.StoppedAt.HasValue)
+					// one last get in case SignalR dropped the ball
+					job = await JobsClient.GetId(job, cancellationToken);
+
+				if (!job.StoppedAt.HasValue)
+				{
+					await JobsClient.Cancel(job, cancellationToken);
+					Assert.Fail($"Job ID {job.Id} \"{job.Description}\" timed out!");
+				}
 			}
 
 			if (expectFailure.HasValue && expectFailure.Value ^ job.ExceptionDetails != null)

--- a/tests/Tgstation.Server.Tests/Live/TestLiveServer.cs
+++ b/tests/Tgstation.Server.Tests/Live/TestLiveServer.cs
@@ -1610,6 +1610,8 @@ namespace Tgstation.Server.Tests.Live
 					await new ChatTest(instanceClient.ChatBots, adminClient.Instances, instanceClient.Jobs, instance).RunPostTest(cancellationToken);
 					await repoTest;
 
+					await DummyChatProvider.RandomDisconnections(false, cancellationToken);
+
 					jobsHubTest.CompleteNow();
 					await jobsHubTestTask;
 


### PR DESCRIPTION
:cl:
Fixed `startedBy.Name` not being set in jobs hub updates.
/:cl: