### PR TITLE
Minidumps

### DIFF
--- a/build/SrcCommon.props
+++ b/build/SrcCommon.props
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <!-- Usage: Linting -->
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/build/Version.props
+++ b/build/Version.props
@@ -5,10 +5,10 @@
   <PropertyGroup>
     <TgsCoreVersion>6.1.5</TgsCoreVersion>
     <TgsConfigVersion>5.1.0</TgsConfigVersion>
-    <TgsApiVersion>10.0.0</TgsApiVersion>
+    <TgsApiVersion>10.1.0</TgsApiVersion>
     <TgsCommonLibraryVersion>7.0.0</TgsCommonLibraryVersion>
-    <TgsApiLibraryVersion>13.0.1</TgsApiLibraryVersion>
-    <TgsClientVersion>15.0.1</TgsClientVersion>
+    <TgsApiLibraryVersion>13.1.0</TgsApiLibraryVersion>
+    <TgsClientVersion>15.1.0</TgsClientVersion>
     <TgsDmapiVersion>7.0.2</TgsDmapiVersion>
     <TgsInteropVersion>5.8.0</TgsInteropVersion>
     <TgsHostWatchdogVersion>1.4.1</TgsHostWatchdogVersion>

--- a/src/Tgstation.Server.Api/Models/Internal/DreamDaemonLaunchParameters.cs
+++ b/src/Tgstation.Server.Api/Models/Internal/DreamDaemonLaunchParameters.cs
@@ -99,6 +99,13 @@ namespace Tgstation.Server.Api.Models.Internal
 		public uint? MapThreads { get; set; }
 
 		/// <summary>
+		/// If minidumps should be taken instead of full dumps.
+		/// </summary>
+		[Required]
+		[ResponseOptions]
+		public bool? Minidumps { get; set; }
+
+		/// <summary>
 		/// Check if we match a given set of <paramref name="otherParameters"/>. <see cref="StartupTimeout"/> is excluded.
 		/// </summary>
 		/// <param name="otherParameters">The <see cref="DreamDaemonLaunchParameters"/> to compare against.</param>
@@ -116,7 +123,7 @@ namespace Tgstation.Server.Api.Models.Internal
 				&& AdditionalParameters == otherParameters.AdditionalParameters
 				&& StartProfiler == otherParameters.StartProfiler
 				&& LogOutput == otherParameters.LogOutput
-				&& MapThreads == otherParameters.MapThreads; // We intentionally don't check StartupTimeout, health check seconds, or health check dump as they don't matter in terms of the watchdog
+				&& MapThreads == otherParameters.MapThreads; // We intentionally don't check StartupTimeout, Minidumps, health check seconds, or health check dump as they don't matter in terms of the watchdog
 		}
 	}
 }

--- a/src/Tgstation.Server.Api/Rights/DreamDaemonRights.cs
+++ b/src/Tgstation.Server.Api/Rights/DreamDaemonRights.cs
@@ -117,5 +117,10 @@ namespace Tgstation.Server.Api.Rights
 		/// User can use <see cref="Models.Request.DreamDaemonRequest.BroadcastMessage"/>.
 		/// </summary>
 		BroadcastMessage = 1 << 20,
+
+		/// <summary>
+		/// User can use <see cref="Models.Internal.DreamDaemonLaunchParameters.Minidumps"/>.
+		/// </summary>
+		SetMinidumps = 1 << 21,
 	}
 }

--- a/src/Tgstation.Server.Host/.config/dotnet-tools.json
+++ b/src/Tgstation.Server.Host/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-ef": {
-      "version": "8.0.0",
+      "version": "8.0.1",
       "commands": [
         "dotnet-ef"
       ]

--- a/src/Tgstation.Server.Host/Components/Session/SessionController.cs
+++ b/src/Tgstation.Server.Host/Components/Session/SessionController.cs
@@ -487,12 +487,12 @@ namespace Tgstation.Server.Host.Components.Session
 				cancellationToken);
 
 		/// <inheritdoc />
-		public ValueTask CreateDump(string outputFile, CancellationToken cancellationToken)
+		public ValueTask CreateDump(string outputFile, bool minidump, CancellationToken cancellationToken)
 		{
 			if (engineLock.UseDotnetDump)
-				return dotnetDumpService.Dump(process, outputFile, cancellationToken);
+				return dotnetDumpService.Dump(process, outputFile, minidump, cancellationToken);
 
-			return process.CreateDump(outputFile, cancellationToken);
+			return process.CreateDump(outputFile, minidump, cancellationToken);
 		}
 
 		/// <summary>

--- a/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
@@ -1249,7 +1249,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 				throw new JobException(ErrorCode.GameServerOffline);
 
 			Logger.LogInformation("Dumping session to {dumpFileName}...", dumpFileName);
-			await session.CreateDump(dumpFileName, cancellationToken);
+			await session.CreateDump(dumpFileName, ActiveLaunchParameters.Minidumps!.Value, cancellationToken);
 		}
 	}
 }

--- a/src/Tgstation.Server.Host/Controllers/DreamDaemonController.cs
+++ b/src/Tgstation.Server.Host/Controllers/DreamDaemonController.cs
@@ -149,7 +149,8 @@ namespace Tgstation.Server.Host.Controllers
 			| DreamDaemonRights.SetProfiler
 			| DreamDaemonRights.SetLogOutput
 			| DreamDaemonRights.SetMapThreads
-			| DreamDaemonRights.BroadcastMessage)]
+			| DreamDaemonRights.BroadcastMessage
+			| DreamDaemonRights.SetMinidumps)]
 		[ProducesResponseType(typeof(DreamDaemonResponse), 200)]
 		[ProducesResponseType(typeof(ErrorMessageResponse), 410)]
 #pragma warning disable CA1502 // TODO: Decomplexify
@@ -222,7 +223,8 @@ namespace Tgstation.Server.Host.Controllers
 				|| CheckModified(x => x.AdditionalParameters, DreamDaemonRights.SetAdditionalParameters)
 				|| CheckModified(x => x.StartProfiler, DreamDaemonRights.SetProfiler)
 				|| CheckModified(x => x.LogOutput, DreamDaemonRights.SetLogOutput)
-				|| CheckModified(x => x.MapThreads, DreamDaemonRights.SetMapThreads))
+				|| CheckModified(x => x.MapThreads, DreamDaemonRights.SetMapThreads)
+				|| CheckModified(x => x.Minidumps, DreamDaemonRights.SetMinidumps))
 				return Forbid();
 
 			return await WithComponentInstance(
@@ -379,6 +381,7 @@ namespace Tgstation.Server.Host.Controllers
 					result.StartProfiler = settings.StartProfiler;
 					result.LogOutput = settings.LogOutput;
 					result.MapThreads = settings.MapThreads;
+					result.Minidumps = settings.Minidumps;
 				}
 
 				if (revision)

--- a/src/Tgstation.Server.Host/Controllers/InstanceController.cs
+++ b/src/Tgstation.Server.Host/Controllers/InstanceController.cs
@@ -732,6 +732,7 @@ namespace Tgstation.Server.Host.Controllers
 					StartProfiler = false,
 					LogOutput = false,
 					MapThreads = 0,
+					Minidumps = true,
 				},
 				DreamMakerSettings = new DreamMakerSettings
 				{

--- a/src/Tgstation.Server.Host/Database/DatabaseContext.cs
+++ b/src/Tgstation.Server.Host/Database/DatabaseContext.cs
@@ -375,22 +375,22 @@ namespace Tgstation.Server.Host.Database
 		/// <summary>
 		/// Used by unit tests to remind us to setup the correct MSSQL migration downgrades.
 		/// </summary>
-		internal static readonly Type MSLatestMigration = typeof(MSAddTopicPort);
+		internal static readonly Type MSLatestMigration = typeof(MSAddMinidumpsOption);
 
 		/// <summary>
 		/// Used by unit tests to remind us to setup the correct MYSQL migration downgrades.
 		/// </summary>
-		internal static readonly Type MYLatestMigration = typeof(MYAddTopicPort);
+		internal static readonly Type MYLatestMigration = typeof(MYAddMinidumpsOption);
 
 		/// <summary>
 		/// Used by unit tests to remind us to setup the correct PostgresSQL migration downgrades.
 		/// </summary>
-		internal static readonly Type PGLatestMigration = typeof(PGAddTopicPort);
+		internal static readonly Type PGLatestMigration = typeof(PGAddMinidumpsOption);
 
 		/// <summary>
 		/// Used by unit tests to remind us to setup the correct SQLite migration downgrades.
 		/// </summary>
-		internal static readonly Type SLLatestMigration = typeof(SLAddTopicPort);
+		internal static readonly Type SLLatestMigration = typeof(SLAddMinidumpsOption);
 
 		/// <inheritdoc />
 #pragma warning disable CA1502 // Cyclomatic complexity
@@ -418,6 +418,16 @@ namespace Tgstation.Server.Host.Database
 			string? targetMigration = null;
 
 			string BadDatabaseType() => throw new ArgumentException($"Invalid DatabaseType: {currentDatabaseType}", nameof(currentDatabaseType));
+
+			if (targetVersion < new Version(6, 2, 0))
+				targetMigration = currentDatabaseType switch
+				{
+					DatabaseType.MySql => nameof(MYAddTopicPort),
+					DatabaseType.PostgresSql => nameof(PGAddTopicPort),
+					DatabaseType.SqlServer => nameof(MSAddTopicPort),
+					DatabaseType.Sqlite => nameof(SLAddTopicPort),
+					_ => BadDatabaseType(),
+				};
 
 			if (targetVersion < new Version(6, 0, 0))
 				targetMigration = currentDatabaseType switch

--- a/src/Tgstation.Server.Host/Database/Migrations/20240202202038_MSAddMinidumpsOption.Designer.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20240202202038_MSAddMinidumpsOption.Designer.cs
@@ -3,13 +3,16 @@ using System;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Tgstation.Server.Host.Database.Migrations
 {
 	[DbContext(typeof(SqlServerDatabaseContext))]
-	partial class SqlServerDatabaseContextModelSnapshot : ModelSnapshot
+	[Migration("20240202202038_MSAddMinidumpsOption")]
+	partial class MSAddMinidumpsOption
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		/// <inheritdoc />
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder

--- a/src/Tgstation.Server.Host/Database/Migrations/20240202202038_MSAddMinidumpsOption.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20240202202038_MSAddMinidumpsOption.cs
@@ -1,0 +1,37 @@
+﻿using System;
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+using Tgstation.Server.Host.System;
+
+namespace Tgstation.Server.Host.Database.Migrations
+{
+	/// <inheritdoc />
+	public partial class MSAddMinidumpsOption : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+			// This was originally minidumps on Linux and full dumps on Windows
+			var defaultValue = !new PlatformIdentifier().IsWindows;
+			migrationBuilder.AddColumn<bool>(
+				name: "Minidumps",
+				table: "DreamDaemonSettings",
+				type: "bit",
+				nullable: false,
+				defaultValue: defaultValue);
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+			migrationBuilder.DropColumn(
+				name: "Minidumps",
+				table: "DreamDaemonSettings");
+		}
+	}
+}

