### PR TITLE
[MUST PASS CI 10 CONSECUTIVE TIMES BEFORE MERGING] Workaround for world.Export potentially hanging forever

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -9,7 +9,7 @@
     <TgsCommonLibraryVersion>7.0.0</TgsCommonLibraryVersion>
     <TgsApiLibraryVersion>13.2.0</TgsApiLibraryVersion>
     <TgsClientVersion>15.2.0</TgsClientVersion>
-    <TgsDmapiVersion>7.1.0</TgsDmapiVersion>
+    <TgsDmapiVersion>7.1.1</TgsDmapiVersion>
     <TgsInteropVersion>5.9.0</TgsInteropVersion>
     <TgsHostWatchdogVersion>1.4.1</TgsHostWatchdogVersion>
     <TgsContainerScriptVersion>1.2.1</TgsContainerScriptVersion>

--- a/src/DMAPI/tgs.dm
+++ b/src/DMAPI/tgs.dm
@@ -1,6 +1,6 @@
 // tgstation-server DMAPI
 
-#define TGS_DMAPI_VERSION "7.1.0"
+#define TGS_DMAPI_VERSION "7.1.1"
 
 // All functions and datums outside this document are subject to change with any version and should not be relied on.
 
@@ -496,7 +496,7 @@
 /// Returns a list of connected [/datum/tgs_chat_channel]s if TGS is present, null otherwise. This function may sleep if the call to [/world/proc/TgsNew] is sleeping!
 /world/proc/TgsChatChannelInfo()
 	return
-	
+
 /**
  * Trigger an event in TGS. Requires TGS version >= 6.3.0. Returns [TRUE] if the event was triggered successfully, [FALSE] otherwise. This function may sleep!
  *

--- a/src/DMAPI/tgs/v5/api.dm
+++ b/src/DMAPI/tgs/v5/api.dm
@@ -48,6 +48,10 @@
 
 	var/datum/tgs_version/api_version = ApiVersion()
 	version = null // we want this to be the TGS version, not the interop version
+
+	// sleep once to prevent an issue where world.Export on the first tick can hang indefinitely
+	sleep(world.tick_lag)
+
 	var/list/bridge_response = Bridge(DMAPI5_BRIDGE_COMMAND_STARTUP, list(DMAPI5_BRIDGE_PARAMETER_MINIMUM_SECURITY_LEVEL = minimum_required_security_level, DMAPI5_BRIDGE_PARAMETER_VERSION = api_version.raw_parameter, DMAPI5_PARAMETER_CUSTOM_COMMANDS = ListCustomCommands(), DMAPI5_PARAMETER_TOPIC_PORT = GetTopicPort()))
 	if(!istype(bridge_response))
 		TGS_ERROR_LOG("Failed initial bridge request!")

--- a/src/DMAPI/tgs/v5/topic.dm
+++ b/src/DMAPI/tgs/v5/topic.dm
@@ -177,7 +177,8 @@
 			reattach_response[DMAPI5_PARAMETER_CUSTOM_COMMANDS] = ListCustomCommands()
 			reattach_response[DMAPI5_PARAMETER_TOPIC_PORT] = GetTopicPort()
 
-			pending_events.Cut()
+			for(var/eventId in pending_events)
+				pending_events[eventId] = TRUE
 
 			return reattach_response
 

--- a/tests/Tgstation.Server.Tests/Live/Instance/WatchdogTest.cs
+++ b/tests/Tgstation.Server.Tests/Live/Instance/WatchdogTest.cs
@@ -526,7 +526,7 @@ namespace Tgstation.Server.Tests.Live.Instance
 			}, cancellationToken);
 			Assert.AreEqual(mini, updated.Minidumps);
 			var dumpJob = await instanceClient.DreamDaemon.CreateDump(cancellationToken);
-			await WaitForJob(dumpJob, 30, false, null, cancellationToken);
+			await WaitForJob(dumpJob, 60, false, null, cancellationToken);
 
 			var dumpFiles = Directory.GetFiles(Path.Combine(
 				instanceClient.Metadata.Path, "Diagnostics", "ProcessDumps"), testVersion.Engine == EngineType.OpenDream ? "*.net.dmp" : "*.dmp");


### PR DESCRIPTION
🆑 DreamMaker API
Worked around an extremely rare BYOND bug where calling `TgsNew()` hung forever.
Fixed waiting on custom events never returning if TGS restarted while the event was processing.
/🆑

🆑
Fixed a rare race condition when suspending Windows processes.
/🆑

Merge with `[DMDeploy]`
Closes #1681

Also if this works create a BYOND bug.