### PR TITLE
v6.1.4: Fix more subpath stupidity

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="WebpanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>6.1.3</TgsCoreVersion>
+    <TgsCoreVersion>6.1.4</TgsCoreVersion>
     <TgsConfigVersion>5.0.0</TgsConfigVersion>
     <TgsApiVersion>10.0.0</TgsApiVersion>
     <TgsCommonLibraryVersion>7.0.0</TgsCommonLibraryVersion>

--- a/build/package/winget/manifest/Tgstation.Server.installer.yaml
+++ b/build/package/winget/manifest/Tgstation.Server.installer.yaml
@@ -22,9 +22,6 @@ Installers:
   AppsAndFeaturesEntries:
   - DisplayName: tgstation-server
     Publisher: /tg/station 13
-  Dependencies:
-    PackageDependencies:
-    - PackageIdentifier: Microsoft.DotNet.HostingBundle.8
   ReleaseDate: 2023-06-24 # Do not change. Set before publish by push_manifest.ps1
 ManifestType: installer
 ManifestVersion: 1.5.0

--- a/src/Tgstation.Server.Host/Controllers/ControlPanelController.cs
+++ b/src/Tgstation.Server.Host/Controllers/ControlPanelController.cs
@@ -31,6 +31,11 @@ namespace Tgstation.Server.Host.Controllers
 		public const string ControlPanelRoute = "/app";
 
 		/// <summary>
+		/// The route to the control panel channel .json.
+		/// </summary>
+		public const string ChannelJsonRoute = "channel.json";
+
+		/// <summary>
 		/// Header for forcing channel.json to be fetched.
 		/// </summary>
 		const string FetchChannelVaryHeader = "X-Webpanel-Fetch-Channel";
@@ -70,7 +75,7 @@ namespace Tgstation.Server.Host.Controllers
 		/// Returns the <see cref="ControlPanelConfiguration.Channel"/>.
 		/// </summary>
 		/// <returns>A <see cref="JsonResult"/> with the <see cref="ControlPanelConfiguration.Channel"/>.</returns>
-		[Route("channel.json")]
+		[Route(ChannelJsonRoute)]
 		[HttpGet]
 		public IActionResult GetChannelJson()
 		{

--- a/src/Tgstation.Server.Host/Core/Application.cs
+++ b/src/Tgstation.Server.Host/Core/Application.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Globalization;
@@ -503,6 +503,10 @@ namespace Tgstation.Server.Host.Core
 
 			if (generalConfiguration.HostApiDocumentation)
 			{
+				var siteDocPath = Routes.ApiRoot + $"doc/{SwaggerConfiguration.DocumentName}.json";
+				if (!String.IsNullOrWhiteSpace(controlPanelConfiguration.PublicPath))
+					siteDocPath = controlPanelConfiguration.PublicPath.TrimEnd('/') + siteDocPath;
+
 				applicationBuilder.UseSwagger(options =>
 				{
 					options.RouteTemplate = Routes.ApiRoot + "doc/{documentName}.{json|yaml}";
@@ -510,7 +514,7 @@ namespace Tgstation.Server.Host.Core
 				applicationBuilder.UseSwaggerUI(options =>
 				{
 					options.RoutePrefix = SwaggerConfiguration.DocumentationSiteRouteExtension;
-					options.SwaggerEndpoint(Routes.ApiRoot + $"doc/{SwaggerConfiguration.DocumentName}.json", "TGS API");
+					options.SwaggerEndpoint(siteDocPath, "TGS API");
 				});
 				logger.LogTrace("Swagger API generation enabled");
 			}

--- a/src/Tgstation.Server.Host/Core/Application.cs
+++ b/src/Tgstation.Server.Host/Core/Application.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Globalization;
@@ -524,6 +524,7 @@ namespace Tgstation.Server.Host.Core
 					RequestPath = ControlPanelController.ControlPanelRoute,
 					EnableDefaultFiles = true,
 					EnableDirectoryBrowsing = false,
+					RedirectToAppendTrailingSlash = false,
 				});
 			}
 			else


### PR DESCRIPTION
🆑
Removed to redirect from `/app` to `/app` for the webpanel.
The API documentation UI at `/documentation` will now use `ControlPanel:PublicPath` to locate the `tgs_api.json` if it is set. Note, that means this site MUST be accessed using the public path to function correctly.
/🆑

Fixes #1761