--- a/src/Tgstation.Server.Host/Database/Migrations/20240202202051_MYAddMinidumpsOption.Designer.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20240202202051_MYAddMinidumpsOption.Designer.cs
@@ -3,20 +3,21 @@ using System;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Tgstation.Server.Host.Database.Migrations
 {
-	[DbContext(typeof(SqlServerDatabaseContext))]
-	partial class SqlServerDatabaseContextModelSnapshot : ModelSnapshot
+	[DbContext(typeof(MySqlDatabaseContext))]
+	[Migration("20240202202051_MYAddMinidumpsOption")]
+	partial class MYAddMinidumpsOption
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		/// <inheritdoc />
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder
 				.HasAnnotation("ProductVersion", "8.0.1")
-				.HasAnnotation("Relational:MaxIdentifierLength", 128);
-
-			SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+				.HasAnnotation("Relational:MaxIdentifierLength", 64);
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.ChatBot", b =>
 			{
@@ -24,18 +25,19 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
-
-				b.Property<int>("ChannelLimit")
-					.HasColumnType("int");
+				b.Property<ushort?>("ChannelLimit")
+					.IsRequired()
+					.HasColumnType("smallint unsigned");
 
 				b.Property<string>("ConnectionString")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("ConnectionString"), "utf8mb4");
 
 				b.Property<bool?>("Enabled")
-					.HasColumnType("bit");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
@@ -43,13 +45,14 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("nvarchar(100)");
+					.HasColumnType("varchar(100)");
 
 				b.Property<int>("Provider")
 					.HasColumnType("int");
 
-				b.Property<long>("ReconnectionInterval")
-					.HasColumnType("bigint");
+				b.Property<uint?>("ReconnectionInterval")
+					.IsRequired()
+					.HasColumnType("int unsigned");
 
 				b.HasKey("Id");
 
@@ -65,47 +68,47 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
-
 				b.Property<long>("ChatSettingsId")
 					.HasColumnType("bigint");
 
-				b.Property<decimal?>("DiscordChannelId")
-					.HasColumnType("decimal(20,0)");
+				b.Property<ulong?>("DiscordChannelId")
+					.HasColumnType("bigint unsigned");
 
 				b.Property<string>("IrcChannel")
 					.HasMaxLength(100)
-					.HasColumnType("nvarchar(100)");
+					.HasColumnType("varchar(100)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("IrcChannel"), "utf8mb4");
 
 				b.Property<bool?>("IsAdminChannel")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("IsSystemChannel")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("IsUpdatesChannel")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("IsWatchdogChannel")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<string>("Tag")
 					.HasMaxLength(10000)
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Tag"), "utf8mb4");
 
 				b.HasKey("Id");
 
 				b.HasIndex("ChatSettingsId", "DiscordChannelId")
-					.IsUnique()
-					.HasFilter("[DiscordChannelId] IS NOT NULL");
+					.IsUnique();
 
 				b.HasIndex("ChatSettingsId", "IrcChannel")
-					.IsUnique()
-					.HasFilter("[IrcChannel] IS NOT NULL");
+					.IsUnique();
 
 				b.ToTable("ChatChannels");
 			});
@@ -115,8 +118,6 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
-
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<int?>("DMApiMajorVersion")
 					.HasColumnType("int");
@@ -129,15 +130,19 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<Guid?>("DirectoryName")
 					.IsRequired()
-					.HasColumnType("uniqueidentifier");
+					.HasColumnType("char(36)");
 
 				b.Property<string>("DmeName")
 					.IsRequired()
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("DmeName"), "utf8mb4");
 
 				b.Property<string>("EngineVersion")
 					.IsRequired()
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("EngineVersion"), "utf8mb4");
 
 				b.Property<int?>("GitHubDeploymentId")
 					.HasColumnType("int");
@@ -153,10 +158,14 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("Output")
 					.IsRequired()
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Output"), "utf8mb4");
 
 				b.Property<string>("RepositoryOrigin")
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("RepositoryOrigin"), "utf8mb4");
 
 				b.Property<long>("RevisionInformationId")
 					.HasColumnType("bigint");
@@ -179,57 +188,62 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
-
 				b.Property<string>("AdditionalParameters")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("AdditionalParameters"), "utf8mb4");
 
 				b.Property<bool?>("AllowWebClient")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("AutoStart")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("DumpOnHealthCheckRestart")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("tinyint(1)");
 
-				b.Property<long>("HealthCheckSeconds")
-					.HasColumnType("bigint");
+				b.Property<uint?>("HealthCheckSeconds")
+					.IsRequired()
+					.HasColumnType("int unsigned");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
 				b.Property<bool?>("LogOutput")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("tinyint(1)");
 
-				b.Property<long>("MapThreads")
-					.HasColumnType("bigint");
+				b.Property<uint?>("MapThreads")
+					.IsRequired()
+					.HasColumnType("int unsigned");
 
 				b.Property<bool?>("Minidumps")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("tinyint(1)");
 
-				b.Property<int>("Port")
-					.HasColumnType("int");
+				b.Property<ushort?>("Port")
+					.IsRequired()
+					.HasColumnType("smallint unsigned");
 
 				b.Property<int>("SecurityLevel")
 					.HasColumnType("int");
 
 				b.Property<bool?>("StartProfiler")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("tinyint(1)");
 
-				b.Property<long>("StartupTimeout")
-					.HasColumnType("bigint");
+				b.Property<uint?>("StartupTimeout")
+					.IsRequired()
+					.HasColumnType("int unsigned");
 
-				b.Property<long>("TopicRequestTimeout")
-					.HasColumnType("bigint");
+				b.Property<uint?>("TopicRequestTimeout")
+					.IsRequired()
+					.HasColumnType("int unsigned");
 
 				b.Property<int>("Visibility")
 					.HasColumnType("int");
@@ -248,10 +262,9 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
-
-				b.Property<int>("ApiValidationPort")
-					.HasColumnType("int");
+				b.Property<ushort?>("ApiValidationPort")
+					.IsRequired()
+					.HasColumnType("smallint unsigned");
 
 				b.Property<int>("ApiValidationSecurityLevel")
 					.HasColumnType("int");
@@ -261,15 +274,17 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<string>("ProjectName")
 					.HasMaxLength(10000)
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("ProjectName"), "utf8mb4");
 
 				b.Property<bool?>("RequireDMApiValidation")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<TimeSpan?>("Timeout")
 					.IsRequired()
-					.HasColumnType("time");
+					.HasColumnType("time(6)");
 
 				b.HasKey("Id");
 
@@ -285,13 +300,13 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
+				b.Property<uint?>("AutoUpdateInterval")
+					.IsRequired()
+					.HasColumnType("int unsigned");
 
-				b.Property<long>("AutoUpdateInterval")
-					.HasColumnType("bigint");
-
-				b.Property<int>("ChatBotLimit")
-					.HasColumnType("int");
+				b.Property<ushort?>("ChatBotLimit")
+					.IsRequired()
+					.HasColumnType("smallint unsigned");
 
 				b.Property<int>("ConfigurationType")
 					.HasColumnType("int");
@@ -299,24 +314,29 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("nvarchar(100)");
+					.HasColumnType("varchar(100)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Name"), "utf8mb4");
 
 				b.Property<bool?>("Online")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<string>("Path")
 					.IsRequired()
-					.HasColumnType("nvarchar(450)");
+					.HasColumnType("varchar(255)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Path"), "utf8mb4");
 
 				b.Property<string>("SwarmIdentifer")
-					.HasColumnType("nvarchar(450)");
+					.HasColumnType("varchar(255)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("SwarmIdentifer"), "utf8mb4");
 
 				b.HasKey("Id");
 
 				b.HasIndex("Path", "SwarmIdentifer")
-					.IsUnique()
-					.HasFilter("[SwarmIdentifer] IS NOT NULL");
+					.IsUnique();
 
 				b.ToTable("Instances");
 			});
@@ -327,34 +347,32 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
+				b.Property<ulong>("ChatBotRights")
+					.HasColumnType("bigint unsigned");
 
-				b.Property<decimal>("ChatBotRights")
-					.HasColumnType("decimal(20,0)");
+				b.Property<ulong>("ConfigurationRights")
+					.HasColumnType("bigint unsigned");
 
-				b.Property<decimal>("ConfigurationRights")
-					.HasColumnType("decimal(20,0)");
+				b.Property<ulong>("DreamDaemonRights")
+					.HasColumnType("bigint unsigned");
 
-				b.Property<decimal>("DreamDaemonRights")
-					.HasColumnType("decimal(20,0)");
+				b.Property<ulong>("DreamMakerRights")
+					.HasColumnType("bigint unsigned");
 
-				b.Property<decimal>("DreamMakerRights")
-					.HasColumnType("decimal(20,0)");
-
-				b.Property<decimal>("EngineRights")
-					.HasColumnType("decimal(20,0)");
+				b.Property<ulong>("EngineRights")
+					.HasColumnType("bigint unsigned");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
-				b.Property<decimal>("InstancePermissionSetRights")
-					.HasColumnType("decimal(20,0)");
+				b.Property<ulong>("InstancePermissionSetRights")
+					.HasColumnType("bigint unsigned");
 
 				b.Property<long>("PermissionSetId")
 					.HasColumnType("bigint");
 
-				b.Property<decimal>("RepositoryRights")
-					.HasColumnType("decimal(20,0)");
+				b.Property<ulong>("RepositoryRights")
+					.HasColumnType("bigint unsigned");
 
 				b.HasKey("Id");
 
@@ -372,46 +390,48 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
+				b.Property<ulong?>("CancelRight")
+					.HasColumnType("bigint unsigned");
 
-				b.Property<decimal?>("CancelRight")
-					.HasColumnType("decimal(20,0)");
-
-				b.Property<decimal?>("CancelRightsType")
-					.HasColumnType("decimal(20,0)");
+				b.Property<ulong?>("CancelRightsType")
+					.HasColumnType("bigint unsigned");
 
 				b.Property<bool?>("Cancelled")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<long?>("CancelledById")
 					.HasColumnType("bigint");
 
 				b.Property<string>("Description")
 					.IsRequired()
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("longtext");
 
-				b.Property<long?>("ErrorCode")
-					.HasColumnType("bigint");
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Description"), "utf8mb4");
+
+				b.Property<uint?>("ErrorCode")
+					.HasColumnType("int unsigned");
 
 				b.Property<string>("ExceptionDetails")
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("ExceptionDetails"), "utf8mb4");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
 				b.Property<byte>("JobCode")
-					.HasColumnType("tinyint");
+					.HasColumnType("tinyint unsigned");
 
 				b.Property<DateTimeOffset?>("StartedAt")
 					.IsRequired()
-					.HasColumnType("datetimeoffset");
+					.HasColumnType("datetime(6)");
 
 				b.Property<long>("StartedById")
 					.HasColumnType("bigint");
 
 				b.Property<DateTimeOffset?>("StoppedAt")
-					.HasColumnType("datetimeoffset");
+					.HasColumnType("datetime(6)");
 
 				b.HasKey("Id");
 
@@ -430,12 +450,12 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
-
 				b.Property<string>("ExternalUserId")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("nvarchar(100)");
+					.HasColumnType("varchar(100)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("ExternalUserId"), "utf8mb4");
 
 				b.Property<int>("Provider")
 					.HasColumnType("int");
@@ -459,16 +479,14 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
-
-				b.Property<decimal>("AdministrationRights")
-					.HasColumnType("decimal(20,0)");
+				b.Property<ulong>("AdministrationRights")
+					.HasColumnType("bigint unsigned");
 
 				b.Property<long?>("GroupId")
 					.HasColumnType("bigint");
 
-				b.Property<decimal>("InstanceManagerRights")
-					.HasColumnType("decimal(20,0)");
+				b.Property<ulong>("InstanceManagerRights")
+					.HasColumnType("bigint unsigned");
 
 				b.Property<long?>("UserId")
 					.HasColumnType("bigint");
@@ -476,12 +494,10 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.HasKey("Id");
 
 				b.HasIndex("GroupId")
-					.IsUnique()
-					.HasFilter("[GroupId] IS NOT NULL");
+					.IsUnique();
 
 				b.HasIndex("UserId")
-					.IsUnique()
-					.HasFilter("[UserId] IS NOT NULL");
+					.IsUnique();
 
 				b.ToTable("PermissionSets");
 			});
@@ -492,11 +508,11 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
-
 				b.Property<string>("AccessIdentifier")
 					.IsRequired()
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("AccessIdentifier"), "utf8mb4");
 
 				b.Property<long>("CompileJobId")
 					.HasColumnType("bigint");
@@ -510,8 +526,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.Property<int>("LaunchVisibility")
 					.HasColumnType("int");
 
-				b.Property<int>("Port")
-					.HasColumnType("int");
+				b.Property<ushort>("Port")
+					.HasColumnType("smallint unsigned");
 
 				b.Property<int>("ProcessId")
 					.HasColumnType("int");
@@ -519,8 +535,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.Property<int>("RebootState")
 					.HasColumnType("int");
 
-				b.Property<int?>("TopicPort")
-					.HasColumnType("int");
+				b.Property<ushort?>("TopicPort")
+					.HasColumnType("smallint unsigned");
 
 				b.HasKey("Id");
 
@@ -537,56 +553,62 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
-
 				b.Property<string>("AccessToken")
 					.HasMaxLength(10000)
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("AccessToken"), "utf8mb4");
 
 				b.Property<string>("AccessUser")
 					.HasMaxLength(10000)
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("AccessUser"), "utf8mb4");
 
 				b.Property<bool?>("AutoUpdatesKeepTestMerges")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("AutoUpdatesSynchronize")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<string>("CommitterEmail")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("CommitterEmail"), "utf8mb4");
 
 				b.Property<string>("CommitterName")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("CommitterName"), "utf8mb4");
 
 				b.Property<bool?>("CreateGitHubDeployments")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
 				b.Property<bool?>("PostTestMergeComment")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("PushTestMergeCommits")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("ShowTestMergeCommitters")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("UpdateSubmodules")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("tinyint(1)");
 
 				b.HasKey("Id");
 
@@ -601,8 +623,6 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
-
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<long>("RevisionInformationId")
 					.HasColumnType("bigint");
@@ -625,12 +645,12 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
-
 				b.Property<string>("CommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("nvarchar(40)");
+					.HasColumnType("varchar(40)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("CommitSha"), "utf8mb4");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
@@ -638,10 +658,12 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.Property<string>("OriginCommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("nvarchar(40)");
+					.HasColumnType("varchar(40)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("OriginCommitSha"), "utf8mb4");
 
 				b.Property<DateTimeOffset>("Timestamp")
-					.HasColumnType("datetimeoffset");
+					.HasColumnType("datetime(6)");
 
 				b.HasKey("Id");
 
@@ -657,22 +679,26 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
-
 				b.Property<string>("Author")
 					.IsRequired()
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Author"), "utf8mb4");
 
 				b.Property<string>("BodyAtMerge")
 					.IsRequired()
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("BodyAtMerge"), "utf8mb4");
 
 				b.Property<string>("Comment")
 					.HasMaxLength(10000)
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Comment"), "utf8mb4");
 
 				b.Property<DateTimeOffset>("MergedAt")
-					.HasColumnType("datetimeoffset");
+					.HasColumnType("datetime(6)");
 
 				b.Property<long>("MergedById")
 					.HasColumnType("bigint");
@@ -687,15 +713,21 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.Property<string>("TargetCommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("nvarchar(40)");
+					.HasColumnType("varchar(40)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("TargetCommitSha"), "utf8mb4");
 
 				b.Property<string>("TitleAtMerge")
 					.IsRequired()
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("TitleAtMerge"), "utf8mb4");
 
 				b.Property<string>("Url")
 					.IsRequired()
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Url"), "utf8mb4");
 
 				b.HasKey("Id");
 
@@ -713,41 +745,47 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
-
 				b.Property<string>("CanonicalName")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("nvarchar(100)");
+					.HasColumnType("varchar(100)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("CanonicalName"), "utf8mb4");
 
 				b.Property<DateTimeOffset?>("CreatedAt")
 					.IsRequired()
-					.HasColumnType("datetimeoffset");
+					.HasColumnType("datetime(6)");
 
 				b.Property<long?>("CreatedById")
 					.HasColumnType("bigint");
 
 				b.Property<bool?>("Enabled")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<long?>("GroupId")
 					.HasColumnType("bigint");
 
 				b.Property<DateTimeOffset?>("LastPasswordUpdate")
-					.HasColumnType("datetimeoffset");
+					.HasColumnType("datetime(6)");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("nvarchar(100)");
+					.HasColumnType("varchar(100)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Name"), "utf8mb4");
 
 				b.Property<string>("PasswordHash")
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("PasswordHash"), "utf8mb4");
 
 				b.Property<string>("SystemIdentifier")
 					.HasMaxLength(100)
-					.HasColumnType("nvarchar(100)");
+					.HasColumnType("varchar(100)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("SystemIdentifier"), "utf8mb4");
 
 				b.HasKey("Id");
 
@@ -759,8 +797,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.HasIndex("GroupId");
 
 				b.HasIndex("SystemIdentifier")
-					.IsUnique()
-					.HasFilter("[SystemIdentifier] IS NOT NULL");
+					.IsUnique();
 
 				b.ToTable("Users");
 			});
@@ -771,12 +808,12 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
-
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("nvarchar(100)");
+					.HasColumnType("varchar(100)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Name"), "utf8mb4");
 
 				b.HasKey("Id");
 
@@ -819,7 +856,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.HasOne("Tgstation.Server.Host.Models.RevisionInformation", "RevisionInformation")
 					.WithMany("CompileJobs")
 					.HasForeignKey("RevisionInformationId")
-					.OnDelete(DeleteBehavior.ClientNoAction)
+					.OnDelete(DeleteBehavior.Cascade)
 					.IsRequired();
 
 				b.Navigation("Job");

--- a/src/Tgstation.Server.Host/Database/Migrations/20240202202051_MYAddMinidumpsOption.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20240202202051_MYAddMinidumpsOption.cs
@@ -1,0 +1,37 @@
+﻿using System;
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+using Tgstation.Server.Host.System;
+
+namespace Tgstation.Server.Host.Database.Migrations
+{
+	/// <inheritdoc />
+	public partial class MYAddMinidumpsOption : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+			// This was originally minidumps on Linux and full dumps on Windows
+			var defaultValue = !new PlatformIdentifier().IsWindows;
+			migrationBuilder.AddColumn<bool>(
+				name: "Minidumps",
+				table: "DreamDaemonSettings",
+				type: "tinyint(1)",
+				nullable: false,
+				defaultValue: defaultValue);
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+			migrationBuilder.DropColumn(
+				name: "Minidumps",
+				table: "DreamDaemonSettings");
+		}
+	}
+}

--- a/src/Tgstation.Server.Host/Database/Migrations/20240202202106_PGAddMinidumpsOption.Designer.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20240202202106_PGAddMinidumpsOption.Designer.cs
@@ -3,20 +3,23 @@ using System;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Tgstation.Server.Host.Database.Migrations
 {
-	[DbContext(typeof(SqlServerDatabaseContext))]
-	partial class SqlServerDatabaseContextModelSnapshot : ModelSnapshot
+	[DbContext(typeof(PostgresSqlDatabaseContext))]
+	[Migration("20240202202106_PGAddMinidumpsOption")]
+	partial class PGAddMinidumpsOption
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		/// <inheritdoc />
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder
 				.HasAnnotation("ProductVersion", "8.0.1")
-				.HasAnnotation("Relational:MaxIdentifierLength", 128);
+				.HasAnnotation("Relational:MaxIdentifierLength", 63);
 
-			SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+			NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.ChatBot", b =>
 			{
@@ -24,18 +27,18 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
+				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
 
 				b.Property<int>("ChannelLimit")
-					.HasColumnType("int");
+					.HasColumnType("integer");
 
 				b.Property<string>("ConnectionString")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("character varying(10000)");
 
 				b.Property<bool?>("Enabled")
-					.HasColumnType("bit");
+					.HasColumnType("boolean");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
@@ -43,10 +46,10 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("nvarchar(100)");
+					.HasColumnType("character varying(100)");
 
 				b.Property<int>("Provider")
-					.HasColumnType("int");
+					.HasColumnType("integer");
 
 				b.Property<long>("ReconnectionInterval")
 					.HasColumnType("bigint");
@@ -65,47 +68,45 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
+				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
 
 				b.Property<long>("ChatSettingsId")
 					.HasColumnType("bigint");
 
 				b.Property<decimal?>("DiscordChannelId")
-					.HasColumnType("decimal(20,0)");
+					.HasColumnType("numeric(20,0)");
 
 				b.Property<string>("IrcChannel")
 					.HasMaxLength(100)
-					.HasColumnType("nvarchar(100)");
+					.HasColumnType("character varying(100)");
 
 				b.Property<bool?>("IsAdminChannel")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("boolean");
 
 				b.Property<bool?>("IsSystemChannel")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("boolean");
 
 				b.Property<bool?>("IsUpdatesChannel")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("boolean");
 
 				b.Property<bool?>("IsWatchdogChannel")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("boolean");
 
 				b.Property<string>("Tag")
 					.HasMaxLength(10000)
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("character varying(10000)");
 
 				b.HasKey("Id");
 
 				b.HasIndex("ChatSettingsId", "DiscordChannelId")
-					.IsUnique()
-					.HasFilter("[DiscordChannelId] IS NOT NULL");
+					.IsUnique();
 
 				b.HasIndex("ChatSettingsId", "IrcChannel")
-					.IsUnique()
-					.HasFilter("[IrcChannel] IS NOT NULL");
+					.IsUnique();
 
 				b.ToTable("ChatChannels");
 			});
@@ -116,31 +117,31 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
+				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
 
 				b.Property<int?>("DMApiMajorVersion")
-					.HasColumnType("int");
+					.HasColumnType("integer");
 
 				b.Property<int?>("DMApiMinorVersion")
-					.HasColumnType("int");
+					.HasColumnType("integer");
 
 				b.Property<int?>("DMApiPatchVersion")
-					.HasColumnType("int");
+					.HasColumnType("integer");
 
 				b.Property<Guid?>("DirectoryName")
 					.IsRequired()
-					.HasColumnType("uniqueidentifier");
+					.HasColumnType("uuid");
 
 				b.Property<string>("DmeName")
 					.IsRequired()
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("text");
 
 				b.Property<string>("EngineVersion")
 					.IsRequired()
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("text");
 
 				b.Property<int?>("GitHubDeploymentId")
-					.HasColumnType("int");
+					.HasColumnType("integer");
 
 				b.Property<long?>("GitHubRepoId")
 					.HasColumnType("bigint");
@@ -149,14 +150,14 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasColumnType("bigint");
 
 				b.Property<int?>("MinimumSecurityLevel")
-					.HasColumnType("int");
+					.HasColumnType("integer");
 
 				b.Property<string>("Output")
 					.IsRequired()
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("text");
 
 				b.Property<string>("RepositoryOrigin")
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("text");
 
 				b.Property<long>("RevisionInformationId")
 					.HasColumnType("bigint");
@@ -179,24 +180,24 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
+				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
 
 				b.Property<string>("AdditionalParameters")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("character varying(10000)");
 
 				b.Property<bool?>("AllowWebClient")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("boolean");
 
 				b.Property<bool?>("AutoStart")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("boolean");
 
 				b.Property<bool?>("DumpOnHealthCheckRestart")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("boolean");
 
 				b.Property<long>("HealthCheckSeconds")
 					.HasColumnType("bigint");
@@ -206,24 +207,24 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<bool?>("LogOutput")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("boolean");
 
 				b.Property<long>("MapThreads")
 					.HasColumnType("bigint");
 
 				b.Property<bool?>("Minidumps")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("boolean");
 
 				b.Property<int>("Port")
-					.HasColumnType("int");
+					.HasColumnType("integer");
 
 				b.Property<int>("SecurityLevel")
-					.HasColumnType("int");
+					.HasColumnType("integer");
 
 				b.Property<bool?>("StartProfiler")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("boolean");
 
 				b.Property<long>("StartupTimeout")
 					.HasColumnType("bigint");
@@ -232,7 +233,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasColumnType("bigint");
 
 				b.Property<int>("Visibility")
-					.HasColumnType("int");
+					.HasColumnType("integer");
 
 				b.HasKey("Id");
 
@@ -248,28 +249,28 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
+				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
 
 				b.Property<int>("ApiValidationPort")
-					.HasColumnType("int");
+					.HasColumnType("integer");
 
 				b.Property<int>("ApiValidationSecurityLevel")
-					.HasColumnType("int");
+					.HasColumnType("integer");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
 				b.Property<string>("ProjectName")
 					.HasMaxLength(10000)
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("character varying(10000)");
 
 				b.Property<bool?>("RequireDMApiValidation")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("boolean");
 
 				b.Property<TimeSpan?>("Timeout")
 					.IsRequired()
-					.HasColumnType("time");
+					.HasColumnType("interval");
 
 				b.HasKey("Id");
 
@@ -285,38 +286,37 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
+				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
 
 				b.Property<long>("AutoUpdateInterval")
 					.HasColumnType("bigint");
 
 				b.Property<int>("ChatBotLimit")
-					.HasColumnType("int");
+					.HasColumnType("integer");
 
 				b.Property<int>("ConfigurationType")
-					.HasColumnType("int");
+					.HasColumnType("integer");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("nvarchar(100)");
+					.HasColumnType("character varying(100)");
 
 				b.Property<bool?>("Online")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("boolean");
 
 				b.Property<string>("Path")
 					.IsRequired()
-					.HasColumnType("nvarchar(450)");
+					.HasColumnType("text");
 
 				b.Property<string>("SwarmIdentifer")
-					.HasColumnType("nvarchar(450)");
+					.HasColumnType("text");
 
 				b.HasKey("Id");
 
 				b.HasIndex("Path", "SwarmIdentifer")
-					.IsUnique()
-					.HasFilter("[SwarmIdentifer] IS NOT NULL");
+					.IsUnique();
 
 				b.ToTable("Instances");
 			});
@@ -327,34 +327,34 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
+				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
 
 				b.Property<decimal>("ChatBotRights")
-					.HasColumnType("decimal(20,0)");
+					.HasColumnType("numeric(20,0)");
 
 				b.Property<decimal>("ConfigurationRights")
-					.HasColumnType("decimal(20,0)");
+					.HasColumnType("numeric(20,0)");
 
 				b.Property<decimal>("DreamDaemonRights")
-					.HasColumnType("decimal(20,0)");
+					.HasColumnType("numeric(20,0)");
 
 				b.Property<decimal>("DreamMakerRights")
-					.HasColumnType("decimal(20,0)");
+					.HasColumnType("numeric(20,0)");
 
 				b.Property<decimal>("EngineRights")
-					.HasColumnType("decimal(20,0)");
+					.HasColumnType("numeric(20,0)");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
 				b.Property<decimal>("InstancePermissionSetRights")
-					.HasColumnType("decimal(20,0)");
+					.HasColumnType("numeric(20,0)");
 
 				b.Property<long>("PermissionSetId")
 					.HasColumnType("bigint");
 
 				b.Property<decimal>("RepositoryRights")
-					.HasColumnType("decimal(20,0)");
+					.HasColumnType("numeric(20,0)");
 
 				b.HasKey("Id");
 
@@ -372,46 +372,46 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
+				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
 
 				b.Property<decimal?>("CancelRight")
-					.HasColumnType("decimal(20,0)");
+					.HasColumnType("numeric(20,0)");
 
 				b.Property<decimal?>("CancelRightsType")
-					.HasColumnType("decimal(20,0)");
+					.HasColumnType("numeric(20,0)");
 
 				b.Property<bool?>("Cancelled")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("boolean");
 
 				b.Property<long?>("CancelledById")
 					.HasColumnType("bigint");
 
 				b.Property<string>("Description")
 					.IsRequired()
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("text");
 
 				b.Property<long?>("ErrorCode")
 					.HasColumnType("bigint");
 
 				b.Property<string>("ExceptionDetails")
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("text");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
 				b.Property<byte>("JobCode")
-					.HasColumnType("tinyint");
+					.HasColumnType("smallint");
 
 				b.Property<DateTimeOffset?>("StartedAt")
 					.IsRequired()
-					.HasColumnType("datetimeoffset");
+					.HasColumnType("timestamp with time zone");
 
 				b.Property<long>("StartedById")
 					.HasColumnType("bigint");
 
 				b.Property<DateTimeOffset?>("StoppedAt")
-					.HasColumnType("datetimeoffset");
+					.HasColumnType("timestamp with time zone");
 
 				b.HasKey("Id");
 
@@ -430,15 +430,15 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
+				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
 
 				b.Property<string>("ExternalUserId")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("nvarchar(100)");
+					.HasColumnType("character varying(100)");
 
 				b.Property<int>("Provider")
-					.HasColumnType("int");
+					.HasColumnType("integer");
 
 				b.Property<long?>("UserId")
 					.HasColumnType("bigint");
@@ -459,16 +459,16 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
+				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
 
 				b.Property<decimal>("AdministrationRights")
-					.HasColumnType("decimal(20,0)");
+					.HasColumnType("numeric(20,0)");
 
 				b.Property<long?>("GroupId")
 					.HasColumnType("bigint");
 
 				b.Property<decimal>("InstanceManagerRights")
-					.HasColumnType("decimal(20,0)");
+					.HasColumnType("numeric(20,0)");
 
 				b.Property<long?>("UserId")
 					.HasColumnType("bigint");
@@ -476,12 +476,10 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.HasKey("Id");
 
 				b.HasIndex("GroupId")
-					.IsUnique()
-					.HasFilter("[GroupId] IS NOT NULL");
+					.IsUnique();
 
 				b.HasIndex("UserId")
-					.IsUnique()
-					.HasFilter("[UserId] IS NOT NULL");
+					.IsUnique();
 
 				b.ToTable("PermissionSets");
 			});
@@ -492,11 +490,11 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
+				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
 
 				b.Property<string>("AccessIdentifier")
 					.IsRequired()
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("text");
 
 				b.Property<long>("CompileJobId")
 					.HasColumnType("bigint");
@@ -505,22 +503,22 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasColumnType("bigint");
 
 				b.Property<int>("LaunchSecurityLevel")
-					.HasColumnType("int");
+					.HasColumnType("integer");
 
 				b.Property<int>("LaunchVisibility")
-					.HasColumnType("int");
+					.HasColumnType("integer");
 
 				b.Property<int>("Port")
-					.HasColumnType("int");
+					.HasColumnType("integer");
 
 				b.Property<int>("ProcessId")
-					.HasColumnType("int");
+					.HasColumnType("integer");
 
 				b.Property<int>("RebootState")
-					.HasColumnType("int");
+					.HasColumnType("integer");
 
 				b.Property<int?>("TopicPort")
-					.HasColumnType("int");
+					.HasColumnType("integer");
 
 				b.HasKey("Id");
 
@@ -537,56 +535,56 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
+				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
 
 				b.Property<string>("AccessToken")
 					.HasMaxLength(10000)
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("character varying(10000)");
 
 				b.Property<string>("AccessUser")
 					.HasMaxLength(10000)
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("character varying(10000)");
 
 				b.Property<bool?>("AutoUpdatesKeepTestMerges")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("boolean");
 
 				b.Property<bool?>("AutoUpdatesSynchronize")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("boolean");
 
 				b.Property<string>("CommitterEmail")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("character varying(10000)");
 
 				b.Property<string>("CommitterName")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("character varying(10000)");
 
 				b.Property<bool?>("CreateGitHubDeployments")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("boolean");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
 				b.Property<bool?>("PostTestMergeComment")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("boolean");
 
 				b.Property<bool?>("PushTestMergeCommits")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("boolean");
 
 				b.Property<bool?>("ShowTestMergeCommitters")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("boolean");
 
 				b.Property<bool?>("UpdateSubmodules")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("boolean");
 
 				b.HasKey("Id");
 
@@ -602,7 +600,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
+				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
 
 				b.Property<long>("RevisionInformationId")
 					.HasColumnType("bigint");
@@ -625,12 +623,12 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
+				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
 
 				b.Property<string>("CommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("nvarchar(40)");
+					.HasColumnType("character varying(40)");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
@@ -638,10 +636,10 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.Property<string>("OriginCommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("nvarchar(40)");
+					.HasColumnType("character varying(40)");
 
 				b.Property<DateTimeOffset>("Timestamp")
-					.HasColumnType("datetimeoffset");
+					.HasColumnType("timestamp with time zone");
 
 				b.HasKey("Id");
 
@@ -657,28 +655,28 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
+				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
 
 				b.Property<string>("Author")
 					.IsRequired()
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("text");
 
 				b.Property<string>("BodyAtMerge")
 					.IsRequired()
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("text");
 
 				b.Property<string>("Comment")
 					.HasMaxLength(10000)
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("character varying(10000)");
 
 				b.Property<DateTimeOffset>("MergedAt")
-					.HasColumnType("datetimeoffset");
+					.HasColumnType("timestamp with time zone");
 
 				b.Property<long>("MergedById")
 					.HasColumnType("bigint");
 
 				b.Property<int>("Number")
-					.HasColumnType("int");
+					.HasColumnType("integer");
 
 				b.Property<long?>("PrimaryRevisionInformationId")
 					.IsRequired()
@@ -687,15 +685,15 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.Property<string>("TargetCommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("nvarchar(40)");
+					.HasColumnType("character varying(40)");
 
 				b.Property<string>("TitleAtMerge")
 					.IsRequired()
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("text");
 
 				b.Property<string>("Url")
 					.IsRequired()
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("text");
 
 				b.HasKey("Id");
 
@@ -713,41 +711,41 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
+				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
 
 				b.Property<string>("CanonicalName")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("nvarchar(100)");
+					.HasColumnType("character varying(100)");
 
 				b.Property<DateTimeOffset?>("CreatedAt")
 					.IsRequired()
-					.HasColumnType("datetimeoffset");
+					.HasColumnType("timestamp with time zone");
 
 				b.Property<long?>("CreatedById")
 					.HasColumnType("bigint");
 
 				b.Property<bool?>("Enabled")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("boolean");
 
 				b.Property<long?>("GroupId")
 					.HasColumnType("bigint");
 
 				b.Property<DateTimeOffset?>("LastPasswordUpdate")
-					.HasColumnType("datetimeoffset");
+					.HasColumnType("timestamp with time zone");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("nvarchar(100)");
+					.HasColumnType("character varying(100)");
 
 				b.Property<string>("PasswordHash")
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("text");
 
 				b.Property<string>("SystemIdentifier")
 					.HasMaxLength(100)
-					.HasColumnType("nvarchar(100)");
+					.HasColumnType("character varying(100)");
 
 				b.HasKey("Id");
 
@@ -759,8 +757,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.HasIndex("GroupId");
 
 				b.HasIndex("SystemIdentifier")
-					.IsUnique()
-					.HasFilter("[SystemIdentifier] IS NOT NULL");
+					.IsUnique();
 
 				b.ToTable("Users");
 			});
@@ -771,12 +768,12 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
+				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("nvarchar(100)");
+					.HasColumnType("character varying(100)");
 
 				b.HasKey("Id");
 
@@ -819,7 +816,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.HasOne("Tgstation.Server.Host.Models.RevisionInformation", "RevisionInformation")
 					.WithMany("CompileJobs")
 					.HasForeignKey("RevisionInformationId")
-					.OnDelete(DeleteBehavior.ClientNoAction)
+					.OnDelete(DeleteBehavior.Cascade)
 					.IsRequired();
 
 				b.Navigation("Job");

--- a/src/Tgstation.Server.Host/Database/Migrations/20240202202106_PGAddMinidumpsOption.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20240202202106_PGAddMinidumpsOption.cs
@@ -1,0 +1,37 @@
+﻿using System;
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+using Tgstation.Server.Host.System;
+
+namespace Tgstation.Server.Host.Database.Migrations
+{
+	/// <inheritdoc />
+	public partial class PGAddMinidumpsOption : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+			// This was originally minidumps on Linux and full dumps on Windows
+			var defaultValue = !new PlatformIdentifier().IsWindows;
+			migrationBuilder.AddColumn<bool>(
+				name: "Minidumps",
+				table: "DreamDaemonSettings",
+				type: "boolean",
+				nullable: false,
+				defaultValue: defaultValue);
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+			migrationBuilder.DropColumn(
+				name: "Minidumps",
+				table: "DreamDaemonSettings");
+		}
+	}
+}

