### PR TITLE
v6.6.1: Deployment Lock State Auditing

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="WebpanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>6.6.0</TgsCoreVersion>
+    <TgsCoreVersion>6.6.1</TgsCoreVersion>
     <TgsConfigVersion>5.1.0</TgsConfigVersion>
     <TgsApiVersion>10.4.0</TgsApiVersion>
     <TgsCommonLibraryVersion>7.0.0</TgsCommonLibraryVersion>

--- a/src/DMAPI/tgs/v5/api.dm
+++ b/src/DMAPI/tgs/v5/api.dm
@@ -50,7 +50,9 @@
 	version = null // we want this to be the TGS version, not the interop version
 
 	// sleep once to prevent an issue where world.Export on the first tick can hang indefinitely
+	TGS_DEBUG_LOG("Starting Export bug prevention sleep tick. time:[world.time] sleep_offline:[world.sleep_offline]")
 	sleep(world.tick_lag)
+	TGS_DEBUG_LOG("Export bug prevention sleep complete")
 
 	var/list/bridge_response = Bridge(DMAPI5_BRIDGE_COMMAND_STARTUP, list(DMAPI5_BRIDGE_PARAMETER_MINIMUM_SECURITY_LEVEL = minimum_required_security_level, DMAPI5_BRIDGE_PARAMETER_VERSION = api_version.raw_parameter, DMAPI5_PARAMETER_CUSTOM_COMMANDS = ListCustomCommands(), DMAPI5_PARAMETER_TOPIC_PORT = GetTopicPort()))
 	if(!istype(bridge_response))

--- a/src/Tgstation.Server.Api/Models/EngineVersion.cs
+++ b/src/Tgstation.Server.Api/Models/EngineVersion.cs
@@ -13,6 +13,11 @@ namespace Tgstation.Server.Api.Models
 	public sealed class EngineVersion : IEquatable<EngineVersion>
 	{
 		/// <summary>
+		/// An array of a single '-' <see cref="char"/>.
+		/// </summary>
+		static readonly char[] DashChar = ['-'];
+
+		/// <summary>
 		/// The <see cref="EngineType"/>.
 		/// </summary>
 		[RequestOptions(FieldPresence.Required)]
@@ -48,7 +53,7 @@ namespace Tgstation.Server.Api.Models
 			if (input == null)
 				throw new ArgumentNullException(nameof(input));
 
-			var splits = input.Split(new char[] { '-' }, StringSplitOptions.RemoveEmptyEntries);
+			var splits = input.Split(DashChar, StringSplitOptions.RemoveEmptyEntries);
 			engineVersion = null;
 
 			if (splits.Length > 3)

--- a/src/Tgstation.Server.Host/Components/Chat/Commands/PullRequestsCommand.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Commands/PullRequestsCommand.cs
@@ -137,7 +137,7 @@ namespace Tgstation.Server.Host.Components.Chat.Commands
 				var compileJobToUse = watchdog.ActiveCompileJob;
 				if (hasStaged)
 				{
-					var latestCompileJob = compileJobProvider.LatestCompileJob();
+					var latestCompileJob = await compileJobProvider.LatestCompileJob();
 					if (latestCompileJob?.Id != compileJobToUse?.Id)
 						compileJobToUse = latestCompileJob;
 					else

--- a/src/Tgstation.Server.Host/Components/Deployment/DeploymentLockManager.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/DeploymentLockManager.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
@@ -95,6 +97,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 		/// <returns>A <see cref="IDmbProvider"/> whose lifetime represents the lock.</returns>
 		public IDmbProvider AddLock(string reason, [CallerFilePath] string? callerFile = null, [CallerLineNumber]int callerLine = default)
 		{
+			ArgumentNullException.ThrowIfNull(reason);
 			lock (locks)
 			{
 				if (locks.Count == 0)
@@ -102,6 +105,20 @@ namespace Tgstation.Server.Host.Components.Deployment
 
 				return CreateLock(reason, callerFile!, callerLine);
 			}
+		}
+
+		/// <summary>
+		/// Add lock stats to a given <paramref name="stringBuilder"/>.
+		/// </summary>
+		/// <param name="stringBuilder">The <see cref="StringBuilder"/> to append to.</param>
+		public void LogLockStats(StringBuilder stringBuilder)
+		{
+			ArgumentNullException.ThrowIfNull(stringBuilder);
+
+			stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"Compile Job #{CompileJob.Id}: {CompileJob.DirectoryName}");
+			lock (locks)
+				foreach (var dmbLock in locks)
+					stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"\t-{GetFullLockDescriptor(dmbLock)}");
 		}
 
 		/// <summary>

--- a/src/Tgstation.Server.Host/Components/Deployment/DeploymentLockManager.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/DeploymentLockManager.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging;
+
+using Tgstation.Server.Host.Models;
+
+namespace Tgstation.Server.Host.Components.Deployment
+{
+	/// <summary>
+	/// Manages locks on a given <see cref="IDmbProvider"/>.
+	/// </summary>
+	sealed class DeploymentLockManager : IAsyncDisposable
+	{
+		/// <summary>
+		/// The <see cref="Models.CompileJob"/> represented by the <see cref="DeploymentLockManager"/>.
+		/// </summary>
+		public CompileJob CompileJob => dmbProvider.CompileJob;
+
+		/// <summary>
+		/// The <see cref="ILogger"/> for the <see cref="DeploymentLockManager"/>.
+		/// </summary>
+		readonly ILogger logger;
+
+		/// <summary>
+		/// The <see cref="IDmbProvider"/> the <see cref="DeploymentLockManager"/> is managing.
+		/// </summary>
+		readonly IDmbProvider dmbProvider;
+
+		/// <summary>
+		/// The <see cref="DmbLock"/>s on the <see cref="dmbProvider"/>.
+		/// </summary>
+		readonly HashSet<DmbLock> locks;
+
+		/// <summary>
+		/// The first lock acquired by the <see cref="DeploymentLockManager"/>.
+		/// </summary>
+		readonly DmbLock firstLock;
+
+		/// <summary>
+		/// Create a <see cref="DeploymentLockManager"/>.
+		/// </summary>
+		/// <param name="dmbProvider">The value of <see cref="dmbProvider"/>.</param>
+		/// <param name="logger">The value of <see cref="logger"/>.</param>
+		/// <param name="initialLockReason">The reason for the first lock.</param>
+		/// <param name="firstLock">The <see cref="IDmbProvider"/> that represents the first lock.</param>
+		/// <param name="callerFile">The file path of the calling function.</param>
+		/// <param name="callerLine">The line number of the call invocation.</param>
+		/// <returns>A new <see cref="DeploymentLockManager"/>.</returns>
+		public static DeploymentLockManager Create(IDmbProvider dmbProvider, ILogger logger, string initialLockReason, out IDmbProvider firstLock, [CallerFilePath] string? callerFile = null, [CallerLineNumber] int callerLine = default)
+		{
+			var manager = new DeploymentLockManager(dmbProvider, logger, initialLockReason, callerFile!, callerLine);
+			firstLock = manager.firstLock;
+			return manager;
+		}
+
+		/// <summary>
+		/// Generates a verbose description of a given <paramref name="dmbLock"/>.
+		/// </summary>
+		/// <param name="dmbLock">The <see cref="DmbLock"/> to get a description of.</param>
+		/// <returns>A verbose description of <paramref name="dmbLock"/>.</returns>
+		static string GetFullLockDescriptor(DmbLock dmbLock) => $"{dmbLock.LockID} {dmbLock.Descriptor} (Created at {dmbLock.LockTime}){(dmbLock.KeptAlive ? " (RELEASED)" : String.Empty)}";
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="DeploymentLockManager"/> class.
+		/// </summary>
+		/// <param name="dmbProvider">The value of <see cref="dmbProvider"/>.</param>
+		/// <param name="logger">The value of <see cref="logger"/>.</param>
+		/// <param name="initialLockReason">The reason for the first lock.</param>
+		/// <param name="callerFile">The file path of the calling function.</param>
+		/// <param name="callerLine">The line number of the call invocation.</param>
+		/// <returns>A new <see cref="DeploymentLockManager"/>.</returns>
+		DeploymentLockManager(IDmbProvider dmbProvider, ILogger logger, string initialLockReason, string callerFile, int callerLine)
+		{
+			this.dmbProvider = dmbProvider ?? throw new ArgumentNullException(nameof(dmbProvider));
+			this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+			logger.LogTrace("Initializing lock manager for compile job {id}", dmbProvider.CompileJob.Id);
+			locks = new HashSet<DmbLock>();
+			firstLock = CreateLock(initialLockReason, callerFile, callerLine);
+		}
+
+		/// <inheritdoc />
+		public ValueTask DisposeAsync()
+			=> firstLock.DisposeAsync();
+
+		/// <summary>
+		/// Add a lock to the managed <see cref="IDmbProvider"/>.
+		/// </summary>
+		/// <param name="reason">The reason for the lock.</param>
+		/// <param name="callerFile">The file path of the calling function.</param>
+		/// <param name="callerLine">The line number of the call invocation.</param>
+		/// <returns>A <see cref="IDmbProvider"/> whose lifetime represents the lock.</returns>
+		public IDmbProvider AddLock(string reason, [CallerFilePath] string? callerFile = null, [CallerLineNumber]int callerLine = default)
+		{
+			lock (locks)
+			{
+				if (locks.Count == 0)
+					throw new InvalidOperationException($"No locks exist on the DmbProvider for CompileJob {dmbProvider.CompileJob.Id}!");
+
+				return CreateLock(reason, callerFile!, callerLine);
+			}
+		}
+
+		/// <summary>
+		/// Creates a <see cref="DmbLock"/> and adds it to <see cref="locks"/>.
+		/// </summary>
+		/// <param name="reason">The reason for the lock.</param>
+		/// <param name="callerFile">The file path of the calling function.</param>
+		/// <param name="callerLine">The line number of the call invocation.</param>
+		/// <returns>A new <see cref="DmbLock"/>.</returns>
+		/// <remarks>Requires exclusive write access to <see cref="locks"/> be held by the caller.</remarks>
+		DmbLock CreateLock(string reason, string callerFile, int callerLine)
+		{
+			DmbLock? newLock = null;
+			string? descriptor = null;
+			ValueTask LockCleanupAction()
+			{
+				ValueTask disposeTask = ValueTask.CompletedTask;
+				lock (locks)
+				{
+					logger.LogTrace("Removing .dmb Lock: {descriptor}", descriptor);
+
+					if (locks.Remove(newLock!))
+						logger.LogTrace("Lock was removed from list successfully");
+					else
+						logger.LogError("A .dmb lock was disposed more than once: {descriptor}", descriptor);
+
+					if (locks.Count == 0)
+						disposeTask = dmbProvider.DisposeAsync();
+					else if (newLock == firstLock)
+						logger.LogDebug("First lock on CompileJob #{compileJobId} removed, it must cleanup {remaining} remaining locks to be cleaned", CompileJob.Id, locks.Count);
+				}
+
+				return disposeTask;
+			}
+
+			newLock = new DmbLock(LockCleanupAction, dmbProvider, $"{callerFile}#{callerLine}: {reason}");
+			locks.Add(newLock);
+
+			descriptor = GetFullLockDescriptor(newLock!);
+			logger.LogTrace("Created .dmb Lock: {descriptor}", descriptor);
+
+			return newLock;
+		}
+	}
+}

--- a/src/Tgstation.Server.Host/Components/Deployment/DmbFactory.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/DmbFactory.cs
@@ -371,7 +371,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 			EngineVersion engineVersion;
 			if (!EngineVersion.TryParse(compileJob.EngineVersion, out var engineVersionNullable))
 			{
-				logger.LogWarning("Error loading compile job, bad engine version: {engineVersion}", compileJob.EngineVersion);
+				logger.LogError("Error loading compile job, bad engine version: {engineVersion}", compileJob.EngineVersion);
 				return (null, null); // omae wa mou shinderu
 			}
 			else

--- a/src/Tgstation.Server.Host/Components/Deployment/DmbLock.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/DmbLock.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Threading.Tasks;
+
+using Tgstation.Server.Api.Models;
+using Tgstation.Server.Host.Models;
+
+namespace Tgstation.Server.Host.Components.Deployment
+{
+	/// <summary>
+	/// Represents a lock on a given <see cref="IDmbProvider"/>.
+	/// </summary>
+	sealed class DmbLock : IDmbProvider
+	{
+		/// <inheritdoc />
+		public string DmbName => baseProvider.DmbName;
+
+		/// <inheritdoc />
+		public string Directory => baseProvider.Directory;
+
+		/// <inheritdoc />
+		public CompileJob CompileJob => baseProvider.CompileJob;
+
+		/// <inheritdoc />
+		public EngineVersion EngineVersion => baseProvider.EngineVersion;
+
+		/// <summary>
+		/// Unique ID of the lock.
+		/// </summary>
+		public Guid LockID { get; }
+
+		/// <summary>
+		/// The <see cref="DateTimeOffset"/> of when the lock was acquired.
+		/// </summary>
+		public DateTimeOffset LockTime { get; }
+
+		/// <summary>
+		/// A description of the <see cref="DmbLock"/>'s purpose.
+		/// </summary>
+		public string Descriptor { get; }
+
+		/// <summary>
+		/// If <see cref="KeepAlive"/> was called on the <see cref="DmbLock"/>.
+		/// </summary>
+		public bool KeptAlive { get; private set; }
+
+		/// <summary>
+		/// The <see cref="IDmbProvider"/> being wrapped.
+		/// </summary>
+		readonly IDmbProvider baseProvider;
+
+		/// <summary>
+		/// A <see cref="Func{TResult}"/> to use as the implementation of <see cref="DisposeAsync"/>.
+		/// </summary>
+		readonly Func<ValueTask> disposeAction;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="DmbLock"/> class.
+		/// </summary>
+		/// <param name="disposeAction">The value of <see cref="disposeAction"/>.</param>
+		/// <param name="baseProvider">The value of <see cref="baseProvider"/>.</param>
+		/// <param name="descriptor">The value of <see cref="Descriptor"/>.</param>
+		public DmbLock(Func<ValueTask> disposeAction, IDmbProvider baseProvider, string descriptor)
+		{
+			this.disposeAction = disposeAction ?? throw new ArgumentNullException(nameof(disposeAction));
+			this.baseProvider = baseProvider ?? throw new ArgumentNullException(nameof(baseProvider));
+			Descriptor = descriptor ?? throw new ArgumentNullException(nameof(descriptor));
+
+			LockID = Guid.NewGuid();
+			LockTime = DateTimeOffset.UtcNow;
+		}
+
+		/// <inheritdoc />
+		public ValueTask DisposeAsync() => disposeAction();
+
+		/// <inheritdoc />
+		public void KeepAlive()
+		{
+			KeptAlive = true;
+			baseProvider.KeepAlive();
+		}
+	}
+}

--- a/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
@@ -326,7 +326,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 						likelyPushedTestMergeCommit,
 						cancellationToken);
 
-				var activeCompileJob = compileJobConsumer.LatestCompileJob();
+				var activeCompileJob = await compileJobConsumer.LatestCompileJob();
 				try
 				{
 					await databaseContextFactory.UseContext(

--- a/src/Tgstation.Server.Host/Components/Deployment/IDmbFactory.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/IDmbFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -25,17 +26,22 @@ namespace Tgstation.Server.Host.Components.Deployment
 		/// <summary>
 		/// Gets the next <see cref="IDmbProvider"/>. <see cref="DmbAvailable"/> is a precondition.
 		/// </summary>
-		/// <param name="lockCount">The amount of locks to give the resulting <see cref="IDmbProvider"/>. It's <see cref="IDisposable.Dispose"/> must be called this many times to properly clean the job.</param>
+		/// <param name="reason">The reason the lock is being acquired.</param>
+		/// <param name="callerFile">The file path of the calling function.</param>
+		/// <param name="callerLine">The line number of the call invocation.</param>
 		/// <returns>A new <see cref="IDmbProvider"/>.</returns>
-		IDmbProvider LockNextDmb(int lockCount);
+		IDmbProvider LockNextDmb(string reason, [CallerFilePath] string? callerFile = null, [CallerLineNumber] int callerLine = default);
 
 		/// <summary>
 		/// Gets a <see cref="IDmbProvider"/> for a given <see cref="CompileJob"/>.
 		/// </summary>
 		/// <param name="compileJob">The <see cref="CompileJob"/> to make the <see cref="IDmbProvider"/> for.</param>
+		/// <param name="reason">The reason the compile job needed to be loaded.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
+		/// <param name="callerFile">The file path of the calling function.</param>
+		/// <param name="callerLine">The line number of the call invocation.</param>
 		/// <returns>A <see cref="ValueTask{TResult}"/> resulting in a new <see cref="IDmbProvider"/> representing the <see cref="CompileJob"/> on success, <see langword="null"/> on failure.</returns>
-		ValueTask<IDmbProvider?> FromCompileJob(CompileJob compileJob, CancellationToken cancellationToken);
+		ValueTask<IDmbProvider?> FromCompileJob(CompileJob compileJob, string reason, CancellationToken cancellationToken, [CallerFilePath] string? callerFile = null, [CallerLineNumber] int callerLine = default);
 
 		/// <summary>
 		/// Deletes all compile jobs that are inactive in the Game folder.

--- a/src/Tgstation.Server.Host/Components/Deployment/ILatestCompileJobProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/ILatestCompileJobProvider.cs
@@ -1,4 +1,6 @@
-﻿using Tgstation.Server.Host.Models;
+﻿using System.Threading.Tasks;
+
+using Tgstation.Server.Host.Models;
 
 namespace Tgstation.Server.Host.Components.Deployment
 {
@@ -10,7 +12,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 		/// <summary>
 		/// Gets the latest <see cref="CompileJob"/>.
 		/// </summary>
-		/// <returns>The latest <see cref="CompileJob"/> or <see langword="null"/> if none are available.</returns>
-		CompileJob? LatestCompileJob();
+		/// <returns>A <see cref="ValueTask{TResult}"/> resulting in the latest <see cref="CompileJob"/> or <see langword="null"/> if none are available.</returns>
+		ValueTask<CompileJob?> LatestCompileJob();
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Engine/EngineManager.cs
+++ b/src/Tgstation.Server.Host/Components/Engine/EngineManager.cs
@@ -466,7 +466,7 @@ namespace Tgstation.Server.Host.Components.Engine
 						logger.LogWarning("The required engine version ({version}) is not readily available! We will have to install it.", version);
 					}
 					else
-						logger.LogDebug("Requested engine version {version} not currently installed. Doing so now...", version);
+						logger.LogInformation("Requested engine version {version} not currently installed. Doing so now...", version);
 
 					if (progressReporter != null)
 						progressReporter.StageName = "Running event";

--- a/src/Tgstation.Server.Host/Components/Engine/OpenDreamInstallation.cs
+++ b/src/Tgstation.Server.Host/Components/Engine/OpenDreamInstallation.cs
@@ -137,6 +137,8 @@ namespace Tgstation.Server.Host.Components.Engine
 			logger.LogTrace("Attempting Robust.Server graceful exit (Timeout: {seconds}s)...", MaximumTerminationSeconds);
 			var timeout = asyncDelayer.Delay(TimeSpan.FromSeconds(MaximumTerminationSeconds), cancellationToken);
 			var lifetime = process.Lifetime;
+			if (lifetime.IsCompleted)
+				logger.LogTrace("Robust.Server already exited");
 
 			var stopwatch = Stopwatch.StartNew();
 			try

--- a/src/Tgstation.Server.Host/Components/Instance.cs
+++ b/src/Tgstation.Server.Host/Components/Instance.cs
@@ -258,7 +258,7 @@ namespace Tgstation.Server.Host.Components
 		}
 
 		/// <inheritdoc />
-		public CompileJob? LatestCompileJob() => dmbFactory.LatestCompileJob();
+		public ValueTask<CompileJob?> LatestCompileJob() => dmbFactory.LatestCompileJob();
 
 		/// <summary>
 		/// The <see cref="JobEntrypoint"/> for updating the repository.
@@ -576,7 +576,7 @@ namespace Tgstation.Server.Host.Components
 							continue;
 						}
 
-						if (deploySha == LatestCompileJob()?.RevisionInformation.CommitSha)
+						if (deploySha == (await LatestCompileJob())?.RevisionInformation.CommitSha)
 						{
 							logger.LogTrace("Aborting auto update, same revision as latest CompileJob");
 							continue;

--- a/src/Tgstation.Server.Host/Components/InstanceFactory.cs
+++ b/src/Tgstation.Server.Host/Components/InstanceFactory.cs
@@ -290,6 +290,7 @@ namespace Tgstation.Server.Host.Components
 					gameIoManager,
 					remoteDeploymentManagerFactory,
 					eventConsumer,
+					asyncDelayer,
 					loggerFactory.CreateLogger<DmbFactory>(),
 					metadata);
 				try

--- a/src/Tgstation.Server.Host/Components/InstanceWrapper.cs
+++ b/src/Tgstation.Server.Host/Components/InstanceWrapper.cs
@@ -58,6 +58,6 @@ namespace Tgstation.Server.Host.Components
 		public ValueTask ScheduleAutoUpdate(uint newInterval, string? newCron) => Instance.ScheduleAutoUpdate(newInterval, newCron);
 
 		/// <inheritdoc />
