### PR TITLE
Add `Session:DelayCleaningFailedDeployments` config

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -4,7 +4,7 @@
   <Import Project="WebpanelVersion.props" />
   <PropertyGroup>
     <TgsCoreVersion>6.1.2</TgsCoreVersion>
-    <TgsConfigVersion>5.0.0</TgsConfigVersion>
+    <TgsConfigVersion>5.1.0</TgsConfigVersion>
     <TgsApiVersion>10.0.0</TgsApiVersion>
     <TgsCommonLibraryVersion>7.0.0</TgsCommonLibraryVersion>
     <TgsApiLibraryVersion>13.0.1</TgsApiLibraryVersion>

--- a/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
@@ -953,6 +953,12 @@ namespace Tgstation.Server.Host.Components.Deployment
 		{
 			async ValueTask CleanDir()
 			{
+				if (sessionConfiguration.DelayCleaningFailedDeployments)
+				{
+					logger.LogDebug("Not cleaning up errored deployment directory {guid} due to config.", job.DirectoryName);
+					return;
+				}
+
 				logger.LogTrace("Cleaning compile directory...");
 				var jobPath = job.DirectoryName!.Value.ToString();
 				try

--- a/src/Tgstation.Server.Host/Configuration/SessionConfiguration.cs
+++ b/src/Tgstation.Server.Host/Configuration/SessionConfiguration.cs
@@ -24,5 +24,10 @@
 		/// If the deployment DreamMaker and DreamDaemon instances are set to be below normal priority processes.
 		/// </summary>
 		public bool LowPriorityDeploymentProcesses { get; set; }
+
+		/// <summary>
+		/// If <see langword="true"/>, deployments that fail will not be immediately cleaned up. They will be cleaned up the next time the instance is onlined.
+		/// </summary>
+		public bool DelayCleaningFailedDeployments { get; set; }
 	}
 }

--- a/src/Tgstation.Server.Host/appsettings.yml
+++ b/src/Tgstation.Server.Host/appsettings.yml
@@ -22,6 +22,7 @@ General:
 Session:
   HighPriorityLiveDreamDaemon: false # If DreamDaemon instances should run as higher priority processes
   LowPriorityDeploymentProcesses: true # If TGS Deployments should run as lower priority processes
+  DelayCleaningFailedDeployments: false # If true, deployments that fail will not be immediately cleaned up. They will be cleaned up the next time the instance is onlined
 FileLogging:
   Directory: # Directory in which log files are stored. Windows default: %PROGRAMDATA%/tgstation-server. Linux default: /var/log/tgstation-server
   Disable: true # Disable file logging entirely


### PR DESCRIPTION
Closes #1768

🆑 **Configuration**
**The new config version is `5.1.0`.**
Added `Session:DelayCleaningFailedDeployments`. If set, failed deployments will leave their directories intact. They will be automatically cleaned up the next time the instance is onlined (i.e. When TGS restarts).
/🆑