### PR TITLE
Fix DMAPI chat message ordering

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -9,7 +9,7 @@
     <TgsCommonLibraryVersion>7.0.0</TgsCommonLibraryVersion>
     <TgsApiLibraryVersion>13.0.1</TgsApiLibraryVersion>
     <TgsClientVersion>15.0.1</TgsClientVersion>
-    <TgsDmapiVersion>7.0.1</TgsDmapiVersion>
+    <TgsDmapiVersion>7.0.2</TgsDmapiVersion>
     <TgsInteropVersion>5.8.0</TgsInteropVersion>
     <TgsHostWatchdogVersion>1.4.1</TgsHostWatchdogVersion>
     <TgsContainerScriptVersion>1.2.1</TgsContainerScriptVersion>

--- a/src/DMAPI/tgs.dm
+++ b/src/DMAPI/tgs.dm
@@ -1,6 +1,6 @@
 // tgstation-server DMAPI
 
-#define TGS_DMAPI_VERSION "7.0.1"
+#define TGS_DMAPI_VERSION "7.0.2"
 
 // All functions and datums outside this document are subject to change with any version and should not be relied on.
 
@@ -426,6 +426,7 @@
 
 /**
  * Send a message to connected chats. This function may sleep!
+ * If TGS is offline when called, the message may be placed in a queue to be sent and this function will return immediately. Your message will be sent when TGS reconnects to the game.
  *
  * message - The [/datum/tgs_message_content] to send.
  * admin_only: If [TRUE], message will be sent to admin connected chats. Vice-versa applies.
@@ -435,6 +436,7 @@
 
 /**
  * Send a private message to a specific user. This function may sleep!
+ * If TGS is offline when called, the message may be placed in a queue to be sent and this function will return immediately. Your message will be sent when TGS reconnects to the game.
  *
  * message - The [/datum/tgs_message_content] to send.
  * user: The [/datum/tgs_chat_user] to PM.
@@ -444,6 +446,7 @@
 
 /**
  * Send a message to connected chats that are flagged as game-related in TGS. This function may sleep!
+ * If TGS is offline when called, the message may be placed in a queue to be sent and this function will return immediately. Your message will be sent when TGS reconnects to the game.
  *
  * message - The [/datum/tgs_message_content] to send.
  * channels - Optional list of [/datum/tgs_chat_channel]s to restrict the message to.

--- a/src/DMAPI/tgs/v5/api.dm
+++ b/src/DMAPI/tgs/v5/api.dm
@@ -194,17 +194,7 @@
 		var/datum/tgs_chat_channel/channel = I
 		ids += channel.id
 
-	message2 = UpgradeDeprecatedChatMessage(message2)
-
-	if (!length(channels))
-		return
-
-	var/list/data = message2._interop_serialize()
-	data[DMAPI5_CHAT_MESSAGE_CHANNEL_IDS] = ids
-	if(intercepted_message_queue)
-		intercepted_message_queue += list(data)
-	else
-		Bridge(DMAPI5_BRIDGE_COMMAND_CHAT_SEND, list(DMAPI5_BRIDGE_PARAMETER_CHAT_MESSAGE = data))
+	SendChatMessageRaw(message2, ids)
 
 /datum/tgs_api/v5/ChatTargetedBroadcast(datum/tgs_message_content/message2, admin_only)
 	var/list/channels = list()
@@ -213,22 +203,19 @@
 		if (!channel.is_private_channel && ((channel.is_admin_channel && admin_only) || (!channel.is_admin_channel && !admin_only)))
 			channels += channel.id
 
+	SendChatMessageRaw(message2, channels)
+
+/datum/tgs_api/v5/ChatPrivateMessage(datum/tgs_message_content/message2, datum/tgs_chat_user/user)
+	SendChatMessageRaw(message2, list(user.channel.id))
+
+/datum/tgs_api/v5/proc/SendChatMessageRaw(datum/tgs_message_content/message2, list/channel_ids)
 	message2 = UpgradeDeprecatedChatMessage(message2)
 
-	if (!length(channels))
+	if (!length(channel_ids))
 		return
 
 	var/list/data = message2._interop_serialize()
-	data[DMAPI5_CHAT_MESSAGE_CHANNEL_IDS] = channels
-	if(intercepted_message_queue)
-		intercepted_message_queue += list(data)
-	else
-		Bridge(DMAPI5_BRIDGE_COMMAND_CHAT_SEND, list(DMAPI5_BRIDGE_PARAMETER_CHAT_MESSAGE = data))
-
-/datum/tgs_api/v5/ChatPrivateMessage(datum/tgs_message_content/message2, datum/tgs_chat_user/user)
-	message2 = UpgradeDeprecatedChatMessage(message2)
-	var/list/data = message2._interop_serialize()
-	data[DMAPI5_CHAT_MESSAGE_CHANNEL_IDS] = list(user.channel.id)
+	data[DMAPI5_CHAT_MESSAGE_CHANNEL_IDS] = channel_ids
 	if(intercepted_message_queue)
 		intercepted_message_queue += list(data)
 	else


### PR DESCRIPTION
Fixes #1744

🆑 DreamMaker API
Fixed chat messages being sent in a random order rather than FIFO while TGS was rebooting. Note, they may still appear out of order due to a potential bug as of TGS 6.1.2 but this fix is necessary to guarantee order in the first place.
/🆑

Merging with `[DMDeploy]`