### PR TITLE
v5.18.2: Never ending train of fixes

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="WebpanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>5.18.1</TgsCoreVersion>
+    <TgsCoreVersion>5.18.2</TgsCoreVersion>
     <TgsConfigVersion>4.7.1</TgsConfigVersion>
     <TgsApiVersion>9.14.0</TgsApiVersion>
     <TgsCommonLibraryVersion>7.0.0</TgsCommonLibraryVersion>

--- a/src/Tgstation.Server.Host/Components/Chat/ChatManager.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/ChatManager.cs
@@ -843,9 +843,12 @@ namespace Tgstation.Server.Host.Components.Chat
 					}
 					else
 					{
-						var (helpHandler, _) = GetCommand();
-						if (helpHandler != default)
+						var helpTuple = GetCommand();
+						if (helpTuple != default)
+						{
+							var (helpHandler, _) = helpTuple;
 							helpText = String.Format(CultureInfo.InvariantCulture, "{0}: {1}{2}", helpHandler.Name, helpHandler.HelpText, helpHandler.AdminOnly ? " - May only be used in admin channels" : String.Empty);
+						}
 						else
 							helpText = UnknownCommandMessage;
 					}
@@ -854,13 +857,15 @@ namespace Tgstation.Server.Host.Components.Chat
 					return;
 				}
 
-				var (commandHandler, trackingContext) = GetCommand();
+				var tuple = GetCommand();
 
-				if (commandHandler == default)
+				if (tuple == default)
 				{
 					await TextReply(UnknownCommandMessage);
 					return;
 				}
+
+				var (commandHandler, trackingContext) = tuple;
 
 				if (trackingContext?.Active == false)
 				{

--- a/src/Tgstation.Server.Host/Components/Chat/IChatTrackingContext.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/IChatTrackingContext.cs
@@ -13,6 +13,7 @@ namespace Tgstation.Server.Host.Components.Chat
 		/// <summary>
 		/// If the <see cref="CustomCommands"/> should be used.
 		/// </summary>
+		/// <remarks>This should only be set by the <see cref="object"/> that sets the <see cref="CustomCommands"/>.</remarks>
 		bool Active { get; set; }
 
 		/// <summary>

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Globalization;
@@ -719,6 +720,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 
 			var remapRequired = false;
 			var guildsClient = serviceProvider.GetRequiredService<IDiscordRestGuildAPI>();
+			var guildTasks = new ConcurrentDictionary<Snowflake, Task<Result<IGuild>>>();
 
 			async ValueTask<Tuple<Models.ChatChannel, IEnumerable<ChannelRepresentation>>> GetModelChannelFromDBChannel(Models.ChatChannel channelFromDB)
 			{
@@ -750,17 +752,28 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 
 				var guildId = discordChannelResponse.Entity.GuildID.Value;
 
-				var guildsResponse = await guildsClient.GetGuildAsync(
+				var added = false;
+				var guildsResponse = await guildTasks.GetOrAdd(
 					guildId,
-					false,
-					cancellationToken);
+					localGuildId =>
+					{
+						added = true;
+						return guildsClient.GetGuildAsync(
+							localGuildId,
+							false,
+							cancellationToken);
+					});
 				if (!guildsResponse.IsSuccess)
 				{
-					Logger.LogWarning(
-						"Error retrieving discord guild {guildID}: {result}",
-						guildId,
-						guildsResponse.LogFormat());
-					remapRequired |= true;
+					if (added)
+					{
+						Logger.LogWarning(
+							"Error retrieving discord guild {guildID}: {result}",
+							guildId,
+							guildsResponse.LogFormat());
+						remapRequired |= true;
+					}
+
 					return null;
 				}
 

--- a/src/Tgstation.Server.Host/Components/Session/ISessionController.cs
+++ b/src/Tgstation.Server.Host/Components/Session/ISessionController.cs
@@ -120,11 +120,6 @@ namespace Tgstation.Server.Host.Components.Session
 		void ResetRebootState();
 
 		/// <summary>
-		/// Enables the reading of custom chat commands from the <see cref="ISessionController"/>.
-		/// </summary>
-		void EnableCustomChatCommands();
-
-		/// <summary>
 		/// Replace the <see cref="IDmbProvider"/> in use with a given <paramref name="newProvider"/>, disposing the old one.
 		/// </summary>
 		/// <param name="newProvider">The new <see cref="IDmbProvider"/>.</param>

--- a/src/Tgstation.Server.Host/Components/Session/SessionController.cs
+++ b/src/Tgstation.Server.Host/Components/Session/SessionController.cs
@@ -1044,7 +1044,7 @@ namespace Tgstation.Server.Host.Components.Session
 				return null;
 			}
 
-			var rebootGate = RebootGate;
+			var reboot = OnReboot;
 			if (!bypassLaunchResult)
 			{
 				var launchResult = await LaunchResult.WaitAsync(cancellationToken);
@@ -1068,11 +1068,11 @@ namespace Tgstation.Server.Host.Components.Session
 			{
 				try
 				{
-					var completed = await Task.WhenAny(Lifetime, rebootGate).WaitAsync(combinedCancellationToken);
+					var completed = await Task.WhenAny(Lifetime, reboot).WaitAsync(combinedCancellationToken);
 
 					Logger.LogDebug(
 						"Server {action}, cancelling pending command: {commandType}",
-						completed != rebootGate
+						completed != reboot
 							? "process ended"
 							: "rebooting",
 						parameters.CommandType);

--- a/src/Tgstation.Server.Host/Components/Session/SessionController.cs
+++ b/src/Tgstation.Server.Host/Components/Session/SessionController.cs
@@ -414,143 +414,8 @@ namespace Tgstation.Server.Host.Components.Session
 		}
 
 		/// <inheritdoc />
-		public async ValueTask<TopicResponse> SendCommand(TopicParameters parameters, CancellationToken cancellationToken)
-		{
-			ArgumentNullException.ThrowIfNull(parameters);
-
-			if (Lifetime.IsCompleted || disposed)
-			{
-				Logger.LogWarning(
-					"Attempted to send a command to an inactive SessionController: {commandType}",
-					parameters.CommandType);
-				return null;
-			}
-
-			if (!DMApiAvailable)
-			{
-				Logger.LogTrace("Not sending topic request {commandType} to server without/with incompatible DMAPI!", parameters.CommandType);
-				return null;
-			}
-
-			var rebootGate = RebootGate;
-			var launchResult = await LaunchResult.WaitAsync(cancellationToken);
-			if (launchResult.ExitCode.HasValue)
-			{
-				Logger.LogDebug("Not sending topic request {commandType} to server that failed to launch!", parameters.CommandType);
-				return null;
-			}
-
-			// meh, this is kind of a hack, but it works
-			if (!chatTrackingContext.Active)
-			{
-				Logger.LogDebug("Not sending topic request {commandType} to server that is rebooting/starting.", parameters.CommandType);
-				return null;
-			}
-
-			using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-			var combinedCancellationToken = cts.Token;
-			async ValueTask CancelIfLifetimeElapses()
-			{
-				try
-				{
-					var completed = await Task.WhenAny(Lifetime, rebootGate).WaitAsync(combinedCancellationToken);
-
-					Logger.LogDebug(
-						"Server {action}, cancelling pending command: {commandType}",
-						completed != rebootGate
-							? "process ended"
-							: "rebooting",
-						parameters.CommandType);
-					cts.Cancel();
-				}
-				catch (OperationCanceledException)
-				{
-					// expected, not even worth tracing
-				}
-				catch (Exception ex)
-				{
-					Logger.LogError(ex, "Error in CancelIfLifetimeElapses!");
-				}
-			}
-
-			TopicResponse fullResponse = null;
-			var lifetimeWatchingTask = CancelIfLifetimeElapses();
-			try
-			{
-				var combinedResponse = await SendTopicRequest(parameters, combinedCancellationToken);
-
-				void LogCombinedResponse()
-				{
-					if (LogTopicRequests && combinedResponse != null)
-						Logger.LogTrace("Topic response: {topicString}", combinedResponse.ByondTopicResponse.StringData ?? "(NO STRING DATA)");
-				}
-
-				LogCombinedResponse();
-
-				if (combinedResponse?.InteropResponse?.Chunk != null)
-				{
-					Logger.LogTrace("Topic response is chunked...");
-
-					ChunkData nextChunk = combinedResponse.InteropResponse.Chunk;
-					do
-					{
-						var nextRequest = await ProcessChunk<TopicResponse, ChunkedTopicParameters>(
-							(completedResponse, _) =>
-							{
-								fullResponse = completedResponse;
-								return ValueTask.FromResult<ChunkedTopicParameters>(null);
-							},
-							error =>
-							{
-								Logger.LogWarning("Topic response chunking error: {message}", error);
-								return null;
-							},
-							combinedResponse?.InteropResponse?.Chunk,
-							combinedCancellationToken);
-
-						if (nextRequest != null)
-						{
-							nextRequest.PayloadId = nextChunk.PayloadId;
-							combinedResponse = await SendTopicRequest(nextRequest, combinedCancellationToken);
-							LogCombinedResponse();
-							nextChunk = combinedResponse?.InteropResponse?.Chunk;
-						}
-						else
-							nextChunk = null;
-					}
-					while (nextChunk != null);
-				}
-				else
-					fullResponse = combinedResponse?.InteropResponse;
-			}
-			catch (OperationCanceledException ex)
-			{
-				Logger.LogDebug(
-					ex,
-					"Topic request {cancellationType}!",
-					combinedCancellationToken.IsCancellationRequested
-						? cancellationToken.IsCancellationRequested
-							? "cancelled"
-							: "aborted"
-						: "timed out");
-
-				// throw only if the original token was the trigger
-				cancellationToken.ThrowIfCancellationRequested();
-			}
-			finally
-			{
-				cts.Cancel();
-				await lifetimeWatchingTask;
-			}
-
-			if (fullResponse?.ErrorMessage != null)
-				Logger.LogWarning(
-					"Errored topic response for command {commandType}: {errorMessage}",
-					parameters.CommandType,
-					fullResponse.ErrorMessage);
-
-			return fullResponse;
-		}
+		public ValueTask<TopicResponse> SendCommand(TopicParameters parameters, CancellationToken cancellationToken)
+			=> SendCommand(parameters, false, cancellationToken);
 
 		/// <inheritdoc />
 		public Task<bool> SetPort(ushort port, CancellationToken cancellationToken)
@@ -697,6 +562,7 @@ namespace Tgstation.Server.Host.Components.Session
 					new TopicParameters(
 						assemblyInformationProvider.Version,
 						ReattachInformation.RuntimeInformation.ServerPort),
+					true,
 					reattachTopicCts.Token);
 
 				if (reattachResponse != null)
@@ -1151,6 +1017,154 @@ namespace Tgstation.Server.Host.Components.Session
 				}
 
 			return new CombinedTopicResponse(byondResponse, interopResponse);
+		}
+
+		/// <summary>
+		/// Sends a command to DreamDaemon through /world/Topic().
+		/// </summary>
+		/// <param name="parameters">The <see cref="TopicParameters"/> to send.</param>
+		/// <param name="bypassLaunchResult">If waiting for the <see cref="LaunchResult"/> should be bypassed.</param>
+		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
+		/// <returns>A <see cref="ValueTask{TResult}"/> resulting in the <see cref="TopicResponse"/> of /world/Topic().</returns>
+		async ValueTask<TopicResponse> SendCommand(TopicParameters parameters, bool bypassLaunchResult, CancellationToken cancellationToken)
+		{
+			ArgumentNullException.ThrowIfNull(parameters);
+
+			if (Lifetime.IsCompleted || disposed)
+			{
+				Logger.LogWarning(
+					"Attempted to send a command to an inactive SessionController: {commandType}",
+					parameters.CommandType);
+				return null;
+			}
+
+			if (!DMApiAvailable)
+			{
+				Logger.LogTrace("Not sending topic request {commandType} to server without/with incompatible DMAPI!", parameters.CommandType);
+				return null;
+			}
+
+			var rebootGate = RebootGate;
+			if (!bypassLaunchResult)
+			{
+				var launchResult = await LaunchResult.WaitAsync(cancellationToken);
+				if (launchResult.ExitCode.HasValue)
+				{
+					Logger.LogDebug("Not sending topic request {commandType} to server that failed to launch!", parameters.CommandType);
+					return null;
+				}
+			}
+
+			// meh, this is kind of a hack, but it works
+			if (!chatTrackingContext.Active)
+			{
+				Logger.LogDebug("Not sending topic request {commandType} to server that is rebooting/starting.", parameters.CommandType);
+				return null;
+			}
+
+			using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+			var combinedCancellationToken = cts.Token;
+			async ValueTask CancelIfLifetimeElapses()
+			{
+				try
+				{
+					var completed = await Task.WhenAny(Lifetime, rebootGate).WaitAsync(combinedCancellationToken);
+
+					Logger.LogDebug(
+						"Server {action}, cancelling pending command: {commandType}",
+						completed != rebootGate
+							? "process ended"
+							: "rebooting",
+						parameters.CommandType);
+					cts.Cancel();
+				}
+				catch (OperationCanceledException)
+				{
+					// expected, not even worth tracing
+				}
+				catch (Exception ex)
+				{
+					Logger.LogError(ex, "Error in CancelIfLifetimeElapses!");
+				}
+			}
+
+			TopicResponse fullResponse = null;
+			var lifetimeWatchingTask = CancelIfLifetimeElapses();
+			try
+			{
+				var combinedResponse = await SendTopicRequest(parameters, combinedCancellationToken);
+
+				void LogCombinedResponse()
+				{
+					if (LogTopicRequests && combinedResponse != null)
+						Logger.LogTrace("Topic response: {topicString}", combinedResponse.ByondTopicResponse.StringData ?? "(NO STRING DATA)");
+				}
+
+				LogCombinedResponse();
+
+				if (combinedResponse?.InteropResponse?.Chunk != null)
+				{
+					Logger.LogTrace("Topic response is chunked...");
+
+					ChunkData nextChunk = combinedResponse.InteropResponse.Chunk;
+					do
+					{
+						var nextRequest = await ProcessChunk<TopicResponse, ChunkedTopicParameters>(
+							(completedResponse, _) =>
+							{
+								fullResponse = completedResponse;
+								return ValueTask.FromResult<ChunkedTopicParameters>(null);
+							},
+							error =>
+							{
+								Logger.LogWarning("Topic response chunking error: {message}", error);
+								return null;
+							},
+							combinedResponse?.InteropResponse?.Chunk,
+							combinedCancellationToken);
+
+						if (nextRequest != null)
+						{
+							nextRequest.PayloadId = nextChunk.PayloadId;
+							combinedResponse = await SendTopicRequest(nextRequest, combinedCancellationToken);
+							LogCombinedResponse();
+							nextChunk = combinedResponse?.InteropResponse?.Chunk;
+						}
+						else
+							nextChunk = null;
+					}
+					while (nextChunk != null);
+				}
+				else
+					fullResponse = combinedResponse?.InteropResponse;
+			}
+			catch (OperationCanceledException ex)
+			{
+				Logger.LogDebug(
+					ex,
+					"Topic request {cancellationType}!",
+					combinedCancellationToken.IsCancellationRequested
+						? cancellationToken.IsCancellationRequested
+							? "cancelled"
+							: "aborted"
+						: "timed out");
+
+				// throw only if the original token was the trigger
+				cancellationToken.ThrowIfCancellationRequested();
+			}
+			finally
+			{
+				cts.Cancel();
+				await lifetimeWatchingTask;
+			}
+
+			if (fullResponse?.ErrorMessage != null)
+				Logger.LogWarning(
+					"Errored topic response for command {commandType}: {errorMessage}",
+					parameters.CommandType,
+					fullResponse.ErrorMessage);
+
+			return fullResponse;
 		}
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Session/SessionController.cs
+++ b/src/Tgstation.Server.Host/Components/Session/SessionController.cs
@@ -402,9 +402,6 @@ namespace Tgstation.Server.Host.Components.Session
 		}
 
 		/// <inheritdoc />
