### PR TITLE
v6.3.2: Fix a deployment directory leak

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -1396,19 +1396,32 @@ jobs:
     name: CI Completion Gate
     needs: [ pages-build, docker-build, build-deb, build-msi, validate-openapi-spec, upload-code-coverage, check-winget-pr-template, code-scanning ]
     runs-on: ubuntu-latest
-    permissions:
-      checks: write
-      contents: read
     if: (!(cancelled() || failure()) && needs.pages-build.result == 'success' && needs.docker-build.result == 'success' && needs.build-deb.result == 'success' && needs.build-msi.result == 'success' && needs.validate-openapi-spec.result == 'success' && needs.upload-code-coverage.result == 'success' && needs.check-winget-pr-template.result == 'success' && needs.code-scanning.result == 'success')
     steps:
-    - name: Create Completion Check
-      uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v4
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        name: CI Completion
-        conclusion: success
-        output: |
-          {"summary":"The CI Pipeline completed successfully"}
+        dotnet-version: '${{ env.TGS_DOTNET_VERSION }}.0.x'
+        dotnet-quality: ${{ env.TGS_DOTNET_QUALITY }}
+
+    - name: Checkout (Branch)
+      uses: actions/checkout@v4
+      if: github.event_name == 'push' || github.event_name == 'schedule'
+
+    - name: Checkout (PR Merge)
+      uses: actions/checkout@v4
+      if: github.event_name != 'push' && github.event_name != 'schedule'
+      with:
+        ref: "refs/pull/${{ github.event.number }}/merge"
+
+    - name: Restore
+      run: dotnet restore
+
+    - name: Build ReleaseNotes
+      run: dotnet build -c Release -p:TGS_HOST_NO_WEBPANEL=true tools/Tgstation.Server.ReleaseNotes/Tgstation.Server.ReleaseNotes.csproj
+
+    - name: Run ReleaseNotes Create CI Completion Check
+      run: dotnet run -c Release --no-build --project tools/Tgstation.Server.ReleaseNotes --ci-completion-check ${{ github.sha }} ${{ secrets.TGS_CI_GITHUB_APP_TOKEN_BASE64 }}
 
   deployment-gate:
     name: Deployment Start Gate

--- a/build/TestCommon.props
+++ b/build/TestCommon.props
@@ -3,7 +3,7 @@
 
   <ItemGroup>
     <!-- Usage: Code coverage collection -->
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -18,9 +18,9 @@
     <!-- Pinned: Be VERY careful about updating https://github.com/moq/moq/issues/1372 -->
     <PackageReference Include="Moq" Version="4.20.70" />
     <!-- Usage: MSTest execution -->
-    <PackageReference Include="MSTest.TestAdapter" Version="3.2.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
     <!-- Usage: MSTest asserts etc... -->
-    <PackageReference Include="MSTest.TestFramework" Version="3.2.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
   </ItemGroup>
 
 </Project>

--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="WebpanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>6.3.1</TgsCoreVersion>
+    <TgsCoreVersion>6.3.2</TgsCoreVersion>
     <TgsConfigVersion>5.1.0</TgsConfigVersion>
     <TgsApiVersion>10.2.0</TgsApiVersion>
     <TgsCommonLibraryVersion>7.0.0</TgsCommonLibraryVersion>

--- a/src/Tgstation.Server.Host/Components/Deployment/DmbFactory.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/DmbFactory.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -325,14 +325,17 @@ namespace Tgstation.Server.Host.Components.Deployment
 					if (!jobLockCounts.TryGetValue(compileJobId, out int value))
 					{
 						value = 1;
+						logger.LogTrace("Initializing lock count for compile job {id}", compileJobId);
 						jobLockCounts.Add(compileJobId, 1);
 					}
 					else
+					{
+						logger.LogTrace("FromCompileJob already had a jobLockCounts entry for {id}. Incrementing lock count to {value}.", compileJobId, value);
 						jobLockCounts[compileJobId] = ++value;
+					}
 
 					providerSubmitted = true;
 
-					logger.LogTrace("Compile job {id} lock count now: {lockCount}", compileJobId, value);
 					return newProvider;
 				}
 			}

--- a/src/Tgstation.Server.Host/Components/Deployment/DmbFactory.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/DmbFactory.cs
@@ -399,11 +399,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 					++deleting;
 					await DeleteCompileJobContent(x, cancellationToken);
 				}
-				catch (OperationCanceledException)
-				{
-					throw;
-				}
-				catch (Exception e)
+				catch (Exception e) when (e is not OperationCanceledException)
 				{
 					logger.LogWarning(e, "Error deleting directory {dirName}!", x);
 				}

--- a/src/Tgstation.Server.Host/Components/Deployment/DmbFactory.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/DmbFactory.cs
@@ -388,7 +388,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 			await ioManager.CreateDirectory(gameDirectory, cancellationToken);
 			var directories = await ioManager.GetDirectories(gameDirectory, cancellationToken);
 			int deleting = 0;
