### PR TITLE
Update pinned `yarn` version to 1.22.21

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -19,6 +19,6 @@
     <!-- Update this frequently with dotnet runtime patches. MAJOR MUST MATCH ABOVE! -->
     <TgsDotnetRedistUrl>https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/6.0.24/dotnet-hosting-6.0.24-win.exe</TgsDotnetRedistUrl>
     <TgsMariaDBRedistVersion>10.11.6</TgsMariaDBRedistVersion>
-    <TgsYarnVersion>1.22.19</TgsYarnVersion>
+    <TgsYarnVersion>1.22.21</TgsYarnVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
I've seen several spurious failures with .19 and I'm hoping this fixes it.