### PR TITLE
v5.18.1: Add `X-Accel-Buffering: no`

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ System administrators will most likely have their own configuration plans, but h
 
 Once complete, test that your configuration worked by visiting your proxy site from a browser on a different computer. You should recieve a 401 Unauthorized response.
 
-_NOTE: For SignalR to function properly, make sure your reverse proxy setup supports SSE (Server-Sent Events)_
+_NOTE: Your reverse proxy setup may interfere with SSE (Server-Sent Events) which is used for real-time job updates. If you find this to be the case, please open an issue describing what you did to fix it as there may be a way for us to bypass the need for a workaround from our end._
 
 #### IIS (Reccommended for Windows)
 

--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="WebpanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>5.18.0</TgsCoreVersion>
+    <TgsCoreVersion>5.18.1</TgsCoreVersion>
     <TgsConfigVersion>4.7.1</TgsConfigVersion>
     <TgsApiVersion>9.14.0</TgsApiVersion>
     <TgsCommonLibraryVersion>7.0.0</TgsCommonLibraryVersion>

--- a/src/Tgstation.Server.Host/Components/Watchdog/AdvancedWatchdog.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/AdvancedWatchdog.cs
@@ -222,7 +222,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 			else
 				Logger.LogTrace("Nothing to do as pendingSwappable is null.");
 
-			return MonitorAction.Continue;
+			return await base.HandleNormalReboot(cancellationToken);
 		}
 
 		/// <inheritdoc />

--- a/src/Tgstation.Server.Host/Core/Application.cs
+++ b/src/Tgstation.Server.Host/Core/Application.cs
@@ -463,6 +463,9 @@ namespace Tgstation.Server.Host.Core
 			// Add the X-Powered-By response header
 			applicationBuilder.UseServerBranding(assemblyInformationProvider);
 
+			// Add the X-Accel-Buffering response header
+			applicationBuilder.UseDisabledNginxProxyBuffering();
+
 			// suppress OperationCancelledExceptions, they are just aborted HTTP requests
 			applicationBuilder.UseCancelledRequestSuppression();
 

--- a/src/Tgstation.Server.Host/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/Tgstation.Server.Host/Extensions/ApplicationBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using System.Net;
 
@@ -158,10 +158,10 @@ namespace Tgstation.Server.Host.Extensions
 			ArgumentNullException.ThrowIfNull(applicationBuilder);
 			ArgumentNullException.ThrowIfNull(assemblyInformationProvider);
 
-			applicationBuilder.Use(async (context, next) =>
+			applicationBuilder.Use((context, next) =>
 			{
 				context.Response.Headers.Add("X-Powered-By", assemblyInformationProvider.VersionPrefix);
-				await next();
+				return next();
 			});
 		}
 

--- a/src/Tgstation.Server.Host/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/Tgstation.Server.Host/Extensions/ApplicationBuilderExtensions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Globalization;
 using System.Net;
 
@@ -161,6 +161,23 @@ namespace Tgstation.Server.Host.Extensions
 			applicationBuilder.Use((context, next) =>
 			{
 				context.Response.Headers.Add("X-Powered-By", assemblyInformationProvider.VersionPrefix);
+				return next();
+			});
+		}
+
+		/// <summary>
+		/// Add the X-Accel-Buffering response header.
+		/// </summary>
+		/// <param name="applicationBuilder">The <see cref="IApplicationBuilder"/> to configure.</param>
+		/// <remarks>This is used to avoid interruption to SignalR streams by Nginx.</remarks>
+		public static void UseDisabledNginxProxyBuffering(this IApplicationBuilder applicationBuilder)
+		{
+			ArgumentNullException.ThrowIfNull(applicationBuilder);
+
+			// https://www.nginx.com/resources/wiki/start/topics/examples/x-accel/#x-accel-buffering
+			applicationBuilder.Use((context, next) =>
+			{
+				context.Response.Headers.Add("X-Accel-Buffering", "no");
 				return next();
 			});
 		}

--- a/tests/Tgstation.Server.Tests/Live/HardFailLogger.cs
+++ b/tests/Tgstation.Server.Tests/Live/HardFailLogger.cs
@@ -30,7 +30,7 @@ namespace Tgstation.Server.Tests.Live
 				&& !(logMessage.StartsWith("An exception occurred in the database while saving changes for context type") && (exception is OperationCanceledException || exception?.InnerException is OperationCanceledException)))
 				|| (logLevel == LogLevel.Critical && logMessage != "DropDatabase configuration option set! Dropping any existing database..."))
 			{
-				failureSink(new AssertFailedException("TGS logged an unexpected error!"));
+				failureSink(new AssertFailedException($"TGS ERR: {logMessage}"));
 			}
 		}
 	}

--- a/tools/Tgstation.Server.ReleaseNotes/Program.cs
+++ b/tools/Tgstation.Server.ReleaseNotes/Program.cs
@@ -1322,6 +1322,12 @@ The user account that created this pull request is available to correct any issu
 				PrintChanges(newNotes, relevantChangelog);
 			}
 
+			if(component == Component.DreamMakerApi)
+			{
+				newNotes.AppendLine();
+				newNotes.AppendLine("#tgs-dmapi-release");
+			}
+
 			var markdown = newNotes.ToString();
 			return markdown;
 		}


### PR DESCRIPTION
:cl:
Added the `X-Accel-Buffering: no` response header to requests to prevent NGINX from interfering with SignalR SSE hubs.
Fixed changing server settings with the advanced watchdog not automatically queuing a graceful reboot.
/:cl: