### PR TITLE
v5.17.3: MariaDB redistribution fixes

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -1515,7 +1515,9 @@ jobs:
       run: |
         [XML]$versionXML = Get-Content build/Version.props
         $tgsVersion = $versionXML.Project.PropertyGroup.TgsCoreVersion
+        $mariaDBVerison = $versionXML.Project.PropertyGroup.TgsMariaDBRedistVersion
         echo "TGS_VERSION=$tgsVersion" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+        echo "MARIADB_VERSION=$mariaDBVerison" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
 
     - name: Upload .msi
       uses: actions/upload-artifact@v3
@@ -1656,6 +1658,16 @@ jobs:
         asset_path: ./packaging-debian/tgstation-server-v${{ env.TGS_VERSION }}.debian.packaging.tar.xz
         asset_name: tgstation-server-v${{ env.TGS_VERSION }}.debian.packaging.tar.xz
         asset_content_type: application/x-tar
+
+    - name: Upload MariaDB .msi
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.DEV_PUSH_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./build/package/winget/Tgstation.Server.Host.Service.Wix.Bundle/bin/Release/mariadb.msi
+        asset_name: mariadb-${{ env.MARIADB_VERSION }}-winx64.msi
+        asset_content_type: application/octet-stream
 
     - name: Upload Installer .exe
       uses: actions/upload-release-asset@v1

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -52,7 +52,7 @@ RUN dotnet restore -nowarn:MSB3202,nu1503 -p:RestoreUseSkipNonexistentTargets=fa
 COPY . .
 
 #run dos2unix on tgs.docker.sh so we can build without issue on windows
-RUN dos2unix build/tgs.docker.sh
+RUN dos2unix build/tgs.docker.sh build/RemoveUnsupportedRuntimes.sh
 
 WORKDIR /repo/src/Tgstation.Server.Host.Console
 RUN dotnet publish -c Release -o /app \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -16,8 +16,7 @@ RUN . $NVM_DIR/nvm.sh \
 	&& apt-get update \
 	&& apt-get install -y \
 		dos2unix \