-		public void EnableCustomChatCommands() => chatTrackingContext.Active = DMApiAvailable;
-
-		/// <inheritdoc />
 		public ValueTask Release()
 		{
 			CheckDisposed();
@@ -751,6 +748,7 @@ namespace Tgstation.Server.Host.Components.Session
 					break;
 				case BridgeCommandType.Kill:
 					Logger.LogInformation("Bridge requested process termination!");
+					chatTrackingContext.Active = false;
 					TerminationWasRequested = true;
 					process.Terminate();
 					break;
@@ -839,15 +837,17 @@ namespace Tgstation.Server.Host.Components.Session
 
 					// Load custom commands
 					chatTrackingContext.CustomCommands = parameters.CustomCommands;
+					chatTrackingContext.Active = true;
 					Interlocked.Exchange(ref startupTcs, new TaskCompletionSource()).SetResult();
 					break;
 				case BridgeCommandType.Reboot:
 					Interlocked.Increment(ref rebootBridgeRequestsProcessing);
 					try
 					{
+						chatTrackingContext.Active = false;
+
 						if (ClosePortOnReboot)
 						{
-							chatTrackingContext.Active = false;
 							response.NewPort = 0;
 							portClosedForReboot = true;
 						}

--- a/src/Tgstation.Server.Host/Components/StaticFiles/Configuration.cs
+++ b/src/Tgstation.Server.Host/Components/StaticFiles/Configuration.cs
@@ -326,16 +326,10 @@ namespace Tgstation.Server.Host.Components.StaticFiles
 									result = ioManager.GetFileStream(path, false);
 								}
 
-								using (SemaphoreSlimContext.TryLock(semaphore, out var locked))
-								{
-									if (!locked)
-										return null;
-
-									if (systemIdentity == null)
-										await Task.Factory.StartNew(GetFileStream, cancellationToken, DefaultIOManager.BlockingTaskCreationOptions, TaskScheduler.Current);
-									else
-										await systemIdentity.RunImpersonated(GetFileStream, cancellationToken);
-								}
+								if (systemIdentity == null)
+									await Task.Factory.StartNew(GetFileStream, cancellationToken, DefaultIOManager.BlockingTaskCreationOptions, TaskScheduler.Current);
+								else
+									await systemIdentity.RunImpersonated(GetFileStream, cancellationToken);
 
 								return result;
 							},

--- a/src/Tgstation.Server.Host/Components/Watchdog/BasicWatchdog.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/BasicWatchdog.cs
@@ -256,8 +256,6 @@ namespace Tgstation.Server.Host.Components.Watchdog
 					await SessionStartupPersist(cancellationToken);
 
 				await CheckLaunchResult(Server, "Server", cancellationToken);
-
-				Server.EnableCustomChatCommands();
 			}
 			catch (Exception ex)
 			{

--- a/src/Tgstation.Server.Host/Components/Watchdog/BasicWatchdog.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/BasicWatchdog.cs
@@ -289,11 +289,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="ValueTask{TResult}"/> resulting in the <see cref="MonitorAction"/> to take.</returns>
 		protected virtual ValueTask<MonitorAction> HandleNormalReboot(CancellationToken cancellationToken)
-		{
-			var settingsUpdatePending = ActiveLaunchParameters != LastLaunchParameters;
-			var result = settingsUpdatePending ? MonitorAction.Restart : MonitorAction.Continue;
-			return ValueTask.FromResult(result);
-		}
+			=> ValueTask.FromResult(MonitorAction.Continue);
 
 		/// <summary>
 		/// Handler for <see cref="MonitorActivationReason.NewDmbAvailable"/>.

--- a/src/Tgstation.Server.Host/Components/Watchdog/IWatchdog.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/IWatchdog.cs
@@ -37,6 +37,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 		/// <summary>
 		/// The <see cref="DreamDaemonLaunchParameters"/> the active server is using.
 		/// </summary>
+		/// <remarks>This may not be the exact same as <see cref="ActiveLaunchParameters"/> but still be associated with the same session.</remarks>
 		DreamDaemonLaunchParameters LastLaunchParameters { get; }
 
 		/// <summary>

--- a/tests/DMAPI/LongRunning/Test.dm
+++ b/tests/DMAPI/LongRunning/Test.dm
@@ -168,7 +168,7 @@ var/run_bridge_test
 	var/tactics7 = data["tgs_integration_test_tactics7"]
 	if(tactics7)
 		var/list/channels = TgsChatChannelInfo()
-		return "[length(channels)]"
+		return length(channels)
 
 	var/tactics8 = data["tgs_integration_test_tactics8"]
 	if(tactics8)

--- a/tests/Tgstation.Server.Tests/Live/HardFailLogger.cs
+++ b/tests/Tgstation.Server.Tests/Live/HardFailLogger.cs
@@ -28,6 +28,7 @@ namespace Tgstation.Server.Tests.Live
 				&& !logMessage.StartsWith("Error disconnecting connection ")
 				&& !(logMessage.StartsWith("An exception occurred while iterating over the results of a query for context type") && (exception is OperationCanceledException || exception?.InnerException is OperationCanceledException))
 				&& !(logMessage.StartsWith("An error occurred using the connection to database ") && (exception is OperationCanceledException || exception?.InnerException is OperationCanceledException))
+				&& !(logMessage.StartsWith("Error when dispatching 'OnConnectedAsync' on hub") && (exception is OperationCanceledException || exception?.InnerException is OperationCanceledException))
 				&& !(logMessage.StartsWith("An exception occurred in the database while saving changes for context type") && (exception is OperationCanceledException || exception?.InnerException is OperationCanceledException)))
 				|| (logLevel == LogLevel.Critical && logMessage != "DropDatabase configuration option set! Dropping any existing database..."))
 			{

--- a/tests/Tgstation.Server.Tests/Live/HardFailLogger.cs
+++ b/tests/Tgstation.Server.Tests/Live/HardFailLogger.cs
@@ -27,6 +27,7 @@ namespace Tgstation.Server.Tests.Live
 				&& !((exception is BadHttpRequestException) && logMessage.Contains("Unexpected end of request content.")) // canceled request
 				&& !logMessage.StartsWith("Error disconnecting connection ")
 				&& !(logMessage.StartsWith("An exception occurred while iterating over the results of a query for context type") && (exception is OperationCanceledException || exception?.InnerException is OperationCanceledException))
+				&& !(logMessage.StartsWith("An error occurred using the connection to database ") && (exception is OperationCanceledException || exception?.InnerException is OperationCanceledException))
 				&& !(logMessage.StartsWith("An exception occurred in the database while saving changes for context type") && (exception is OperationCanceledException || exception?.InnerException is OperationCanceledException)))
 				|| (logLevel == LogLevel.Critical && logMessage != "DropDatabase configuration option set! Dropping any existing database..."))
 			{

--- a/tests/Tgstation.Server.Tests/Live/Instance/WatchdogTest.cs
+++ b/tests/Tgstation.Server.Tests/Live/Instance/WatchdogTest.cs
@@ -497,13 +497,14 @@ namespace Tgstation.Server.Tests.Live.Instance
 			Assert.AreEqual(false, daemonStatus.SoftRestart);
 			Assert.AreEqual(false, daemonStatus.SoftShutdown);
 			Assert.AreEqual(string.Empty, daemonStatus.AdditionalParameters);
+			Assert.AreEqual(false, daemonStatus.SoftRestart);
 			var initialCompileJob = daemonStatus.ActiveCompileJob;
 			await CheckDMApiFail(daemonStatus.ActiveCompileJob, cancellationToken);
 
 			daemonStatus = await DeployTestDme("BasicOperation/basic_operation_test", DreamDaemonSecurity.Trusted, true, cancellationToken);
 
 			Assert.AreEqual(WatchdogStatus.Online, daemonStatus.Status.Value);
-
+			Assert.AreEqual(false, daemonStatus.SoftRestart); // dme name change triggered, instant reboot
 			Assert.AreEqual(initialCompileJob.Id, daemonStatus.ActiveCompileJob.Id);
 			var newerCompileJob = daemonStatus.StagedCompileJob;
 
@@ -1063,6 +1064,7 @@ namespace Tgstation.Server.Tests.Live.Instance
 			Assert.IsNull(daemonStatus.StagedCompileJob);
 			Assert.AreEqual(DMApiConstants.InteropVersion, daemonStatus.ActiveCompileJob.DMApiVersion);
 			Assert.AreEqual(DreamDaemonSecurity.Safe, daemonStatus.ActiveCompileJob.MinimumSecurityLevel);
+			Assert.AreEqual(false, daemonStatus.SoftRestart);
 
 			var startJob = await StartDD(cancellationToken);
 
@@ -1072,6 +1074,7 @@ namespace Tgstation.Server.Tests.Live.Instance
 
 
 			Assert.AreEqual(WatchdogStatus.Online, daemonStatus.Status.Value);
+			Assert.AreEqual(true, daemonStatus.SoftRestart);
 			CheckDDPriority();
 
 			Assert.AreEqual(initialCompileJob.Id, daemonStatus.ActiveCompileJob.Id);
@@ -1085,6 +1088,7 @@ namespace Tgstation.Server.Tests.Live.Instance
 			daemonStatus = await TellWorldToReboot(cancellationToken);
 
 			Assert.AreNotEqual(initialCompileJob.Id, daemonStatus.ActiveCompileJob.Id);
+			Assert.AreEqual(false, daemonStatus.SoftRestart);
 			Assert.IsNull(daemonStatus.StagedCompileJob);
 
 			await instanceClient.DreamDaemon.Shutdown(cancellationToken);

--- a/tests/Tgstation.Server.Tests/Live/TestLiveServer.cs
+++ b/tests/Tgstation.Server.Tests/Live/TestLiveServer.cs
@@ -104,7 +104,10 @@ namespace Tgstation.Server.Tests.Live
 		{
 			foreach (var proc in GetDDProcessesOnPort(null))
 				using (proc)
+				{
 					proc.Kill();
+					proc.WaitForExit();
+				}
 		}
 
 		static ushort FreeTcpPort(params ushort[] usedPorts)

--- a/tests/Tgstation.Server.Tests/Live/TestLiveServer.cs
+++ b/tests/Tgstation.Server.Tests/Live/TestLiveServer.cs
@@ -1235,6 +1235,9 @@ namespace Tgstation.Server.Tests.Live
 			// uncomment to force this test to run with DummyChatProviders
 			// missingChatVarsCount = TotalChatVars;
 
+			// uncomment to force this test to run with pasic watchdog
+			// Environment.SetEnvironmentVariable("General__UseBasicWatchdog", "true");
+
 			if (missingChatVarsCount != 0)
 			{
 				if (missingChatVarsCount != TotalChatVars)

--- a/tests/Tgstation.Server.Tests/Live/TestLiveServer.cs
+++ b/tests/Tgstation.Server.Tests/Live/TestLiveServer.cs
@@ -1478,24 +1478,11 @@ namespace Tgstation.Server.Tests.Live
 					var chatReadTask = instanceClient.ChatBots.List(null, cancellationToken);
 
 					// Check the DMAPI got the channels again https://github.com/tgstation/tgstation-server/issues/1490
-					var tries = 3;
-					while (true)
-						try
-						{
-							// HEY I THINK I FOUND A WAY TO RELIABLY REPRODUCE THE TOPIC HANG
-							// JUST SET A BREAKPOINT IN THE CATCH
-							// Maybe, with enough investigation, either I can figure out the cause or get Lummox to tell me
-							topicRequestResult = await WatchdogTest.StaticTopicClient.SendTopic(
-								IPAddress.Loopback,
-								$"tgs_integration_test_tactics7=1",
-								mainDDPort,
-								cancellationToken);
-							break;
-						}
-						catch (OperationCanceledException) when (--tries > 0)
-						{
-							await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
-						}
+					topicRequestResult = await WatchdogTest.StaticTopicClient.SendTopic(
+						IPAddress.Loopback,
+						$"tgs_integration_test_tactics7=1",
+						mainDDPort,
+						cancellationToken);
 
 					Assert.IsNotNull(topicRequestResult);
 					if(!Int32.TryParse(topicRequestResult.StringData, out var channelsPresent))

--- a/tests/Tgstation.Server.Tests/Live/TestLiveServer.cs
+++ b/tests/Tgstation.Server.Tests/Live/TestLiveServer.cs
@@ -1485,15 +1485,12 @@ namespace Tgstation.Server.Tests.Live
 						cancellationToken);
 
 					Assert.IsNotNull(topicRequestResult);
-					if(!Int32.TryParse(topicRequestResult.StringData, out var channelsPresent))
-					{
-						Assert.Fail("Expected DD to send us an int!");
-					}
+					Assert.IsTrue(topicRequestResult.FloatData.HasValue);
 
 					var currentChatBots = await chatReadTask;
 					var connectedChannelCount = currentChatBots.Where(x => x.Enabled.Value).SelectMany(x => x.Channels).Count();
 
-					Assert.AreEqual(connectedChannelCount, channelsPresent);
+					Assert.AreEqual(connectedChannelCount, topicRequestResult.FloatData.Value);
 
 					await WatchdogTest.TellWorldToReboot2(instanceClient, WatchdogTest.StaticTopicClient, mainDDPort, cancellationToken);
 

--- a/tests/Tgstation.Server.Tests/Live/TestLiveServer.cs
+++ b/tests/Tgstation.Server.Tests/Live/TestLiveServer.cs
@@ -1475,11 +1475,24 @@ namespace Tgstation.Server.Tests.Live
 					var chatReadTask = instanceClient.ChatBots.List(null, cancellationToken);
 
 					// Check the DMAPI got the channels again https://github.com/tgstation/tgstation-server/issues/1490
-					topicRequestResult = await WatchdogTest.StaticTopicClient.SendTopic(
-						IPAddress.Loopback,
-						$"tgs_integration_test_tactics7=1",
-						mainDDPort,
-						cancellationToken);
+					var tries = 3;
+					while (true)
+						try
+						{
+							// HEY I THINK I FOUND A WAY TO RELIABLY REPRODUCE THE TOPIC HANG
+							// JUST SET A BREAKPOINT IN THE CATCH
+							// Maybe, with enough investigation, either I can figure out the cause or get Lummox to tell me
+							topicRequestResult = await WatchdogTest.StaticTopicClient.SendTopic(
+								IPAddress.Loopback,
+								$"tgs_integration_test_tactics7=1",
+								mainDDPort,
+								cancellationToken);
+							break;
+						}
+						catch (OperationCanceledException) when (--tries > 0)
+						{
+							await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
+						}
 
 					Assert.IsNotNull(topicRequestResult);
 					if(!Int32.TryParse(topicRequestResult.StringData, out var channelsPresent))


### PR DESCRIPTION
:cl:
Cleaned up handling of topic requests while the server is starting/rebooting.
Reduced Discord API spam when connecting to a guild with many mapped channels.
Fixed race condition that could result in TGS having multiple mappings of the same chat channel.
Fixed downloading instance `Configuration` files requiring exclusive access.
The previous patch erroneously caused full watchdog restarts whenever any setting was changed. This has been rectified.
/:cl:

And a bunch of live test fixes.