### PR TITLE
`oom_score_adj` support. Test merge URL deduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ docker run \
 	--network="host" \ # Not recommended, eases networking setup if your sql server is on the same machine
 	--name="tgs" \ # Name for the container
 	--cap-add=sys_nice \ # Recommended, allows TGS to lower the niceness of child processes if it sees fit
+	--cap-add=sys_resource \ # Recommended, allows TGS to not be killed by the OOM killer before its child processes
 	--init \ #Highly recommended, reaps potential zombie processes
 	-p 5000:5000 \ # Port bridge for accessing TGS, you can change this if you need
 	-p 0.0.0.0:<public game port>:<public game port> \ # Port bridge for accessing DreamDaemon

--- a/src/Tgstation.Server.Api/Tgstation.Server.Api.csproj
+++ b/src/Tgstation.Server.Api/Tgstation.Server.Api.csproj
@@ -27,7 +27,7 @@
     <!-- Usage: HTTP constants reference -->
     <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.2.0" />
     <!-- Usage: Decoding the 'nbf' property of JWTs -->
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.3.1" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.4.0" />
     <!-- Usage: Primary JSON library -->
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <!-- Usage: Data model annotating -->

--- a/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
@@ -855,11 +855,12 @@ namespace Tgstation.Server.Host.Components.Deployment
 			var environment = await engineLock.LoadEnv(logger, true, cancellationToken);
 			var arguments = engineLock.FormatCompilerArguments($"{job.DmeName}.{DmeExtension}");
 