-	&& rm -rf /var/lib/apt/lists/* \
-	&& npm install -g npm
+	&& rm -rf /var/lib/apt/lists/*
 
 # Build web control panel
 WORKDIR /repo/build

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -19,9 +19,6 @@ RUN . $NVM_DIR/nvm.sh \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& npm install -g npm
 
-#You may wonder why this needs to be in a seperate step. I don't know... It just works(tm)
-RUN npm install -g yarn
-
 # Build web control panel
 WORKDIR /repo/build
 

--- a/build/Version.props
+++ b/build/Version.props
@@ -19,5 +19,6 @@
     <!-- Update this frequently with dotnet runtime patches. MAJOR MUST MATCH ABOVE! -->
     <TgsDotnetRedistUrl>https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/6.0.24/dotnet-hosting-6.0.24-win.exe</TgsDotnetRedistUrl>
     <TgsMariaDBRedistVersion>10.11.6</TgsMariaDBRedistVersion>
+    <TgsYarnVersion>1.22.19</TgsYarnVersion>
   </PropertyGroup>
 </Project>

--- a/build/Version.props
+++ b/build/Version.props
@@ -18,8 +18,6 @@
     <TgsNetMajorVersion>6</TgsNetMajorVersion>
     <!-- Update this frequently with dotnet runtime patches. MAJOR MUST MATCH ABOVE! -->
     <TgsDotnetRedistUrl>https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/6.0.24/dotnet-hosting-6.0.24-win.exe</TgsDotnetRedistUrl>
-    <TgsMariaDBRedistVersion>10.11.5</TgsMariaDBRedistVersion>
-    <!-- The two versions must match above, this is referenced by XML readers in scripts so we can't use an MSBuild property reference -->
-    <TgsMariaDBRedistUrl>https://atl.mirrors.knownhost.com/mariadb//mariadb-10.11.5/winx64-packages/mariadb-10.11.5-winx64.msi</TgsMariaDBRedistUrl>
+    <TgsMariaDBRedistVersion>10.11.6</TgsMariaDBRedistVersion>
   </PropertyGroup>
 </Project>

--- a/build/package/winget/Tgstation.Server.Host.Service.Wix.Bundle/Tgstation.Server.Host.Service.Wix.Bundle.wixproj
+++ b/build/package/winget/Tgstation.Server.Host.Service.Wix.Bundle/Tgstation.Server.Host.Service.Wix.Bundle.wixproj
@@ -1,7 +1,7 @@
 <Project Sdk="WixToolset.Sdk/4.0.2" xmlns:bal="http://schemas.microsoft.com/wix/BalExtension">
   <Import Project="../../../Common.props" />
   <PropertyGroup>
-    <DefineConstants>ProductVersion=$(TgsCoreVersion);NetMajorVersion=$(TgsNetMajorVersion);DotnetRedistUrl=$(TgsDotnetRedistUrl);MariaDBRedistUrl=$(TgsMariaDBRedistUrl)</DefineConstants>
+    <DefineConstants>ProductVersion=$(TgsCoreVersion);NetMajorVersion=$(TgsNetMajorVersion);DotnetRedistUrl=$(TgsDotnetRedistUrl);MariaDBRedistUrl=https://github.com/tgstation/tgstation-server/releases/download/tgstation-server-v$(TgsCoreVersion)/mariadb-$(TgsMariaDBRedistVersion)-winx64.msi</DefineConstants>
     <OutputType>Bundle</OutputType>
     <Platforms>x86</Platforms>
     <OutputName>tgstation-server-installer</OutputName>

--- a/build/package/winget/prepare_installer_input_artifacts.ps1
+++ b/build/package/winget/prepare_installer_input_artifacts.ps1
@@ -13,7 +13,21 @@ try
 
     [XML]$versionXML = Get-Content build/Version.props -ErrorAction Stop
     $redistUrl = $versionXML.Project.PropertyGroup.TgsDotnetRedistUrl
-    $dbRedistUrl = $versionXML.Project.PropertyGroup.TgsMariaDBRedistUrl
+
+    $dbRedistVersion = $versionXML.Project.PropertyGroup.TgsMariaDBRedistVersion
+
+    $dbRedistMinorVersion = $dbRedistVersion.Substring(0, $dbRedistVersion.LastIndexOf("."))
+
+    $ProgressPreference = 'SilentlyContinue'
+    try
+    {
+        $json=Invoke-RestMethod -Uri "https://downloads.mariadb.org/rest-api/mariadb/${dbRedistMinorVersion}/"
+    } finally {
+        $ProgressPreference = $previousProgressPreference
+    }
+
+    $msiFile = $json.releases.$dbRedistVersion.files | Where-Object { $_.package_type -eq "MSI Package" } | Select-Object -First 1
+    $dbRedistUrl = $msiFile.file_download_url
 
     mkdir artifacts
     $previousProgressPreference = $ProgressPreference

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+    "sdk": {
+        "version": "6.0.0",
+        "rollForward": "latestMajor",
+        "allowPrerelease": false
+    }
+}

--- a/src/Tgstation.Server.Common/Tgstation.Server.Common.csproj
+++ b/src/Tgstation.Server.Common/Tgstation.Server.Common.csproj
@@ -17,7 +17,7 @@
   <!-- This is here because I know we have node as a build dep so this just works -->
   <Target Name="IconGeneration" BeforeTargets="ResolveAssemblyReferences" Inputs="build_logo.js;../../build/logo.svg" Outputs="../../artifacts/tgs.ico;../../artifacts/tgs.png">
     <Message Text="Restoring yarn packages..." Importance="high" />
-    <Exec Command="npx --yes yarn add svg-to-ico@1.0.14 svg2img@1.0.0-beta.2" />
+    <Exec Command="npx --yes yarn@$(TgsYarnVersion) add svg-to-ico@1.0.14 svg2img@1.0.0-beta.2" />
     <Message Text="Generating icons from SVG..." Importance="high" />
     <Exec Command="node ./build_logo.js" />
   </Target>

--- a/src/Tgstation.Server.Host/Database/MySqlDatabaseContext.cs
+++ b/src/Tgstation.Server.Host/Database/MySqlDatabaseContext.cs
@@ -47,7 +47,7 @@ namespace Tgstation.Server.Host.Database
 					databaseConfiguration.ServerVersion,
 					databaseConfiguration.DatabaseType == DatabaseType.MariaDB
 						? ServerType.MariaDb
-				: ServerType.MySql);
+						: ServerType.MySql);
 			}
 			else
 				serverVersion = ServerVersion.AutoDetect(databaseConfiguration.ConnectionString);

--- a/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
+++ b/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
@@ -28,13 +28,13 @@
     <Exec Command="git clone https://github.com/tgstation/tgstation-server-webpanel --branch v$(TgsControlPanelVersion) --depth 1 ClientApp" />
     <RemoveDir Directories="ClientApp/.git" /> <!-- Allows git clean to clean it out -->
     <Message Text="Restoring yarn packages..." Importance="high" />
-    <Exec WorkingDirectory="ClientApp" Command="npx --yes yarn install --immutable" />
+    <Exec WorkingDirectory="ClientApp" Command="npx --yes yarn@$(TgsYarnVersion) install --immutable" />
     <Touch Files="$(NpmInstallStampFile)" AlwaysCreate="true" />
   </Target>
 
   <Target Condition="'$(TGS_HOST_NO_WEBPANEL)' != 'true'" Name="NpmBuild" BeforeTargets="BeforeBuild" DependsOnTargets="ClientInstall" Inputs="../../build/ControlPanelVersion.props" Outputs="wwwroot\index.html">
     <Message Text="Building web control panel..." Importance="high" />
-    <Exec WorkingDirectory="ClientApp" Command="npx --yes yarn run msbuild" />
+    <Exec WorkingDirectory="ClientApp" Command="npx --yes yarn@$(TgsYarnVersion) run msbuild" />
   </Target>
 
   <Target Name="NpmClean" AfterTargets="Clean">


### PR DESCRIPTION
:cl:
Older Windows installers would fail to install MariaDB if the mirror was taken down. The MariaDB .msi is now hosted on this GitHub to prevent this.
MariaDB redistributable updated to 10.11.6.
/:cl: