### PR TITLE
Update DMAPI License year. Fix potential proc must call parent linter errors

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -9,7 +9,7 @@
     <TgsCommonLibraryVersion>7.0.0</TgsCommonLibraryVersion>
     <TgsApiLibraryVersion>13.2.0</TgsApiLibraryVersion>
     <TgsClientVersion>15.2.0</TgsClientVersion>
-    <TgsDmapiVersion>7.1.1</TgsDmapiVersion>
+    <TgsDmapiVersion>7.1.2</TgsDmapiVersion>
     <TgsInteropVersion>5.9.0</TgsInteropVersion>
     <TgsHostWatchdogVersion>1.4.1</TgsHostWatchdogVersion>
     <TgsContainerScriptVersion>1.2.1</TgsContainerScriptVersion>

--- a/src/DMAPI/tgs.dm
+++ b/src/DMAPI/tgs.dm
@@ -510,7 +510,7 @@
 /*
 The MIT License
 
-Copyright (c) 2017-2023 Jordan Brown
+Copyright (c) 2017-2024 Jordan Brown
 
 Permission is hereby granted, free of charge,
 to any person obtaining a copy of this software and

--- a/src/DMAPI/tgs.dm
+++ b/src/DMAPI/tgs.dm
@@ -1,6 +1,6 @@
 // tgstation-server DMAPI
 
-#define TGS_DMAPI_VERSION "7.1.1"
+#define TGS_DMAPI_VERSION "7.1.2"
 
 // All functions and datums outside this document are subject to change with any version and should not be relied on.
 
@@ -312,6 +312,7 @@
 	var/datum/tgs_chat_embed/structure/embed
 
 /datum/tgs_message_content/New(text)
+	..()
 	if(!istext(text))
 		TGS_ERROR_LOG("[/datum/tgs_message_content] created with no text!")
 		text = null
@@ -354,6 +355,7 @@
 	var/proxy_url
 
 /datum/tgs_chat_embed/media/New(url)
+	..()
 	if(!istext(url))
 		CRASH("[/datum/tgs_chat_embed/media] created with no url!")
 
@@ -367,6 +369,7 @@
 	var/proxy_icon_url
 
 /datum/tgs_chat_embed/footer/New(text)
+	..()
 	if(!istext(text))
 		CRASH("[/datum/tgs_chat_embed/footer] created with no text!")
 
@@ -383,6 +386,7 @@
 	var/proxy_icon_url
 
 /datum/tgs_chat_embed/provider/author/New(name)
+	..()
 	if(!istext(name))
 		CRASH("[/datum/tgs_chat_embed/provider/author] created with no name!")
 
@@ -395,6 +399,7 @@
 	var/is_inline
 
 /datum/tgs_chat_embed/field/New(name, value)
+	..()
 	if(!istext(name))
 		CRASH("[/datum/tgs_chat_embed/field] created with no name!")
 

--- a/src/DMAPI/tgs/LICENSE
+++ b/src/DMAPI/tgs/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2017-2023 Jordan Brown
+Copyright (c) 2017-2024 Jordan Brown
 
 Permission is hereby granted, free of charge,
 to any person obtaining a copy of this software and

--- a/src/DMAPI/tgs/core/datum.dm
+++ b/src/DMAPI/tgs/core/datum.dm
@@ -7,7 +7,7 @@ TGS_DEFINE_AND_SET_GLOBAL(tgs, null)
 	var/list/warned_deprecated_command_runs
 
 /datum/tgs_api/New(datum/tgs_event_handler/event_handler, datum/tgs_version/version)
-	. = ..()
+	..()
 	src.event_handler = event_handler
 	src.version = version
 

--- a/src/DMAPI/tgs/core/tgs_version.dm
+++ b/src/DMAPI/tgs/core/tgs_version.dm
@@ -1,4 +1,5 @@
 /datum/tgs_version/New(raw_parameter)
+	..()
 	src.raw_parameter = raw_parameter
 	deprefixed_parameter = replacetext(raw_parameter, "/tg/station 13 Server v", "")
 	var/list/version_bits = splittext(deprefixed_parameter, ".")


### PR DESCRIPTION
:cl: DreamMaker API
Fixed potential must_call_parent linter errors with SpacemanDMM.
/:cl:

Merging with `[DMDeploy]`