--- a/src/Tgstation.Server.Host/Database/Migrations/20240202202121_SLAddMinidumpsOption.Designer.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20240202202121_SLAddMinidumpsOption.Designer.cs
@@ -3,53 +3,52 @@ using System;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Tgstation.Server.Host.Database.Migrations
 {
-	[DbContext(typeof(SqlServerDatabaseContext))]
-	partial class SqlServerDatabaseContextModelSnapshot : ModelSnapshot
+	[DbContext(typeof(SqliteDatabaseContext))]
+	[Migration("20240202202121_SLAddMinidumpsOption")]
+	partial class SLAddMinidumpsOption
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		/// <inheritdoc />
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
-			modelBuilder
-				.HasAnnotation("ProductVersion", "8.0.1")
-				.HasAnnotation("Relational:MaxIdentifierLength", 128);
-
-			SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+			modelBuilder.HasAnnotation("ProductVersion", "8.0.1");
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.ChatBot", b =>
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
-
-				b.Property<int>("ChannelLimit")
-					.HasColumnType("int");
+				b.Property<ushort?>("ChannelLimit")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("ConnectionString")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("TEXT");
 
 				b.Property<bool?>("Enabled")
-					.HasColumnType("bit");
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("nvarchar(100)");
+					.HasColumnType("TEXT");
 
 				b.Property<int>("Provider")
-					.HasColumnType("int");
+					.HasColumnType("INTEGER");
 
-				b.Property<long>("ReconnectionInterval")
-					.HasColumnType("bigint");
+				b.Property<uint?>("ReconnectionInterval")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
 				b.HasKey("Id");
 
@@ -63,49 +62,45 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("ChatSettingsId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
-				b.Property<decimal?>("DiscordChannelId")
-					.HasColumnType("decimal(20,0)");
+				b.Property<ulong?>("DiscordChannelId")
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("IrcChannel")
 					.HasMaxLength(100)
-					.HasColumnType("nvarchar(100)");
+					.HasColumnType("TEXT");
 
 				b.Property<bool?>("IsAdminChannel")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("IsSystemChannel")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("IsUpdatesChannel")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("IsWatchdogChannel")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("Tag")
 					.HasMaxLength(10000)
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("TEXT");
 
 				b.HasKey("Id");
 
 				b.HasIndex("ChatSettingsId", "DiscordChannelId")
-					.IsUnique()
-					.HasFilter("[DiscordChannelId] IS NOT NULL");
+					.IsUnique();
 
 				b.HasIndex("ChatSettingsId", "IrcChannel")
-					.IsUnique()
-					.HasFilter("[IrcChannel] IS NOT NULL");
+					.IsUnique();
 
 				b.ToTable("ChatChannels");
 			});
@@ -114,52 +109,50 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<int?>("DMApiMajorVersion")
-					.HasColumnType("int");
+					.HasColumnType("INTEGER");
 
 				b.Property<int?>("DMApiMinorVersion")
-					.HasColumnType("int");
+					.HasColumnType("INTEGER");
 
 				b.Property<int?>("DMApiPatchVersion")
-					.HasColumnType("int");
+					.HasColumnType("INTEGER");
 
 				b.Property<Guid?>("DirectoryName")
 					.IsRequired()
-					.HasColumnType("uniqueidentifier");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("DmeName")
 					.IsRequired()
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("EngineVersion")
 					.IsRequired()
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("TEXT");
 
 				b.Property<int?>("GitHubDeploymentId")
-					.HasColumnType("int");
+					.HasColumnType("INTEGER");
 
 				b.Property<long?>("GitHubRepoId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("JobId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<int?>("MinimumSecurityLevel")
-					.HasColumnType("int");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("Output")
 					.IsRequired()
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("RepositoryOrigin")
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("TEXT");
 
 				b.Property<long>("RevisionInformationId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.HasKey("Id");
 
@@ -177,62 +170,65 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("AdditionalParameters")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("TEXT");
 
 				b.Property<bool?>("AllowWebClient")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("AutoStart")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("DumpOnHealthCheckRestart")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("INTEGER");
 
-				b.Property<long>("HealthCheckSeconds")
-					.HasColumnType("bigint");
+				b.Property<uint?>("HealthCheckSeconds")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("LogOutput")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("INTEGER");
 
-				b.Property<long>("MapThreads")
-					.HasColumnType("bigint");
+				b.Property<uint?>("MapThreads")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("Minidumps")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("INTEGER");
 
-				b.Property<int>("Port")
-					.HasColumnType("int");
+				b.Property<ushort?>("Port")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
 				b.Property<int>("SecurityLevel")
-					.HasColumnType("int");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("StartProfiler")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("INTEGER");
 
-				b.Property<long>("StartupTimeout")
-					.HasColumnType("bigint");
+				b.Property<uint?>("StartupTimeout")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
-				b.Property<long>("TopicRequestTimeout")
-					.HasColumnType("bigint");
+				b.Property<uint?>("TopicRequestTimeout")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
 				b.Property<int>("Visibility")
-					.HasColumnType("int");
+					.HasColumnType("INTEGER");
 
 				b.HasKey("Id");
 
@@ -246,30 +242,29 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
-
-				b.Property<int>("ApiValidationPort")
-					.HasColumnType("int");
+				b.Property<ushort?>("ApiValidationPort")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
 				b.Property<int>("ApiValidationSecurityLevel")
-					.HasColumnType("int");
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("ProjectName")
 					.HasMaxLength(10000)
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("TEXT");
 
 				b.Property<bool?>("RequireDMApiValidation")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("INTEGER");
 
 				b.Property<TimeSpan?>("Timeout")
 					.IsRequired()
-					.HasColumnType("time");
+					.HasColumnType("TEXT");
 
 				b.HasKey("Id");
 
@@ -283,40 +278,39 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
+				b.Property<uint?>("AutoUpdateInterval")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
-				b.Property<long>("AutoUpdateInterval")
-					.HasColumnType("bigint");
-
-				b.Property<int>("ChatBotLimit")
-					.HasColumnType("int");
+				b.Property<ushort?>("ChatBotLimit")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
 				b.Property<int>("ConfigurationType")
-					.HasColumnType("int");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("nvarchar(100)");
+					.HasColumnType("TEXT");
 
 				b.Property<bool?>("Online")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("Path")
 					.IsRequired()
-					.HasColumnType("nvarchar(450)");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("SwarmIdentifer")
-					.HasColumnType("nvarchar(450)");
+					.HasColumnType("TEXT");
 
 				b.HasKey("Id");
 
 				b.HasIndex("Path", "SwarmIdentifer")
-					.IsUnique()
-					.HasFilter("[SwarmIdentifer] IS NOT NULL");
+					.IsUnique();
 
 				b.ToTable("Instances");
 			});
@@ -325,36 +319,34 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
+				b.Property<ulong>("ChatBotRights")
+					.HasColumnType("INTEGER");
 
-				b.Property<decimal>("ChatBotRights")
-					.HasColumnType("decimal(20,0)");
+				b.Property<ulong>("ConfigurationRights")
+					.HasColumnType("INTEGER");
 
-				b.Property<decimal>("ConfigurationRights")
-					.HasColumnType("decimal(20,0)");
+				b.Property<ulong>("DreamDaemonRights")
+					.HasColumnType("INTEGER");
 
-				b.Property<decimal>("DreamDaemonRights")
-					.HasColumnType("decimal(20,0)");
+				b.Property<ulong>("DreamMakerRights")
+					.HasColumnType("INTEGER");
 