-			var tasks = directories.Select(async x =>
+			var tasks = directories.Select<string, ValueTask>(async x =>
 			{
 				var nameOnly = ioManager.GetFileName(x);
 				if (jobUidsToNotErase.Contains(nameOnly))
@@ -405,7 +405,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 				}
 			}).ToList();
 			if (deleting > 0)
-				await Task.WhenAll(tasks);
+				await ValueTaskExtensions.WhenAll(tasks);
 		}
 #pragma warning restore CA1506
 

--- a/src/Tgstation.Server.Host/Components/Deployment/SwappableDmbProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/SwappableDmbProvider.cs
@@ -87,7 +87,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 		}
 
 		/// <summary>
-		/// Should be <see langword="await"/>. before calling <see cref="MakeActive(CancellationToken)"/> to ensure the <see cref="SwappableDmbProvider"/> is ready to instantly swap. Can be called multiple times.
+		/// Should be <see langword="await"/>ed. before calling <see cref="MakeActive(CancellationToken)"/> to ensure the <see cref="SwappableDmbProvider"/> is ready to instantly swap. Can be called multiple times.
 		/// </summary>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task"/> representing the preparation process.</returns>

--- a/src/Tgstation.Server.Host/Components/Watchdog/AdvancedWatchdog.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/AdvancedWatchdog.cs
@@ -184,7 +184,8 @@ namespace Tgstation.Server.Host.Components.Watchdog
 						currentCompileJobId,
 						lingeringDeploymentExpirySeconds);
 
-					var timeout = AsyncDelayer.Delay(TimeSpan.FromSeconds(lingeringDeploymentExpirySeconds), cancellationToken);
+					// DCT: A cancel firing here can result in us leaving a dmbprovider undisposed, localDeploymentCleanupGate will always fire in that case
+					var timeout = AsyncDelayer.Delay(TimeSpan.FromSeconds(lingeringDeploymentExpirySeconds), CancellationToken.None);
 
 					var completedTask = await Task.WhenAny(
 						localDeploymentCleanupGate.Task,

--- a/src/Tgstation.Server.Host/Components/Watchdog/AdvancedWatchdog.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/AdvancedWatchdog.cs
@@ -127,8 +127,12 @@ namespace Tgstation.Server.Host.Components.Watchdog
 
 			// If we reach this point, we can guarantee PrepServerForLaunch will be called before starting again.
 			ActiveSwappable = null;
-			await (pendingSwappable?.DisposeAsync() ?? ValueTask.CompletedTask);
-			pendingSwappable = null;
+
+			if (pendingSwappable != null)
+			{
+				await pendingSwappable.DisposeAsync();
+				pendingSwappable = null;
+			}
 
 			await DrainDeploymentCleanupTasks(true);
 		}

--- a/src/Tgstation.Server.Host/Components/Watchdog/AdvancedWatchdog.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/AdvancedWatchdog.cs
@@ -142,8 +142,6 @@ namespace Tgstation.Server.Host.Components.Watchdog
 		{
 			if (pendingSwappable != null)
 			{
-				ValueTask RunPrequel() => BeforeApplyDmb(pendingSwappable.CompileJob, cancellationToken);
-
 				var needToSwap = !pendingSwappable.Swapped;
 				var controller = Server!;
 				if (needToSwap)
@@ -155,7 +153,6 @@ namespace Tgstation.Server.Host.Components.Watchdog
 						// integration test logging will catch this
 						Logger.LogError(
 							"The reboot bridge request completed before the watchdog could suspend the server! This can lead to buggy DreamDaemon behaviour and should be reported! To ensure stability, we will need to hard reboot the server");
-						await RunPrequel();
 						return MonitorAction.Restart;
 					}
 
@@ -169,7 +166,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 					}
 				}
 
-				var updateTask = RunPrequel();
+				var updateTask = BeforeApplyDmb(pendingSwappable.CompileJob, cancellationToken);
 				if (needToSwap)
 					await PerformDmbSwap(pendingSwappable, cancellationToken);
 

--- a/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
+++ b/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
@@ -104,7 +104,7 @@
     <!-- Usage: GitHub.com interop -->
     <PackageReference Include="Octokit" Version="10.0.0" />
     <!-- Usage: MYSQL/MariaDB ORM plugin -->
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.0" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.1" />
     <!-- Usage: Discord interop -->
     <PackageReference Include="Remora.Discord" Version="2024.1.0" />
     <!-- Usage: Rich logger builder -->
@@ -128,7 +128,7 @@
     <!-- Usage: Temporary resolution to compatibility issues with EFCore 7 and .NET 8 -->
     <PackageReference Include="System.Security.Permissions" Version="8.0.0" />
     <!-- Usage: .DeleteAsync() support for IQueryable<T>s -->
-    <PackageReference Include="Z.EntityFramework.Plus.EFCore" Version="8.102.1" />
+    <PackageReference Include="Z.EntityFramework.Plus.EFCore" Version="8.102.1.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
🆑
Fixed an issue where stopping or rebooting the server could cause the previously used deployment directory to not properly get cleaned up.
/🆑

Also adds a bunch of logging to help detect the issue in the future.

Potentially fixes #1779

Mergine with `[TGSDeploy]`