### PR TITLE
Fix `TopicPort` not being included in session persistence. Fix exit code 0 crashes. Fix homepage link. Fix transfer upload limits. Reduce SignalR spam

### DIFF
--- a/src/Tgstation.Server.Host/Components/Session/SessionPersistor.cs
+++ b/src/Tgstation.Server.Host/Components/Session/SessionPersistor.cs
@@ -83,6 +83,7 @@ namespace Tgstation.Server.Host.Components.Session
 				RebootState = reattachInformation.RebootState,
 				LaunchSecurityLevel = reattachInformation.LaunchSecurityLevel,
 				LaunchVisibility = reattachInformation.LaunchVisibility,
+				TopicPort = reattachInformation.TopicPort,
 			};
 
 			db.ReattachInformations.Add(dbReattachInfo);
@@ -116,6 +117,7 @@ namespace Tgstation.Server.Host.Components.Session
 			dbReattachInfo.RebootState = reattachInformation.RebootState;
 			dbReattachInfo.LaunchSecurityLevel = reattachInformation.LaunchSecurityLevel;
 			dbReattachInfo.LaunchVisibility = reattachInformation.LaunchVisibility;
+			dbReattachInfo.TopicPort = reattachInformation.TopicPort;
 
 			await db.Save(cancellationToken);
 

--- a/src/Tgstation.Server.Host/Components/Watchdog/BasicWatchdog.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/BasicWatchdog.cs
@@ -113,7 +113,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 			switch (reason)
 			{
 				case MonitorActivationReason.ActiveServerCrashed:
-					var eventType = controller.TerminationWasRequested
+					var eventType = controller.TerminationWasRequested || (await controller.Lifetime) == 0
 						? EventType.WorldEndProcess
 						: EventType.WatchdogCrash;
 					await HandleEventImpl(eventType, Enumerable.Empty<string>(), false, cancellationToken);

--- a/src/Tgstation.Server.Host/Controllers/RootController.cs
+++ b/src/Tgstation.Server.Host/Controllers/RootController.cs
@@ -97,7 +97,7 @@ namespace Tgstation.Server.Host.Controllers
 			var panelEnabled = controlPanelConfiguration.Enable;
 			var apiDocsEnabled = generalConfiguration.HostApiDocumentation;
 
-			var controlPanelRoute = ControlPanelController.ControlPanelRoute.TrimStart('/');
+			var controlPanelRoute = $"{ControlPanelController.ControlPanelRoute.TrimStart('/')}/";
 			if (panelEnabled ^ apiDocsEnabled)
 				if (panelEnabled)
 					return Redirect(controlPanelRoute);

--- a/src/Tgstation.Server.Host/Controllers/TransferController.cs
+++ b/src/Tgstation.Server.Host/Controllers/TransferController.cs
@@ -80,6 +80,7 @@ namespace Tgstation.Server.Host.Controllers
 		/// <response code="410">The <paramref name="ticket"/> was no longer or was never valid.</response>
 		[TgsAuthorize]
 		[HttpPut]
+		[DisableRequestSizeLimit]
 		[ProducesResponseType(204)]
 		[ProducesResponseType(410, Type = typeof(ErrorMessageResponse))]
 		public async ValueTask<IActionResult> Upload([Required, FromQuery] string ticket, CancellationToken cancellationToken)

--- a/src/Tgstation.Server.Host/Jobs/JobService.cs
+++ b/src/Tgstation.Server.Host/Jobs/JobService.cs
@@ -30,7 +30,7 @@ namespace Tgstation.Server.Host.Jobs
 		/// <summary>
 		/// The maximum rate at which hub clients can receive updates.
 		/// </summary>
-		const int MaxHubUpdatesPerSecond = 4;
+		const int MaxHubUpdatesPerSecond = 1;
 
 		/// <summary>
 		/// The <see cref="IHubContext"/> for the <see cref="JobsHub"/>.

--- a/tests/Tgstation.Server.Tests/Live/Instance/InstanceTest.cs
+++ b/tests/Tgstation.Server.Tests/Live/Instance/InstanceTest.cs
@@ -161,7 +161,7 @@ namespace Tgstation.Server.Tests.Live.Instance
 
 			async Task UpdateDMSettings()
 			{
-				for (var i = 0; i < 5; ++i)
+				for (var i = 0; i < 10; ++i)
 					try
 					{
 						await instanceClient.DreamMaker.Update(new DreamMakerRequest

--- a/tests/Tgstation.Server.Tests/Live/TestLiveServer.cs
+++ b/tests/Tgstation.Server.Tests/Live/TestLiveServer.cs
@@ -154,7 +154,7 @@ namespace Tgstation.Server.Tests.Live
 			{
 				do
 				{
-					var l = new TcpListener(IPAddress.Loopback, 0);
+					var l = new TcpListener(IPAddress.Any, 0);
 					l.Start();
 					try
 					{


### PR DESCRIPTION
🆑
Fixed health checks failing on OpenDream servers after a TGS restart.
When game servers exit with code 0, chat bots will no longer call it a crash.
Fixed homepage links to the app again.
Removed size limit on `/Transfer` uploads.
Reduced number of job updates per second sent over SignalR from 4 to 1.
/🆑