-		public CompileJob? LatestCompileJob() => Instance.LatestCompileJob();
+		public ValueTask<CompileJob?> LatestCompileJob() => Instance.LatestCompileJob();
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Session/SessionController.cs
+++ b/src/Tgstation.Server.Host/Components/Session/SessionController.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 using Newtonsoft.Json;
 
@@ -942,7 +943,9 @@ namespace Tgstation.Server.Host.Components.Session
 			using (await TopicSendSemaphore.Lock(cancellationToken))
 				byondResponse = await byondTopicSender.SendWithOptionalPriority(
 					asyncDelayer,
-					Logger,
+					LogTopicRequests
+						? Logger
+						: NullLogger.Instance,
 					queryString,
 					targetPort,
 					priority,

--- a/src/Tgstation.Server.Host/Components/Session/SessionPersistor.cs
+++ b/src/Tgstation.Server.Host/Components/Session/SessionPersistor.cs
@@ -208,7 +208,7 @@ namespace Tgstation.Server.Host.Components.Session
 				return null;
 			}
 
-			var dmb = await dmbFactory.FromCompileJob(result!.CompileJob!, cancellationToken);
+			var dmb = await dmbFactory.FromCompileJob(result!.CompileJob!, "Session Loading Main Deployment", cancellationToken);
 			if (dmb == null)
 			{
 				logger.LogError("Unable to reattach! Could not load .dmb!");
@@ -230,7 +230,7 @@ namespace Tgstation.Server.Host.Components.Session
 			if (result.InitialCompileJob != null)
 			{
 				logger.LogTrace("Loading initial compile job...");
-				initialDmb = await dmbFactory.FromCompileJob(result.InitialCompileJob, cancellationToken);
+				initialDmb = await dmbFactory.FromCompileJob(result.InitialCompileJob, "Session Loading Initial Deployment", cancellationToken);
 			}
 
 			logger.LogTrace("Retrieved ReattachInformation");

--- a/src/Tgstation.Server.Host/Components/Watchdog/AdvancedWatchdog.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/AdvancedWatchdog.cs
@@ -232,7 +232,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 		/// <inheritdoc />
 		protected sealed override async ValueTask HandleNewDmbAvailable(CancellationToken cancellationToken)
 		{
-			IDmbProvider compileJobProvider = DmbFactory.LockNextDmb(1);
+			IDmbProvider compileJobProvider = DmbFactory.LockNextDmb("AdvancedWatchdog next compile job preload");
 			bool canSeamlesslySwap = CanUseSwappableDmbProvider(compileJobProvider);
 			if (canSeamlesslySwap)
 				if (compileJobProvider.CompileJob.EngineVersion != ActiveCompileJob!.EngineVersion)

--- a/src/Tgstation.Server.Host/Components/Watchdog/BasicWatchdog.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/BasicWatchdog.cs
@@ -181,7 +181,8 @@ namespace Tgstation.Server.Host.Components.Watchdog
 					await HandleEventImpl(EventType.WorldPrime, Enumerable.Empty<string>(), false, cancellationToken);
 					break;
 				case MonitorActivationReason.ActiveServerStartup:
-					break; // unused in BasicWatchdog
+					Status = Api.Models.WatchdogStatus.Online;
+					break;
 				case MonitorActivationReason.HealthCheck:
 				default:
 					throw new InvalidOperationException($"Invalid activation reason: {reason}");
@@ -296,7 +297,12 @@ namespace Tgstation.Server.Host.Components.Watchdog
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="ValueTask{TResult}"/> resulting in the <see cref="MonitorAction"/> to take.</returns>
 		protected virtual ValueTask<MonitorAction> HandleNormalReboot(CancellationToken cancellationToken)
-			=> ValueTask.FromResult(MonitorAction.Continue);
+		{
+			if (Server!.CompileJob.DMApiVersion != null)
+				Status = Api.Models.WatchdogStatus.Restoring;
+
+			return ValueTask.FromResult(MonitorAction.Continue);
+		}
 
 		/// <summary>
 		/// Handler for <see cref="MonitorActivationReason.NewDmbAvailable"/>.

--- a/src/Tgstation.Server.Host/Components/Watchdog/BasicWatchdog.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/BasicWatchdog.cs
@@ -214,7 +214,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 		{
 			// don't need a new dmb if reattaching
 			var reattachInProgress = reattachInfo != null;
-			var dmbToUse = reattachInProgress ? null : DmbFactory.LockNextDmb(1);
+			var dmbToUse = reattachInProgress ? null : DmbFactory.LockNextDmb("Watchdog initialization");
 
 			// if this try catches something, both servers are killed
 			try

--- a/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
@@ -42,10 +42,11 @@ namespace Tgstation.Server.Host.Components.Watchdog
 		public WatchdogStatus Status
 		{
 			get => status;
-			set
+			protected set
 			{
+				var oldStatus = status;
 				status = value;
-				Logger.LogTrace("Status set to {status}", status);
+				Logger.LogTrace("Status set from {oldStatus} to {status}", oldStatus, status);
 			}
 		}
 

--- a/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
@@ -815,21 +815,18 @@ namespace Tgstation.Server.Host.Components.Watchdog
 		/// </summary>
 		/// <param name="currentCompileJob">The session's current <see cref="CompileJob"/>.</param>
 		/// <returns>A <see cref="Task"/> that completes if and when a newer <see cref="CompileJob"/> is available.</returns>
-		Task InitialCheckDmbUpdated(CompileJob currentCompileJob)
+		async Task InitialCheckDmbUpdated(CompileJob currentCompileJob)
 		{
 			var factoryTask = DmbFactory.OnNewerDmb;
 
-			var latestCompileJob = DmbFactory.LatestCompileJob();
-			if (latestCompileJob == null)
-				return factoryTask;
-
-			if (latestCompileJob.Id != currentCompileJob.Id)
+			var latestCompileJob = await DmbFactory.LatestCompileJob();
+			if (latestCompileJob != null && latestCompileJob.Id != currentCompileJob.Id)
 			{
 				Logger.LogDebug("Found new CompileJob without waiting");
-				return Task.CompletedTask;
+				return;
 			}
 
-			return factoryTask;
+			await factoryTask;
 		}
 
 		/// <summary>

--- a/src/Tgstation.Server.Host/Components/Watchdog/WindowsWatchdog.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/WindowsWatchdog.cs
@@ -87,7 +87,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 				return;
 			}
 
-			Server.ReattachInformation.InitialDmb = await DmbFactory.FromCompileJob(Server.CompileJob, cancellationToken);
+			Server.ReattachInformation.InitialDmb = await DmbFactory.FromCompileJob(Server.CompileJob, "WindowsWatchdog Initial Deployment", cancellationToken);
 		}
 
 		/// <inheritdoc />

--- a/src/Tgstation.Server.Host/Controllers/DreamDaemonController.cs
+++ b/src/Tgstation.Server.Host/Controllers/DreamDaemonController.cs
@@ -386,7 +386,7 @@ namespace Tgstation.Server.Host.Controllers
 
 				if (revision)
 				{
-					var latestCompileJob = instance.LatestCompileJob();
+					var latestCompileJob = await instance.LatestCompileJob();
 					result.ActiveCompileJob = ((instance.Watchdog.Status != WatchdogStatus.Offline
 						? dd.ActiveCompileJob
 						: latestCompileJob) ?? latestCompileJob)

--- a/src/Tgstation.Server.Host/Extensions/TopicClientExtensions.cs
+++ b/src/Tgstation.Server.Host/Extensions/TopicClientExtensions.cs
@@ -17,6 +17,11 @@ namespace Tgstation.Server.Host.Extensions
 	static class TopicClientExtensions
 	{
 		/// <summary>
+		/// Counter for topic request logging.
+		/// </summary>
+		static ulong topicRequestId;
+
+		/// <summary>
 		/// Send a <paramref name="queryString"/> with optional repeated priority.
 		/// </summary>
 		/// <param name="topicClient">The <see cref="ITopicClient"/> to send with.</param>
@@ -45,13 +50,14 @@ namespace Tgstation.Server.Host.Extensions
 				{
 					firstSend = false;
 
-					logger.LogTrace("Begin topic request");
+					var localRequestId = Interlocked.Increment(ref topicRequestId);
+					logger.LogTrace("Begin topic request #{requestId}: {query}", localRequestId, queryString);
 					var byondResponse = await topicClient.SendTopic(
 						endpoint,
 						queryString,
 						cancellationToken);
 
-					logger.LogTrace("End topic request");
+					logger.LogTrace("End topic request #{requestId}", localRequestId);
 					return byondResponse;
 				}
 				catch (Exception ex) when (ex is not OperationCanceledException)

--- a/tests/DMAPI/LongRunning/Test.dm
+++ b/tests/DMAPI/LongRunning/Test.dm
@@ -3,7 +3,7 @@
 	loop_checks = FALSE
 
 /world/proc/RunTest()
-	log << "Initial value of sleep_offline: [sleep_offline]"
+	log << "Initial value of sleep_offline: [sleep_offline], setting to FALSE"
 	sleep_offline = FALSE
 
 	if(params["slow_start"])
@@ -215,6 +215,7 @@ var/run_bridge_test
 var/kajigger_test = FALSE
 
 /world/Reboot(reason)
+	log << "Reboot Start"
 	TgsChatBroadcast("World Rebooting")
 
 	if(kajigger_test && !fexists("kajigger.txt"))
@@ -222,6 +223,7 @@ var/kajigger_test = FALSE
 
 	TgsReboot()
 
+	log << "Calling base reboot"
 	..()
 
 var/received_health_check = FALSE

--- a/tests/Tgstation.Server.Tests/Live/Instance/EngineTest.cs
+++ b/tests/Tgstation.Server.Tests/Live/Instance/EngineTest.cs
@@ -93,7 +93,7 @@ namespace Tgstation.Server.Tests.Live.Instance
 				}
 				else
 				{
-					var masterBranch = await TestingGitHubService.RealTestClient.Repository.Branch.Get("OpenDreamProject", "OpenDream", "master");
+					var masterBranch = await TestingGitHubService.RealClient.Repository.Branch.Get("OpenDreamProject", "OpenDream", "master");
 
 					engineVersion = new EngineVersion
 					{

--- a/tests/Tgstation.Server.Tests/Live/Instance/InstanceTest.cs
+++ b/tests/Tgstation.Server.Tests/Live/Instance/InstanceTest.cs
@@ -74,7 +74,12 @@ namespace Tgstation.Server.Tests.Live.Instance
 				ddPort,
 				usingBasicWatchdog);
 			await wdt.Run(cancellationToken);
-			await wdt.ExpectGameDirectoryCount(2, cancellationToken);
+
+			await wdt.ExpectGameDirectoryCount(
+				usingBasicWatchdog || new PlatformIdentifier().IsWindows
+					? 2 // old + new deployment
+					: 3, // + new mirrored deployment waiting to take over Live
+				cancellationToken);
 		}
 
 		public static async ValueTask<IEngineInstallationData> DownloadEngineVersion(
@@ -285,7 +290,9 @@ namespace Tgstation.Server.Tests.Live.Instance
 
 			await instanceClient.DreamDaemon.Shutdown(cancellationToken);
 
-			await wdt.ExpectGameDirectoryCount(1, cancellationToken);
+			await wdt.ExpectGameDirectoryCount(
+				1, // current deployment
+				cancellationToken);
 
 			await instanceManagerClient.Update(new InstanceUpdateRequest
 			{

--- a/tests/Tgstation.Server.Tests/Live/Instance/InstanceTest.cs
+++ b/tests/Tgstation.Server.Tests/Live/Instance/InstanceTest.cs
@@ -51,7 +51,7 @@ namespace Tgstation.Server.Tests.Live.Instance
 			await using var chatTest = new ChatTest(instanceClient.ChatBots, instanceManagerClient, instanceClient.Jobs, instanceClient.Metadata);
 			var configTest = new ConfigurationTest(instanceClient.Configuration, instanceClient.Metadata);
 			await using var repoTest = new RepositoryTest(instanceClient.Repository, instanceClient.Jobs);
-			await using var dmTest = new DeploymentTest(instanceClient, instanceClient.Jobs, dmPort, ddPort, lowPrioDeployment, testVersion.Engine.Value);
+			await using var dmTest = new DeploymentTest(instanceClient, instanceClient.Jobs, dmPort, ddPort, lowPrioDeployment, testVersion);
 
 			var byondTask = engineTest.Run(cancellationToken, out var firstInstall);
 			var chatTask = chatTest.RunPreWatchdog(cancellationToken);

--- a/tests/Tgstation.Server.Tests/Live/Instance/InstanceTest.cs
+++ b/tests/Tgstation.Server.Tests/Live/Instance/InstanceTest.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -24,7 +22,6 @@ using Tgstation.Server.Host.Components.Events;
 using Tgstation.Server.Host.Components.Repository;
 using Tgstation.Server.Host.Configuration;
 using Tgstation.Server.Host.IO;
-using Tgstation.Server.Host.Jobs;
 using Tgstation.Server.Host.System;
 using Tgstation.Server.Host.Utils;
 
@@ -77,6 +74,7 @@ namespace Tgstation.Server.Tests.Live.Instance
 				ddPort,
 				usingBasicWatchdog);
 			await wdt.Run(cancellationToken);
+			await wdt.ExpectGameDirectoryCount(2, cancellationToken);
 		}
 
 		public static async ValueTask<IEngineInstallationData> DownloadEngineVersion(
@@ -284,6 +282,10 @@ namespace Tgstation.Server.Tests.Live.Instance
 
 			await using var wdt = new WatchdogTest(compatVersion, instanceClient, instanceManager, serverPort, highPrioDD, ddPort, usingBasicWatchdog);
 			await wdt.Run(cancellationToken);
+
+			await instanceClient.DreamDaemon.Shutdown(cancellationToken);
+
+			await wdt.ExpectGameDirectoryCount(1, cancellationToken);
 
 			await instanceManagerClient.Update(new InstanceUpdateRequest
 			{

--- a/tests/Tgstation.Server.Tests/Live/Instance/JobsRequiredTest.cs
+++ b/tests/Tgstation.Server.Tests/Live/Instance/JobsRequiredTest.cs
@@ -162,7 +162,8 @@ namespace Tgstation.Server.Tests.Live.Instance
 
 			await JobsClient.Cancel(job, cancellationToken);
 
-			timeout -= (int)Math.Ceiling((DateTimeOffset.UtcNow - start).TotalSeconds);
+			timeout -= Math.Max(0, (int)Math.Ceiling((DateTimeOffset.UtcNow - start).TotalSeconds));
+			timeout = Math.Max(0, timeout);
 			return await WaitForJob(job, timeout, false, null, cancellationToken);
 		}
 	}

--- a/tests/Tgstation.Server.Tests/Live/Instance/WatchdogTest.cs
+++ b/tests/Tgstation.Server.Tests/Live/Instance/WatchdogTest.cs
@@ -1069,6 +1069,15 @@ namespace Tgstation.Server.Tests.Live.Instance
 		// - Injects a custom bridge handler into the bridge registrar and makes the test hack into the DMAPI and change its access_identifier
 		async Task WhiteBoxChatCommandTest(CancellationToken cancellationToken)
 		{
+			var ddInfo = await instanceClient.DreamDaemon.Read(cancellationToken);
+			for (int i = 0; ddInfo.Status != WatchdogStatus.Online && i < 15; ++i)
+			{
+				await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
+				ddInfo = await instanceClient.DreamDaemon.Read(cancellationToken);
+			}
+
+			Assert.AreEqual(WatchdogStatus.Online, ddInfo.Status);
+
 			MessageContent embedsResponse, overloadResponse, overloadResponse2, embedsResponse2;
 			var startTime = DateTimeOffset.UtcNow - TimeSpan.FromSeconds(5);
 			using (var instanceReference = instanceManager.GetInstanceReference(instanceClient.Metadata))
@@ -1115,7 +1124,7 @@ namespace Tgstation.Server.Tests.Live.Instance
 
 			var endTime = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(5);
 
-			var ddInfo = await instanceClient.DreamDaemon.Read(cancellationToken);
+			ddInfo = await instanceClient.DreamDaemon.Read(cancellationToken);
 			await CheckDMApiFail(ddInfo.ActiveCompileJob, cancellationToken);
 
 			CheckEmbedsTest(embedsResponse, startTime, endTime);

--- a/tests/Tgstation.Server.Tests/Live/Instance/WatchdogTest.cs
+++ b/tests/Tgstation.Server.Tests/Live/Instance/WatchdogTest.cs
@@ -633,15 +633,16 @@ namespace Tgstation.Server.Tests.Live.Instance
 
 		public async ValueTask ExpectGameDirectoryCount(int expected, CancellationToken cancellationToken)
 		{
+			string[] lastDirectories;
 			int CountNonLiveDirs()
 			{
-				var directories = Directory.GetDirectories(Path.Combine(instanceClient.Metadata.Path, "Game"));
-				return directories.Where(directory => Path.GetFileName(directory) != "Live").Count();
+				lastDirectories = Directory.GetDirectories(Path.Combine(instanceClient.Metadata.Path, "Game"));
+				return lastDirectories.Where(directory => Path.GetFileName(directory) != "Live").Count();
 			}
 
 			int nonLiveDirs = 0;
 			// cleanup task is async
-			for(var i = 0; i < 15; ++i)
+			for(var i = 0; i < 20; ++i)
 			{
 				nonLiveDirs = CountNonLiveDirs();
 				if (expected == nonLiveDirs)
@@ -651,7 +652,7 @@ namespace Tgstation.Server.Tests.Live.Instance
 			}
 
 			nonLiveDirs = CountNonLiveDirs();
-			Assert.AreEqual(expected, nonLiveDirs);
+			Assert.AreEqual(expected, nonLiveDirs, $"Directories present: {String.Join(", ", lastDirectories.Select(Path.GetFileName))}");
 		}
 
 		async Task RunBasicTest(CancellationToken cancellationToken)

--- a/tests/Tgstation.Server.Tests/Live/TestLiveServer.cs
+++ b/tests/Tgstation.Server.Tests/Live/TestLiveServer.cs
@@ -1724,7 +1724,7 @@ namespace Tgstation.Server.Tests.Live
 					Assert.AreEqual(dd.StagedCompileJob.Job.Id, compileJob.Id);
 
 					expectedCompileJobId = compileJob.Id.Value;
-					dd = await wdt.TellWorldToReboot(server.UsingBasicWatchdog, cancellationToken);
+					dd = await wdt.TellWorldToReboot(true, cancellationToken);
 
 					Assert.AreEqual(dd.ActiveCompileJob.Job.Id, expectedCompileJobId);
 					Assert.AreEqual(WatchdogStatus.Online, dd.Status.Value);

--- a/tests/Tgstation.Server.Tests/Live/TestingGitHubService.cs
+++ b/tests/Tgstation.Server.Tests/Live/TestingGitHubService.cs
@@ -28,7 +28,7 @@ namespace Tgstation.Server.Tests.Live
 		readonly ICryptographySuite cryptographySuite;
 		readonly ILogger<TestingGitHubService> logger;
 
-		public static readonly IGitHubClient RealTestClient;
+		public static readonly IGitHubClient RealClient;
 
 		static TestingGitHubService()
 		{
@@ -39,7 +39,7 @@ namespace Tgstation.Server.Tests.Live
 			});
 
 			var gitHubClientFactory = new GitHubClientFactory(new AssemblyInformationProvider(), Mock.Of<ILogger<GitHubClientFactory>>(), mockOptions.Object);
-			RealTestClient = gitHubClientFactory.CreateClient();
+			RealClient = gitHubClientFactory.CreateClient();
 		}
 
 		public static async Task InitializeAndInject(CancellationToken cancellationToken)
@@ -47,7 +47,7 @@ namespace Tgstation.Server.Tests.Live
 			Release targetRelease;
 			do
 			{
-				var releases = await RealTestClient
+				var releases = await RealClient
 					.Repository
 					.Release
 					.GetAll("tgstation", "tgstation-server")
@@ -62,12 +62,12 @@ namespace Tgstation.Server.Tests.Live
 				{ TestLiveServer.TestUpdateVersion, targetRelease }
 			};
 
-			var testCommitTask = RealTestClient
+			var testCommitTask = RealClient
 				.Repository
 				.Commit
 				.Get("Cyberboss", "common_core", "4b4926dfaf6295f19f8ae7abf03cb357dbb05b29")
 				.WaitAsync(cancellationToken);
-			testPr = await RealTestClient
+			testPr = await RealClient
 				.PullRequest
 				.Get("Cyberboss", "common_core", 2)
 				.WaitAsync(cancellationToken);


### PR DESCRIPTION
🆑
Potentially fixed issue with deployment objects leaking and causing disk pollution. Please report if this issue reoccurs.
Added extensive auditing on how deployment objects are used internally in order to track down the cause of issue should it arise again.
When DreamDaemon reboots while using the Advanced Watchdog the status will now be set to restoring.
/🆑

Tentatively closes #1779 