-				b.Property<decimal>("DreamMakerRights")
-					.HasColumnType("decimal(20,0)");
-
-				b.Property<decimal>("EngineRights")
-					.HasColumnType("decimal(20,0)");
+				b.Property<ulong>("EngineRights")
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
-				b.Property<decimal>("InstancePermissionSetRights")
-					.HasColumnType("decimal(20,0)");
+				b.Property<ulong>("InstancePermissionSetRights")
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("PermissionSetId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
-				b.Property<decimal>("RepositoryRights")
-					.HasColumnType("decimal(20,0)");
+				b.Property<ulong>("RepositoryRights")
+					.HasColumnType("INTEGER");
 
 				b.HasKey("Id");
 
@@ -370,48 +362,46 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
+				b.Property<ulong?>("CancelRight")
+					.HasColumnType("INTEGER");
 
-				b.Property<decimal?>("CancelRight")
-					.HasColumnType("decimal(20,0)");
-
-				b.Property<decimal?>("CancelRightsType")
-					.HasColumnType("decimal(20,0)");
+				b.Property<ulong?>("CancelRightsType")
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("Cancelled")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("INTEGER");
 
 				b.Property<long?>("CancelledById")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("Description")
 					.IsRequired()
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("TEXT");
 
-				b.Property<long?>("ErrorCode")
-					.HasColumnType("bigint");
+				b.Property<uint?>("ErrorCode")
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("ExceptionDetails")
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("TEXT");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<byte>("JobCode")
-					.HasColumnType("tinyint");
+					.HasColumnType("INTEGER");
 
 				b.Property<DateTimeOffset?>("StartedAt")
 					.IsRequired()
-					.HasColumnType("datetimeoffset");
+					.HasColumnType("TEXT");
 
 				b.Property<long>("StartedById")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<DateTimeOffset?>("StoppedAt")
-					.HasColumnType("datetimeoffset");
+					.HasColumnType("TEXT");
 
 				b.HasKey("Id");
 
@@ -428,20 +418,18 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("ExternalUserId")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("nvarchar(100)");
+					.HasColumnType("TEXT");
 
 				b.Property<int>("Provider")
-					.HasColumnType("int");
+					.HasColumnType("INTEGER");
 
 				b.Property<long?>("UserId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.HasKey("Id");
 
@@ -457,31 +445,27 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
-
-				b.Property<decimal>("AdministrationRights")
-					.HasColumnType("decimal(20,0)");
+				b.Property<ulong>("AdministrationRights")
+					.HasColumnType("INTEGER");
 
 				b.Property<long?>("GroupId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
-				b.Property<decimal>("InstanceManagerRights")
-					.HasColumnType("decimal(20,0)");
+				b.Property<ulong>("InstanceManagerRights")
+					.HasColumnType("INTEGER");
 
 				b.Property<long?>("UserId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.HasKey("Id");
 
 				b.HasIndex("GroupId")
-					.IsUnique()
-					.HasFilter("[GroupId] IS NOT NULL");
+					.IsUnique();
 
 				b.HasIndex("UserId")
-					.IsUnique()
-					.HasFilter("[UserId] IS NOT NULL");
+					.IsUnique();
 
 				b.ToTable("PermissionSets");
 			});
@@ -490,37 +474,35 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("AccessIdentifier")
 					.IsRequired()
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("TEXT");
 
 				b.Property<long>("CompileJobId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<long?>("InitialCompileJobId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<int>("LaunchSecurityLevel")
-					.HasColumnType("int");
+					.HasColumnType("INTEGER");
 
 				b.Property<int>("LaunchVisibility")
-					.HasColumnType("int");
+					.HasColumnType("INTEGER");
 
-				b.Property<int>("Port")
-					.HasColumnType("int");
+				b.Property<ushort>("Port")
+					.HasColumnType("INTEGER");
 
 				b.Property<int>("ProcessId")
-					.HasColumnType("int");
+					.HasColumnType("INTEGER");
 
 				b.Property<int>("RebootState")
-					.HasColumnType("int");
+					.HasColumnType("INTEGER");
 
-				b.Property<int?>("TopicPort")
-					.HasColumnType("int");
+				b.Property<ushort?>("TopicPort")
+					.HasColumnType("INTEGER");
 
 				b.HasKey("Id");
 
@@ -535,58 +517,56 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("AccessToken")
 					.HasMaxLength(10000)
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("AccessUser")
 					.HasMaxLength(10000)
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("TEXT");
 
 				b.Property<bool?>("AutoUpdatesKeepTestMerges")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("AutoUpdatesSynchronize")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("CommitterEmail")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("CommitterName")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("TEXT");
 
 				b.Property<bool?>("CreateGitHubDeployments")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("PostTestMergeComment")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("PushTestMergeCommits")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("ShowTestMergeCommitters")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("UpdateSubmodules")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("INTEGER");
 
 				b.HasKey("Id");
 
@@ -600,15 +580,13 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("RevisionInformationId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("TestMergeId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.HasKey("Id");
 
@@ -623,25 +601,23 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("CommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("nvarchar(40)");
+					.HasColumnType("TEXT");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("OriginCommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("nvarchar(40)");
+					.HasColumnType("TEXT");
 
 				b.Property<DateTimeOffset>("Timestamp")
-					.HasColumnType("datetimeoffset");
+					.HasColumnType("TEXT");
 
 				b.HasKey("Id");
 
@@ -655,47 +631,45 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("Author")
 					.IsRequired()
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("BodyAtMerge")
 					.IsRequired()
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("Comment")
 					.HasMaxLength(10000)
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("TEXT");
 
 				b.Property<DateTimeOffset>("MergedAt")
-					.HasColumnType("datetimeoffset");
+					.HasColumnType("TEXT");
 
 				b.Property<long>("MergedById")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<int>("Number")
-					.HasColumnType("int");
+					.HasColumnType("INTEGER");
 
 				b.Property<long?>("PrimaryRevisionInformationId")
 					.IsRequired()
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("TargetCommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("nvarchar(40)");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("TitleAtMerge")
 					.IsRequired()
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("Url")
 					.IsRequired()
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("TEXT");
 
 				b.HasKey("Id");
 
@@ -711,43 +685,41 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("CanonicalName")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("nvarchar(100)");
+					.HasColumnType("TEXT");
 
 				b.Property<DateTimeOffset?>("CreatedAt")
 					.IsRequired()
-					.HasColumnType("datetimeoffset");
+					.HasColumnType("TEXT");
 
 				b.Property<long?>("CreatedById")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("Enabled")
 					.IsRequired()
-					.HasColumnType("bit");
+					.HasColumnType("INTEGER");
 
 				b.Property<long?>("GroupId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<DateTimeOffset?>("LastPasswordUpdate")
-					.HasColumnType("datetimeoffset");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("nvarchar(100)");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("PasswordHash")
-					.HasColumnType("nvarchar(max)");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("SystemIdentifier")
 					.HasMaxLength(100)
-					.HasColumnType("nvarchar(100)");
+					.HasColumnType("TEXT");
 
 				b.HasKey("Id");
 
@@ -759,8 +731,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.HasIndex("GroupId");
 
 				b.HasIndex("SystemIdentifier")
-					.IsUnique()
-					.HasFilter("[SystemIdentifier] IS NOT NULL");
+					.IsUnique();
 
 				b.ToTable("Users");
 			});
@@ -769,14 +740,12 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("nvarchar(100)");
+					.HasColumnType("TEXT");
 
 				b.HasKey("Id");
 

--- a/src/Tgstation.Server.Host/Database/Migrations/20240202202121_SLAddMinidumpsOption.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20240202202121_SLAddMinidumpsOption.cs
@@ -1,0 +1,37 @@
+﻿using System;
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+using Tgstation.Server.Host.System;
+
+namespace Tgstation.Server.Host.Database.Migrations
+{
+	/// <inheritdoc />
+	public partial class SLAddMinidumpsOption : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+			// This was originally minidumps on Linux and full dumps on Windows
+			var defaultValue = !new PlatformIdentifier().IsWindows;
+			migrationBuilder.AddColumn<bool>(
+				name: "Minidumps",
+				table: "DreamDaemonSettings",
+				type: "INTEGER",
+				nullable: false,
+				defaultValue: defaultValue);
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+			migrationBuilder.DropColumn(
+				name: "Minidumps",
+				table: "DreamDaemonSettings");
+		}
+	}
+}

--- a/src/Tgstation.Server.Host/Database/Migrations/MySqlDatabaseContextModelSnapshot.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/MySqlDatabaseContextModelSnapshot.cs
@@ -13,7 +13,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 		{
 #pragma warning disable 612, 618
 			modelBuilder
-				.HasAnnotation("ProductVersion", "8.0.0")
+				.HasAnnotation("ProductVersion", "8.0.1")
 				.HasAnnotation("Relational:MaxIdentifierLength", 64);
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.ChatBot", b =>
@@ -218,6 +218,10 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.Property<uint?>("MapThreads")
 					.IsRequired()
 					.HasColumnType("int unsigned");
+
+				b.Property<bool?>("Minidumps")
+					.IsRequired()
+					.HasColumnType("tinyint(1)");
 
 				b.Property<ushort?>("Port")
 					.IsRequired()

--- a/src/Tgstation.Server.Host/Database/Migrations/PostgresSqlDatabaseContextModelSnapshot.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/PostgresSqlDatabaseContextModelSnapshot.cs
@@ -13,7 +13,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 		{
 #pragma warning disable 612, 618
 			modelBuilder
-				.HasAnnotation("ProductVersion", "8.0.0")
+				.HasAnnotation("ProductVersion", "8.0.1")
 				.HasAnnotation("Relational:MaxIdentifierLength", 63);
 
 			NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
@@ -208,6 +208,10 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<long>("MapThreads")
 					.HasColumnType("bigint");
+
+				b.Property<bool?>("Minidumps")
+					.IsRequired()
+					.HasColumnType("boolean");
 
 				b.Property<int>("Port")
 					.HasColumnType("integer");

--- a/src/Tgstation.Server.Host/Database/Migrations/SqliteDatabaseContextModelSnapshot.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/SqliteDatabaseContextModelSnapshot.cs
@@ -12,7 +12,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 		protected override void BuildModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
-			modelBuilder.HasAnnotation("ProductVersion", "8.0.0");
+			modelBuilder.HasAnnotation("ProductVersion", "8.0.1");
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.ChatBot", b =>
 			{
@@ -198,6 +198,10 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasColumnType("INTEGER");
 
 				b.Property<uint?>("MapThreads")
+					.IsRequired()
+					.HasColumnType("INTEGER");
+
+				b.Property<bool?>("Minidumps")
 					.IsRequired()
 					.HasColumnType("INTEGER");
 

--- a/src/Tgstation.Server.Host/System/DotnetDumpService.cs
+++ b/src/Tgstation.Server.Host/System/DotnetDumpService.cs
@@ -26,7 +26,7 @@ namespace Tgstation.Server.Host.System
 		}
 
 		/// <inheritdoc />
-		public async ValueTask Dump(IProcess process, string outputFile, CancellationToken cancellationToken)
+		public async ValueTask Dump(IProcess process, string outputFile, bool minidump, CancellationToken cancellationToken)
 		{
 			// need to use an extra timeout here because if the process is truly deadlocked. A cooperative dump will hang forever
 			using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -42,7 +42,13 @@ namespace Tgstation.Server.Host.System
 			var pid = process.Id;
 			logger.LogDebug("dotnet-dump requested for PID {pid}...", pid);
 			var client = new DiagnosticsClient(pid);
-			await client.WriteDumpAsync(DumpType.Full, outputFile, false, cts.Token);
+			await client.WriteDumpAsync(
+				minidump
+					? DumpType.Normal
+					: DumpType.Full,
+				outputFile,
+				false,
+				cts.Token);
 		}
 	}
 }

--- a/src/Tgstation.Server.Host/System/IDotnetDumpService.cs
+++ b/src/Tgstation.Server.Host/System/IDotnetDumpService.cs
@@ -13,8 +13,9 @@ namespace Tgstation.Server.Host.System
 		/// </summary>
 		/// <param name="process">The <see cref="IProcess"/> to dump.</param>
 		/// <param name="outputFile">The path to the output dump file.</param>
+		/// <param name="minidump">If a minidump should be taken as opposed to a full dump.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="ValueTask"/> representing the running operation.</returns>
-		ValueTask Dump(IProcess process, string outputFile, CancellationToken cancellationToken);
+		ValueTask Dump(IProcess process, string outputFile, bool minidump, CancellationToken cancellationToken);
 	}
 }

--- a/src/Tgstation.Server.Host/System/IProcessBase.cs
+++ b/src/Tgstation.Server.Host/System/IProcessBase.cs
@@ -33,8 +33,9 @@ namespace Tgstation.Server.Host.System
 		/// Create a dump file of the process.
 		/// </summary>
 		/// <param name="outputFile">The full path to the output file.</param>
+		/// <param name="minidump">If a minidump should be taken as opposed to a full dump.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="ValueTask"/> representing the running operation.</returns>
-		ValueTask CreateDump(string outputFile, CancellationToken cancellationToken);
+		ValueTask CreateDump(string outputFile, bool minidump, CancellationToken cancellationToken);
 	}
 }