-			await using var dm = processExecutor.LaunchProcess(
+			await using var dm = await processExecutor.LaunchProcess(
 				engineLock.CompilerExePath,
 				ioManager.ResolvePath(
 					job.DirectoryName!.Value.ToString()),
 				arguments,
+				cancellationToken,
 				environment,
 				readStandardHandles: true,
 				noShellExecute: true);

--- a/src/Tgstation.Server.Host/Components/Engine/OpenDreamInstaller.cs
+++ b/src/Tgstation.Server.Host/Components/Engine/OpenDreamInstaller.cs
@@ -241,10 +241,11 @@ namespace Tgstation.Server.Host.Components.Engine
 				async shortenedPath =>
 				{
 					var shortenedDeployPath = IOManager.ConcatPath(shortenedPath, DeployDir);
-					await using var buildProcess = ProcessExecutor.LaunchProcess(
+					await using var buildProcess = await ProcessExecutor.LaunchProcess(
 						dotnetPath,
 						shortenedPath,
 						$"run -c Release --project OpenDreamPackageTool -- --tgs -o {shortenedDeployPath}",
+						cancellationToken,
 						null,
 						null,
 						!GeneralConfiguration.OpenDreamSuppressInstallOutput,

--- a/src/Tgstation.Server.Host/Components/Engine/WindowsByondInstaller.cs
+++ b/src/Tgstation.Server.Host/Components/Engine/WindowsByondInstaller.cs
@@ -283,10 +283,11 @@ namespace Tgstation.Server.Host.Components.Engine
 			try
 			{
 				// noShellExecute because we aren't doing runas shennanigans
-				await using var directXInstaller = processExecutor.LaunchProcess(
+				await using var directXInstaller = await processExecutor.LaunchProcess(
 					IOManager.ConcatPath(rbdx, "DXSETUP.exe"),
 					rbdx,
 					"/silent",
+					cancellationToken,
 					noShellExecute: true);
 
 				int exitCode;

--- a/src/Tgstation.Server.Host/Components/Repository/GitHubRemoteFeatures.cs
+++ b/src/Tgstation.Server.Host/Components/Repository/GitHubRemoteFeatures.cs
@@ -93,7 +93,7 @@ namespace Tgstation.Server.Host.Components.Repository
 				Comment = parameters.Comment,
 				Number = parameters.Number,
 				TargetCommitSha = revisionToUse,
-				Url = pr?.HtmlUrl ?? errorMessage,
+				Url = pr?.HtmlUrl ?? $"https://github.com/{RemoteRepositoryOwner}/{RemoteRepositoryName}/pull/{parameters.Number}",
 			};
 
 			return testMerge;

--- a/src/Tgstation.Server.Host/Components/Repository/GitLabRemoteFeatures.cs
+++ b/src/Tgstation.Server.Host/Components/Repository/GitLabRemoteFeatures.cs
@@ -85,7 +85,7 @@ namespace Tgstation.Server.Host.Components.Repository
 					Comment = parameters.Comment,
 					Number = parameters.Number,
 					TargetCommitSha = parameters.TargetCommitSha,
-					Url = ex.Message,
+					Url = $"https://gitlab.com/{RemoteRepositoryOwner}/{RemoteRepositoryName}/-/merge_requests/{parameters.Number}",
 				};
 			}
 		}

--- a/src/Tgstation.Server.Host/Components/Session/SessionControllerFactory.cs
+++ b/src/Tgstation.Server.Host/Components/Session/SessionControllerFactory.cs
@@ -516,10 +516,11 @@ namespace Tgstation.Server.Host.Components.Session
 					? logFilePath
 					: null);
 
-			var process = processExecutor.LaunchProcess(
+			var process = await processExecutor.LaunchProcess(
 				engineLock.ServerExePath,
 				dmbProvider.Directory,
 				arguments,
+				cancellationToken,
 				environment,
 				logFilePath,
 				engineLock.HasStandardOutput,

--- a/src/Tgstation.Server.Host/Components/StaticFiles/Configuration.cs
+++ b/src/Tgstation.Server.Host/Components/StaticFiles/Configuration.cs
@@ -761,7 +761,7 @@ namespace Tgstation.Server.Host.Components.StaticFiles
 				foreach (var scriptFile in scriptFiles)
 				{
 					logger.LogTrace("Running event script {scriptFile}...", scriptFile);
-					await using (var script = processExecutor.LaunchProcess(
+					await using (var script = await processExecutor.LaunchProcess(
 						ioManager.ConcatPath(resolvedScriptsDir, scriptFile),
 						resolvedScriptsDir,
 						String.Join(
@@ -778,6 +778,7 @@ namespace Tgstation.Server.Host.Components.StaticFiles
 
 								return $"\"{arg}\"";
 							})),
+						cancellationToken,
 						readStandardHandles: true,
 						noShellExecute: true))
 					using (cancellationToken.Register(() => script.Terminate()))

--- a/src/Tgstation.Server.Host/Core/Application.cs
+++ b/src/Tgstation.Server.Host/Core/Application.cs
@@ -356,6 +356,7 @@ namespace Tgstation.Server.Host.Core
 				services.AddSingleton<IPostWriteHandler, PosixPostWriteHandler>();
 
 				services.AddSingleton<IProcessFeatures, PosixProcessFeatures>();
+				services.AddHostedService<PosixProcessFeatures>();
 
 				// PosixProcessFeatures also needs a IProcessExecutor for gcore
 				services.AddSingleton(x => new Lazy<IProcessExecutor>(() => x.GetRequiredService<IProcessExecutor>(), true));

--- a/src/Tgstation.Server.Host/IO/DefaultIOManager.cs
+++ b/src/Tgstation.Server.Host/IO/DefaultIOManager.cs
@@ -221,14 +221,7 @@ namespace Tgstation.Server.Host.IO
 		/// <inheritdoc />
 		public async ValueTask<byte[]> ReadAllBytes(string path, CancellationToken cancellationToken)
 		{
-			path = ResolvePath(path);
-			await using var file = new FileStream(
-				path,
-				FileMode.Open,
-				FileAccess.Read,
-				FileShare.ReadWrite | FileShare.Delete,
-				DefaultBufferSize,
-				FileOptions.Asynchronous | FileOptions.SequentialScan);
+			await using var file = CreateAsyncSequentialReadStream(path);
 			byte[] buf;
 			buf = new byte[file.Length];
 			await file.ReadAsync(buf, cancellationToken);
@@ -257,6 +250,19 @@ namespace Tgstation.Server.Host.IO
 				FileMode.Create,
 				FileAccess.Write,
 				FileShare.Read | FileShare.Delete,
+				DefaultBufferSize,
+				FileOptions.Asynchronous | FileOptions.SequentialScan);
+		}
+
+		/// <inheritdoc />
+		public FileStream CreateAsyncSequentialReadStream(string path)
+		{
+			path = ResolvePath(path);
+			return new FileStream(
+				path,
+				FileMode.Open,
+				FileAccess.Read,
+				FileShare.ReadWrite | FileShare.Delete,
 				DefaultBufferSize,
 				FileOptions.Asynchronous | FileOptions.SequentialScan);
 		}

--- a/src/Tgstation.Server.Host/IO/IIOManager.cs
+++ b/src/Tgstation.Server.Host/IO/IIOManager.cs
@@ -85,6 +85,7 @@ namespace Tgstation.Server.Host.IO
 		/// <param name="path">The path of the file to read.</param>
 		/// <param name="cancellationToken">A <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="ValueTask"/> that results in the contents of a file at <paramref name="path"/>.</returns>
+		/// <remarks>This function will fail to read files from the /proc filesystem on Linux.</remarks>
 		ValueTask<byte[]> ReadAllBytes(string path, CancellationToken cancellationToken);
 
 		/// <summary>

--- a/src/Tgstation.Server.Host/IO/IIOManager.cs
+++ b/src/Tgstation.Server.Host/IO/IIOManager.cs
@@ -111,6 +111,13 @@ namespace Tgstation.Server.Host.IO
 		FileStream CreateAsyncSequentialWriteStream(string path);
 
 		/// <summary>
+		/// Creates an asynchronous <see cref="FileStream"/> for sequential reading.
+		/// </summary>
+		/// <param name="path">The path of the file to write, will be truncated.</param>
+		/// <returns>The open <see cref="FileStream"/>.</returns>
+		FileStream CreateAsyncSequentialReadStream(string path);
+
+		/// <summary>
 		/// Writes some <paramref name="contents"/> to a file at <paramref name="path"/> overwriting previous content.
 		/// </summary>
 		/// <param name="path">The path of the file to write.</param>

--- a/src/Tgstation.Server.Host/System/IProcessExecutor.cs
+++ b/src/Tgstation.Server.Host/System/IProcessExecutor.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Tgstation.Server.Host.System
 {
@@ -13,15 +15,17 @@ namespace Tgstation.Server.Host.System
 		/// <param name="fileName">The full path to the executable file.</param>
 		/// <param name="workingDirectory">The working directory for the <see cref="IProcess"/>.</param>
 		/// <param name="arguments">The arguments for the <see cref="IProcess"/>.</param>
+		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <param name="environment">A <see cref="IReadOnlyDictionary{TKey, TValue}"/> of environment variables to set.</param>
 		/// <param name="fileRedirect">File to write process output and error streams to. Requires <paramref name="readStandardHandles"/> to be <see langword="true"/>.</param>
 		/// <param name="readStandardHandles">If the process output and error streams should be read.</param>
 		/// <param name="noShellExecute">If shell execute should not be used. Must be set if <paramref name="readStandardHandles"/> is set.</param>
-		/// <returns>The new <see cref="IProcess"/>.</returns>
-		IProcess LaunchProcess(
+		/// <returns>A <see cref="ValueTask{TResult}"/> resulting in the new <see cref="IProcess"/>.</returns>
+		ValueTask<IProcess> LaunchProcess(
 			string fileName,
 			string workingDirectory,
 			string arguments,
+			CancellationToken cancellationToken,
 			IReadOnlyDictionary<string, string>? environment = null,
 			string? fileRedirect = null,
 			bool readStandardHandles = false,

--- a/src/Tgstation.Server.Host/System/IProcessFeatures.cs
+++ b/src/Tgstation.Server.Host/System/IProcessFeatures.cs
@@ -18,11 +18,11 @@ namespace Tgstation.Server.Host.System
 		/// <summary>
 		/// Suspend a given <paramref name="process"/>.
 		/// </summary>
-		/// <param name="process">The <see cref="Process"/> to suspend.</param>
+		/// <param name="process">The <see cref="global::System.Diagnostics.Process"/> to suspend.</param>
 		void SuspendProcess(global::System.Diagnostics.Process process);
 
 		/// <summary>
-		/// Resume a given suspended <see cref="Process"/>.
+		/// Resume a given suspended <see cref="global::System.Diagnostics.Process"/>.
 		/// </summary>
 		/// <param name="process">The <see cref="Process"/> to suspended.</param>
 		void ResumeProcess(global::System.Diagnostics.Process process);
@@ -30,11 +30,19 @@ namespace Tgstation.Server.Host.System
 		/// <summary>
 		/// Create a dump file for a given <paramref name="process"/>.
 		/// </summary>
-		/// <param name="process">The <see cref="Process"/> to dump.</param>
+		/// <param name="process">The <see cref="global::System.Diagnostics.Process"/> to dump.</param>
 		/// <param name="outputFile">The full path to the output file.</param>
 		/// <param name="minidump">If a minidump should be taken as opposed to a full dump.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="ValueTask"/> representing the running operation.</returns>
 		ValueTask CreateDump(global::System.Diagnostics.Process process, string outputFile, bool minidump, CancellationToken cancellationToken);
+
+		/// <summary>
+		/// Run events on starting a process.
+		/// </summary>
+		/// <param name="process">The <see cref="global::System.Diagnostics.Process"/> that was started.</param>
+		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
+		/// <returns>A <see cref="ValueTask{TResult}"/> resulting in the <paramref name="process"/> ID.</returns>
+		ValueTask<int> HandleProcessStart(global::System.Diagnostics.Process process, CancellationToken cancellationToken);
 	}
 }

--- a/src/Tgstation.Server.Host/System/WindowsFirewallHelper.cs
+++ b/src/Tgstation.Server.Host/System/WindowsFirewallHelper.cs
@@ -31,10 +31,11 @@ namespace Tgstation.Server.Host.System
 		{
 			logger.LogInformation("Adding Windows Firewall exception for {path}...", exePath);
 			var arguments = $"advfirewall firewall add rule name=\"{exceptionName}\" program=\"{exePath}\" protocol=tcp dir=in enable=yes action=allow";
-			await using var netshProcess = processExecutor.LaunchProcess(
+			await using var netshProcess = await processExecutor.LaunchProcess(
 				"netsh.exe",
 				Environment.CurrentDirectory,
 				arguments,
+				cancellationToken,
 				readStandardHandles: true,
 				noShellExecute: true);
 

--- a/src/Tgstation.Server.Host/System/WindowsProcessFeatures.cs
+++ b/src/Tgstation.Server.Host/System/WindowsProcessFeatures.cs
@@ -172,5 +172,9 @@ namespace Tgstation.Server.Host.System
 				DefaultIOManager.BlockingTaskCreationOptions,
 				TaskScheduler.Current);
 		}
+
+		/// <inheritdoc />
+		public ValueTask<int> HandleProcessStart(global::System.Diagnostics.Process process, CancellationToken cancellationToken)
+			=> ValueTask.FromResult((process ?? throw new ArgumentNullException(nameof(process))).Id);
 	}
 }

--- a/tests/Tgstation.Server.Host.Tests/System/TestPosixSignalHandler.cs
+++ b/tests/Tgstation.Server.Host.Tests/System/TestPosixSignalHandler.cs
@@ -63,11 +63,12 @@ namespace Tgstation.Server.Host.System.Tests
 				Mock.Of<IIOManager>(),
 				loggerFactory.CreateLogger<ProcessExecutor>(),
 				loggerFactory);
-			await using var subProc = processExecutor
+			await using var subProc = await processExecutor
 				.LaunchProcess(
 					"dotnet",
 					pathToSignalTestApp,
 					$"run -c {CurrentConfig} --no-build",
+					CancellationToken.None,
 					null,
 					null,
 					true,

--- a/tests/Tgstation.Server.Tests/Live/Instance/WatchdogTest.cs
+++ b/tests/Tgstation.Server.Tests/Live/Instance/WatchdogTest.cs
@@ -731,7 +731,7 @@ namespace Tgstation.Server.Tests.Live.Instance
 
 			var features = new PosixProcessFeatures(
 				new Lazy<IProcessExecutor>(Mock.Of<IProcessExecutor>()),
-				Mock.Of<IIOManager>(),
+				new DefaultIOManager(),
 				Mock.Of<ILogger<PosixProcessFeatures>>());
 
 			features.SuspendProcess(proc);
@@ -798,7 +798,7 @@ namespace Tgstation.Server.Tests.Live.Instance
 			executor = new ProcessExecutor(
 				RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
 					? new WindowsProcessFeatures(Mock.Of<ILogger<WindowsProcessFeatures>>())
-					: new PosixProcessFeatures(new Lazy<IProcessExecutor>(() => executor), Mock.Of<IIOManager>(), Mock.Of<ILogger<PosixProcessFeatures>>()),
+					: new PosixProcessFeatures(new Lazy<IProcessExecutor>(() => executor), new DefaultIOManager(), Mock.Of<ILogger<PosixProcessFeatures>>()),
 				Mock.Of<IIOManager>(),
 				Mock.Of<ILogger<ProcessExecutor>>(),
 				LoggerFactory.Create(x => { }));

--- a/tests/Tgstation.Server.Tests/Live/TestLiveServer.cs
+++ b/tests/Tgstation.Server.Tests/Live/TestLiveServer.cs
@@ -1100,10 +1100,11 @@ namespace Tgstation.Server.Tests.Live
 
 					async ValueTask RunGitCommand(string args)
 					{
-						await using var gitRemoteOriginFixProc = processExecutor.LaunchProcess(
+						await using var gitRemoteOriginFixProc = await processExecutor.LaunchProcess(
 							"git",
 							repoPath,
 							args,
+							cancellationToken,
 							null,
 							null,
 							true,

--- a/tests/Tgstation.Server.Tests/TestSystemInteraction.cs
+++ b/tests/Tgstation.Server.Tests/TestSystemInteraction.cs
@@ -28,7 +28,7 @@ namespace Tgstation.Server.Tests
 				Mock.Of<ILogger<ProcessExecutor>>(),
 				loggerFactory);
 
-			await using var process = processExecutor.LaunchProcess("test." + platformIdentifier.ScriptFileExtension, ".", string.Empty, null, null, true, true);
+			await using var process = await processExecutor.LaunchProcess("test." + platformIdentifier.ScriptFileExtension, ".", string.Empty, CancellationToken.None, null, null, true, true);
 			using var cts = new CancellationTokenSource();
 			cts.CancelAfter(3000);
 			var exitCode = await process.Lifetime.WaitAsync(cts.Token);
@@ -63,7 +63,7 @@ namespace Tgstation.Server.Tests
 				File.Delete(tempFile);
 				try
 				{
-					await using (var process = processExecutor.LaunchProcess("test." + platformIdentifier.ScriptFileExtension, ".", string.Empty, null, tempFile, true, true))
+					await using (var process = await processExecutor.LaunchProcess("test." + platformIdentifier.ScriptFileExtension, ".", string.Empty, CancellationToken.None, null, tempFile, true, true))
 					{
 						using var cts = new CancellationTokenSource();
 						cts.CancelAfter(3000);

--- a/tests/Tgstation.Server.Tests/TestVersions.cs
+++ b/tests/Tgstation.Server.Tests/TestVersions.cs
@@ -208,7 +208,7 @@ namespace Tgstation.Server.Tests
 					? new WindowsProcessFeatures(Mock.Of<ILogger<WindowsProcessFeatures>>())
 					: new PosixProcessFeatures(
 						new Lazy<IProcessExecutor>(() => null),
-						Mock.Of<IIOManager>(),
+						new DefaultIOManager(),
 						loggerFactory.CreateLogger<PosixProcessFeatures>()),
 					Mock.Of<IIOManager>(),
 					loggerFactory.CreateLogger<ProcessExecutor>(),
@@ -498,10 +498,11 @@ namespace Tgstation.Server.Tests
 
 			try
 			{
-				await using var process = processExecutor.LaunchProcess(
+				await using var process = await processExecutor.LaunchProcess(
 					ddPath,
 					Environment.CurrentDirectory,
 					"fake.dmb -map-threads 3 -close",
+					CancellationToken.None,
 					null,
 					null,
 					true,


### PR DESCRIPTION
🆑
On Linux, TGS will now set the `oom_score_adj` of child processes appropriately so as to ensure they are terminated when memory becomes scarce before its own processes. This means game processes with runaway memory no longer risk killing TGS. **Note: Docker users should add `--cap-add=sys_resource` to their command lines to allow this.**
When test merge metadata fails to be retrieved using a GitHub or GitLab remote, TGS will attempt to deduce the URL using known paths.
/🆑

Looking at you OpenDream

Closes #1792
Closes #1795