--- a/src/Tgstation.Server.Host/System/IProcessFeatures.cs
+++ b/src/Tgstation.Server.Host/System/IProcessFeatures.cs
@@ -32,8 +32,9 @@ namespace Tgstation.Server.Host.System
 		/// </summary>
 		/// <param name="process">The <see cref="Process"/> to dump.</param>
 		/// <param name="outputFile">The full path to the output file.</param>
+		/// <param name="minidump">If a minidump should be taken as opposed to a full dump.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="ValueTask"/> representing the running operation.</returns>
-		ValueTask CreateDump(global::System.Diagnostics.Process process, string outputFile, CancellationToken cancellationToken);
+		ValueTask CreateDump(global::System.Diagnostics.Process process, string outputFile, bool minidump, CancellationToken cancellationToken);
 	}
 }

--- a/src/Tgstation.Server.Host/System/PosixProcessFeatures.cs
+++ b/src/Tgstation.Server.Host/System/PosixProcessFeatures.cs
@@ -64,7 +64,7 @@ namespace Tgstation.Server.Host.System
 			=> throw new NotSupportedException();
 
 		/// <inheritdoc />
-		public async ValueTask CreateDump(global::System.Diagnostics.Process process, string outputFile, CancellationToken cancellationToken)
+		public async ValueTask CreateDump(global::System.Diagnostics.Process process, string outputFile, bool minidump, CancellationToken cancellationToken)
 		{
 			ArgumentNullException.ThrowIfNull(process);
 			ArgumentNullException.ThrowIfNull(outputFile);
@@ -91,7 +91,7 @@ namespace Tgstation.Server.Host.System
 			await using (var gcoreProc = lazyLoadedProcessExecutor.Value.LaunchProcess(
 				GCorePath,
 				Environment.CurrentDirectory,
-				$"-o {outputFile} {process.Id}",
+				$"{(!minidump ? "-a " : String.Empty)}-o {outputFile} {process.Id}",
 				readStandardHandles: true,
 				noShellExecute: true))
 			{
@@ -99,7 +99,7 @@ namespace Tgstation.Server.Host.System
 					exitCode = (await gcoreProc.Lifetime).Value;
 
 				output = await gcoreProc.GetCombinedOutput(cancellationToken);
-				logger.LogDebug("gcore output:{0}{1}", Environment.NewLine, output);
+				logger.LogDebug("gcore output:{newline}{output}", Environment.NewLine, output);
 			}
 
 			if (exitCode != 0)

--- a/src/Tgstation.Server.Host/System/Process.cs
+++ b/src/Tgstation.Server.Host/System/Process.cs
@@ -224,13 +224,13 @@ namespace Tgstation.Server.Host.System
 		}
 
 		/// <inheritdoc />
-		public ValueTask CreateDump(string outputFile, CancellationToken cancellationToken)
+		public ValueTask CreateDump(string outputFile, bool minidump, CancellationToken cancellationToken)
 		{
 			ArgumentNullException.ThrowIfNull(outputFile);
 			CheckDisposed();
 
 			logger.LogTrace("Dumping PID {pid} to {dumpFilePath}...", Id, outputFile);
-			return processFeatures.CreateDump(handle, outputFile, cancellationToken);
+			return processFeatures.CreateDump(handle, outputFile, minidump, cancellationToken);
 		}
 
 		/// <summary>

--- a/src/Tgstation.Server.Host/System/WindowsProcessFeatures.cs
+++ b/src/Tgstation.Server.Host/System/WindowsProcessFeatures.cs
@@ -120,7 +120,7 @@ namespace Tgstation.Server.Host.System
 		}
 
 		/// <inheritdoc />
-		public async ValueTask CreateDump(global::System.Diagnostics.Process process, string outputFile, CancellationToken cancellationToken)
+		public async ValueTask CreateDump(global::System.Diagnostics.Process process, string outputFile, bool minidump, CancellationToken cancellationToken)
 		{
 			try
 			{
@@ -137,15 +137,19 @@ namespace Tgstation.Server.Host.System
 			await Task.Factory.StartNew(
 				() =>
 				{
+					var flags = NativeMethods.MiniDumpType.WithHandleData
+						| NativeMethods.MiniDumpType.WithThreadInfo
+						| NativeMethods.MiniDumpType.WithUnloadedModules;
+
+					if (!minidump)
+						flags |= NativeMethods.MiniDumpType.WithDataSegs
+							| NativeMethods.MiniDumpType.WithFullMemory;
+
 					if (!NativeMethods.MiniDumpWriteDump(
 						process.Handle,
 						(uint)process.Id,
 						fileStream.SafeFileHandle,
-						NativeMethods.MiniDumpType.WithDataSegs
-						| NativeMethods.MiniDumpType.WithFullMemory
-						| NativeMethods.MiniDumpType.WithHandleData
-						| NativeMethods.MiniDumpType.WithThreadInfo
-						| NativeMethods.MiniDumpType.WithUnloadedModules,
+						flags,
 						IntPtr.Zero,
 						IntPtr.Zero,
 						IntPtr.Zero))

--- a/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
+++ b/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="../../build/SrcCommon.props" />
 
   <PropertyGroup>
@@ -102,7 +102,7 @@
     <!-- Usage: PostgresSQL ORM plugin -->
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
     <!-- Usage: GitHub.com interop -->
-    <PackageReference Include="Octokit" Version="9.1.1" />
+    <PackageReference Include="Octokit" Version="9.1.2" />
     <!-- Usage: MYSQL/MariaDB ORM plugin -->
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.0-beta.2" />
     <!-- Usage: Discord interop -->

--- a/tests/Tgstation.Server.Tests/Live/Instance/WatchdogTest.cs
+++ b/tests/Tgstation.Server.Tests/Live/Instance/WatchdogTest.cs
@@ -1,4 +1,4 @@
-using Byond.TopicSender;
+﻿using Byond.TopicSender;
 
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -351,13 +351,11 @@ namespace Tgstation.Server.Tests.Live.Instance
 
 			var deleteJob = await deleteJobTask;
 
-			// And this freezes DD
-			await DumpTests(cancellationToken);
+			// And this freezes DD (also restarts it)
+			await DumpTests(false, cancellationToken);
+			await DumpTests(true, cancellationToken);
 
-			// Restart to unlock previous BYOND version
-			var restartJob = await instanceClient.DreamDaemon.Restart(cancellationToken);
 			await WaitForJob(deleteJob, 15, false, null, cancellationToken);
-			await WaitForJob(restartJob, 15, false, null, cancellationToken);
 		}
 
 		async ValueTask RegressionTest1550(CancellationToken cancellationToken)
@@ -519,9 +517,14 @@ namespace Tgstation.Server.Tests.Live.Instance
 			Assert.AreEqual("sent", topicRequestResult.StringData);
 		}
 
-		async Task DumpTests(CancellationToken cancellationToken)
+		async Task DumpTests(bool mini, CancellationToken cancellationToken)
 		{
 			System.Console.WriteLine("TEST: WATCHDOG DUMP TESTS");
+			var updated = await instanceClient.DreamDaemon.Update(new DreamDaemonRequest
+			{
+				Minidumps = mini,
+			}, cancellationToken);
+			Assert.AreEqual(mini, updated.Minidumps);
 			var dumpJob = await instanceClient.DreamDaemon.CreateDump(cancellationToken);
 			await WaitForJob(dumpJob, 30, false, null, cancellationToken);
 

--- a/tests/Tgstation.Server.Tests/Live/Instance/WatchdogTest.cs
+++ b/tests/Tgstation.Server.Tests/Live/Instance/WatchdogTest.cs
@@ -1,4 +1,4 @@
-﻿using Byond.TopicSender;
+using Byond.TopicSender;
 
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -526,7 +526,7 @@ namespace Tgstation.Server.Tests.Live.Instance
 			await WaitForJob(dumpJob, 30, false, null, cancellationToken);
 
 			var dumpFiles = Directory.GetFiles(Path.Combine(
-				instanceClient.Metadata.Path, "Diagnostics", "ProcessDumps"), "*.dmp");
+				instanceClient.Metadata.Path, "Diagnostics", "ProcessDumps"), testVersion.Engine == EngineType.OpenDream ? "*.net.dmp" : "*.dmp");
 			Assert.AreEqual(1, dumpFiles.Length);
 			File.Delete(dumpFiles.Single());
 

--- a/tests/Tgstation.Server.Tests/TestDatabase.cs
+++ b/tests/Tgstation.Server.Tests/TestDatabase.cs
@@ -122,6 +122,7 @@ namespace Tgstation.Server.Tests
 					StartProfiler = false,
 					LogOutput = true,
 					MapThreads = 69,
+					Minidumps = true,
 				},
 				DreamMakerSettings = new Host.Models.DreamMakerSettings
 				{


### PR DESCRIPTION
🆑
Newly created instances will have their `minidumps` watchdog setting set to `true`. Previously, this behavior was `true` on Linux, and `false` on Windows. This will persist into this update.
/🆑

🆑 HTTP API
Added the `minidumps` flag to watchdog settings. This allows selecting between minidumps when `true` and full dumps when `false`.
Added watchdog permission `2097152` for setting the `minidumps` flag.
/🆑

🆑 Nuget: API
Added `DreamDaemonLaunchParameters.Minidumps` boolean.
Added `DreamDaemonRights.SetMinidumps` flag.
/🆑

🆑 Nuget: Client
Added `DreamDaemonLaunchParameters.Minidumps` boolean.
Added `DreamDaemonRights.SetMinidumps` flag.
/🆑

Closes #1741 

Merging with `[APIDeploy][NugetDeploy]`
