### PR TITLE
Adds OpenDream topic port as a DreamDaemon option

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -3,12 +3,12 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="WebpanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>6.6.1</TgsCoreVersion>
+    <TgsCoreVersion>6.7.0</TgsCoreVersion>
     <TgsConfigVersion>5.1.0</TgsConfigVersion>
-    <TgsApiVersion>10.4.0</TgsApiVersion>
+    <TgsApiVersion>10.5.0</TgsApiVersion>
     <TgsCommonLibraryVersion>7.0.0</TgsCommonLibraryVersion>
-    <TgsApiLibraryVersion>13.4.0</TgsApiLibraryVersion>
-    <TgsClientVersion>15.4.0</TgsClientVersion>
+    <TgsApiLibraryVersion>13.5.0</TgsApiLibraryVersion>
+    <TgsClientVersion>15.5.0</TgsClientVersion>
     <TgsDmapiVersion>7.1.2</TgsDmapiVersion>
     <TgsInteropVersion>5.9.0</TgsInteropVersion>
     <TgsHostWatchdogVersion>1.4.1</TgsHostWatchdogVersion>

--- a/build/package/winget/.config/dotnet-tools.json
+++ b/build/package/winget/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "wix": {
-      "version": "4.0.4",
+      "version": "5.0.1",
       "commands": [
         "wix"
       ]

--- a/build/package/winget/Tgstation.Server.Host.Service.Wix.Bundle/Tgstation.Server.Host.Service.Wix.Bundle.wixproj
+++ b/build/package/winget/Tgstation.Server.Host.Service.Wix.Bundle/Tgstation.Server.Host.Service.Wix.Bundle.wixproj
@@ -1,4 +1,4 @@
-<Project Sdk="WixToolset.Sdk/4.0.4" xmlns:bal="http://schemas.microsoft.com/wix/BalExtension">
+<Project Sdk="WixToolset.Sdk/5.0.1" xmlns:bal="http://schemas.microsoft.com/wix/BalExtension">
   <Import Project="../../../Common.props" />
   <PropertyGroup>
     <DefineConstants>ProductVersion=$(TgsCoreVersion);NetMajorVersion=$(TgsNetMajorVersion);DotnetRedistUrl=$(TgsDotnetRedistUrl);MariaDBRedistUrl=https://github.com/tgstation/tgstation-server/releases/download/tgstation-server-v$(TgsCoreVersion)/mariadb-$(TgsMariaDBRedistVersion)-winx64.msi</DefineConstants>
@@ -24,8 +24,8 @@
     <Content Include="Theme.xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="WixToolset.Bal.wixext" Version="4.0.4" />
-    <PackageReference Include="WixToolset.Netfx.wixext" Version="4.0.4" />
+    <PackageReference Include="WixToolset.Bal.wixext" Version="5.0.1" />
+    <PackageReference Include="WixToolset.Netfx.wixext" Version="5.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tgstation.Server.Host.Service.Wix\Tgstation.Server.Host.Service.Wix.wixproj" />

--- a/build/package/winget/Tgstation.Server.Host.Service.Wix/Tgstation.Server.Host.Service.Wix.wixproj
+++ b/build/package/winget/Tgstation.Server.Host.Service.Wix/Tgstation.Server.Host.Service.Wix.wixproj
@@ -1,4 +1,4 @@
-<Project Sdk="WixToolset.Sdk/4.0.4">
+<Project Sdk="WixToolset.Sdk/5.0.1">
   <Import Project="../../../Common.props" />
   <PropertyGroup>
     <DefineConstants>ProductVersion=$(TgsCoreVersion)</DefineConstants>
@@ -25,8 +25,8 @@
     </HarvestDirectory>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="WixToolset.Heat" Version="4.0.4" />
-    <PackageReference Include="WixToolset.Util.wixext" Version="4.0.4" />
+    <PackageReference Include="WixToolset.Heat" Version="5.0.1" />
+    <PackageReference Include="WixToolset.Util.wixext" Version="5.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tgstation.Server.Host.Service.Wix.Extensions\Tgstation.Server.Host.Service.Wix.Extensions.csproj" />

--- a/src/Tgstation.Server.Api/Models/Internal/DreamDaemonLaunchParameters.cs
+++ b/src/Tgstation.Server.Api/Models/Internal/DreamDaemonLaunchParameters.cs
@@ -47,6 +47,13 @@ namespace Tgstation.Server.Api.Models.Internal
 		public ushort? Port { get; set; }
 
 		/// <summary>
+		/// The port used by <see cref="EngineType.OpenDream"/> for its topic port.
+		/// </summary>
+		[Required]
+		[ResponseOptions]
+		public ushort? OpenDreamTopicPort { get; set; }
+
+		/// <summary>
 		/// The DreamDaemon startup timeout in seconds.
 		/// </summary>
 		[Required]
@@ -109,8 +116,9 @@ namespace Tgstation.Server.Api.Models.Internal
 		/// Check if we match a given set of <paramref name="otherParameters"/>. <see cref="StartupTimeout"/> is excluded.
 		/// </summary>
 		/// <param name="otherParameters">The <see cref="DreamDaemonLaunchParameters"/> to compare against.</param>
+		/// <param name="engineType">The <see cref="EngineType"/> currently running.</param>
 		/// <returns><see langword="true"/> if they match, <see langword="false"/> otherwise.</returns>
-		public bool CanApplyWithoutReboot(DreamDaemonLaunchParameters otherParameters)
+		public bool CanApplyWithoutReboot(DreamDaemonLaunchParameters otherParameters, EngineType engineType)
 		{
 			if (otherParameters == null)
 				throw new ArgumentNullException(nameof(otherParameters));
@@ -119,6 +127,7 @@ namespace Tgstation.Server.Api.Models.Internal
 				&& SecurityLevel == otherParameters.SecurityLevel
 				&& Visibility == otherParameters.Visibility
 				&& Port == otherParameters.Port
+				&& (OpenDreamTopicPort == otherParameters.OpenDreamTopicPort || engineType != EngineType.OpenDream)
 				&& TopicRequestTimeout == otherParameters.TopicRequestTimeout
 				&& AdditionalParameters == otherParameters.AdditionalParameters
 				&& StartProfiler == otherParameters.StartProfiler

--- a/src/Tgstation.Server.Api/Models/Response/DreamDaemonResponse.cs
+++ b/src/Tgstation.Server.Api/Models/Response/DreamDaemonResponse.cs
@@ -49,6 +49,12 @@ namespace Tgstation.Server.Api.Models.Response
 		public ushort? CurrentPort { get; set; }
 
 		/// <summary>
+		/// The <see cref="EngineType.OpenDream"/> topic port the running <see cref="DreamDaemonResponse"/> instance is set to.
+		/// </summary>
+		[ResponseOptions]
+		public ushort? CurrentTopicPort { get; set; }
+
+		/// <summary>
 		/// The webclient status the running <see cref="DreamDaemonResponse"/> instance is set to.
 		/// </summary>
 		[ResponseOptions]

--- a/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
@@ -785,6 +785,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 			{
 				AllowWebClient = false,
 				Port = portToUse,
+				OpenDreamTopicPort = 0,
 				SecurityLevel = securityLevel,
 				Visibility = DreamDaemonVisibility.Invisible,
 				StartupTimeout = timeout,

--- a/src/Tgstation.Server.Host/Components/Engine/OpenDreamInstallation.cs
+++ b/src/Tgstation.Server.Host/Components/Engine/OpenDreamInstallation.cs
@@ -107,7 +107,7 @@ namespace Tgstation.Server.Host.Components.Engine
 
 			var parametersString = EncodeParameters(parameters, launchParameters);
 
-			var arguments = $"--cvar {(logFilePath != null ? $"log.path=\"{InstallationIOManager.GetDirectoryName(logFilePath)}\" --cvar log.format=\"{InstallationIOManager.GetFileName(logFilePath)}\"" : "log.enabled=false")} --cvar watchdog.token={accessIdentifier} --cvar log.runtimelog=false --cvar net.port={launchParameters.Port!.Value} --cvar opendream.topic_port=0 --cvar opendream.world_params=\"{parametersString}\" --cvar opendream.json_path=\"./{dmbProvider.DmbName}\"";
+			var arguments = $"--cvar {(logFilePath != null ? $"log.path=\"{InstallationIOManager.GetDirectoryName(logFilePath)}\" --cvar log.format=\"{InstallationIOManager.GetFileName(logFilePath)}\"" : "log.enabled=false")} --cvar watchdog.token={accessIdentifier} --cvar log.runtimelog=false --cvar net.port={launchParameters.Port!.Value} --cvar opendream.topic_port={launchParameters.OpenDreamTopicPort!.Value} --cvar opendream.world_params=\"{parametersString}\" --cvar opendream.json_path=\"./{dmbProvider.DmbName}\"";
 			return arguments;
 		}
 

--- a/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
@@ -272,8 +272,13 @@ namespace Tgstation.Server.Host.Components.Watchdog
 		{
 			using (await SemaphoreSlimContext.Lock(synchronizationSemaphore, cancellationToken))
 			{
-				bool match = launchParameters.CanApplyWithoutReboot(ActiveLaunchParameters);
+				var currentLaunchParameters = ActiveLaunchParameters;
 				ActiveLaunchParameters = launchParameters;
+				var currentEngine = GetActiveController()?.EngineVersion.Engine;
+				if (!currentEngine.HasValue)
+					return false;
+
+				bool match = launchParameters.CanApplyWithoutReboot(currentLaunchParameters, currentEngine.Value);
 				if (match || Status == WatchdogStatus.Offline || Status == WatchdogStatus.DelayedRestart)
 					return false;
 

--- a/src/Tgstation.Server.Host/Controllers/DreamDaemonController.cs
+++ b/src/Tgstation.Server.Host/Controllers/DreamDaemonController.cs
@@ -211,6 +211,7 @@ namespace Tgstation.Server.Host.Controllers
 			if (CheckModified(x => x.AllowWebClient, DreamDaemonRights.SetWebClient)
 				|| CheckModified(x => x.AutoStart, DreamDaemonRights.SetAutoStart)
 				|| CheckModified(x => x.Port, DreamDaemonRights.SetPort)
+				|| CheckModified(x => x.OpenDreamTopicPort, DreamDaemonRights.SetPort)
 				|| CheckModified(x => x.SecurityLevel, DreamDaemonRights.SetSecurity)
 				|| CheckModified(x => x.Visibility, DreamDaemonRights.SetVisibility)
 				|| (model.SoftRestart.HasValue && !ddRights.HasFlag(DreamDaemonRights.SoftRestart))
@@ -344,10 +345,12 @@ namespace Tgstation.Server.Host.Controllers
 					var rstate = dd.RebootState;
 					result.AutoStart = settings.AutoStart!.Value;
 					result.CurrentPort = llp?.Port!.Value;
+					result.CurrentTopicPort = llp?.OpenDreamTopicPort;
 					result.CurrentSecurity = llp?.SecurityLevel!.Value;
 					result.CurrentVisibility = llp?.Visibility!.Value;
 					result.CurrentAllowWebclient = llp?.AllowWebClient!.Value;
 					result.Port = settings.Port!.Value;
+					result.OpenDreamTopicPort = settings.OpenDreamTopicPort;
 					result.AllowWebClient = settings.AllowWebClient!.Value;
 
 					var firstIteration = true;

--- a/src/Tgstation.Server.Host/Controllers/InstanceController.cs
+++ b/src/Tgstation.Server.Host/Controllers/InstanceController.cs
@@ -742,6 +742,7 @@ namespace Tgstation.Server.Host.Controllers
 					AllowWebClient = false,
 					AutoStart = false,
 					Port = ddPort,
+					OpenDreamTopicPort = 0,
 					SecurityLevel = DreamDaemonSecurity.Safe,
 					Visibility = DreamDaemonVisibility.Public,
 					StartupTimeout = 60,

--- a/src/Tgstation.Server.Host/Database/DatabaseContext.cs
+++ b/src/Tgstation.Server.Host/Database/DatabaseContext.cs
@@ -375,22 +375,22 @@ namespace Tgstation.Server.Host.Database
 		/// <summary>
 		/// Used by unit tests to remind us to setup the correct MSSQL migration downgrades.
 		/// </summary>
-		internal static readonly Type MSLatestMigration = typeof(MSAddCronAutoUpdates);
+		internal static readonly Type MSLatestMigration = typeof(MSAddOpenDreamTopicPort);
 
 		/// <summary>
 		/// Used by unit tests to remind us to setup the correct MYSQL migration downgrades.
 		/// </summary>
-		internal static readonly Type MYLatestMigration = typeof(MYAddCronAutoUpdates);
+		internal static readonly Type MYLatestMigration = typeof(MYAddOpenDreamTopicPort);
 
 		/// <summary>
 		/// Used by unit tests to remind us to setup the correct PostgresSQL migration downgrades.
 		/// </summary>
-		internal static readonly Type PGLatestMigration = typeof(PGAddCronAutoUpdates);
+		internal static readonly Type PGLatestMigration = typeof(PGAddOpenDreamTopicPort);
 
 		/// <summary>
 		/// Used by unit tests to remind us to setup the correct SQLite migration downgrades.
 		/// </summary>
-		internal static readonly Type SLLatestMigration = typeof(SLAddCronAutoUpdates);
+		internal static readonly Type SLLatestMigration = typeof(SLAddOpenDreamTopicPort);
 
 		/// <inheritdoc />
 #pragma warning disable CA1502 // Cyclomatic complexity
@@ -418,6 +418,16 @@ namespace Tgstation.Server.Host.Database
 			string? targetMigration = null;
 
 			string BadDatabaseType() => throw new ArgumentException($"Invalid DatabaseType: {currentDatabaseType}", nameof(currentDatabaseType));
+
+			if (targetVersion < new Version(6, 7, 0))
+				targetMigration = currentDatabaseType switch
+				{
+					DatabaseType.MySql => nameof(MSAddCronAutoUpdates),
+					DatabaseType.PostgresSql => nameof(PGAddCronAutoUpdates),
+					DatabaseType.SqlServer => nameof(MSAddCronAutoUpdates),
+					DatabaseType.Sqlite => nameof(SLAddCronAutoUpdates),
+					_ => BadDatabaseType(),
+				};
 
 			if (targetVersion < new Version(6, 6, 0))
 				targetMigration = currentDatabaseType switch

--- a/src/Tgstation.Server.Host/Database/Migrations/20240719010153_MSAddOpenDreamTopicPort.Designer.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20240719010153_MSAddOpenDreamTopicPort.Designer.cs
@@ -3,20 +3,23 @@ using System;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Tgstation.Server.Host.Database.Migrations
 {
-	[DbContext(typeof(PostgresSqlDatabaseContext))]
-	partial class PostgresSqlDatabaseContextModelSnapshot : ModelSnapshot
+	[DbContext(typeof(SqlServerDatabaseContext))]
+	[Migration("20240719010153_MSAddOpenDreamTopicPort")]
+	partial class MSAddOpenDreamTopicPort
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		/// <inheritdoc />
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder
 				.HasAnnotation("ProductVersion", "8.0.7")
-				.HasAnnotation("Relational:MaxIdentifierLength", 63);
+				.HasAnnotation("Relational:MaxIdentifierLength", 128);
 
-			NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
+			SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.ChatBot", b =>
 			{
@@ -24,18 +27,18 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<int>("ChannelLimit")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<string>("ConnectionString")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<bool?>("Enabled")
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
@@ -43,10 +46,10 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("nvarchar(100)");
 
 				b.Property<int>("Provider")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<long>("ReconnectionInterval")
 					.HasColumnType("bigint");
@@ -65,45 +68,47 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<long>("ChatSettingsId")
 					.HasColumnType("bigint");
 
 				b.Property<decimal?>("DiscordChannelId")
-					.HasColumnType("numeric(20,0)");
+					.HasColumnType("decimal(20,0)");
 
 				b.Property<string>("IrcChannel")
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("nvarchar(100)");
 
 				b.Property<bool?>("IsAdminChannel")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<bool?>("IsSystemChannel")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<bool?>("IsUpdatesChannel")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<bool?>("IsWatchdogChannel")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<string>("Tag")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("nvarchar(max)");
 
 				b.HasKey("Id");
 
 				b.HasIndex("ChatSettingsId", "DiscordChannelId")
-					.IsUnique();
+					.IsUnique()
+					.HasFilter("[DiscordChannelId] IS NOT NULL");
 
 				b.HasIndex("ChatSettingsId", "IrcChannel")
-					.IsUnique();
+					.IsUnique()
+					.HasFilter("[IrcChannel] IS NOT NULL");
 
 				b.ToTable("ChatChannels");
 			});
@@ -114,28 +119,28 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<int?>("DMApiMajorVersion")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int?>("DMApiMinorVersion")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int?>("DMApiPatchVersion")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<Guid?>("DirectoryName")
 					.IsRequired()
-					.HasColumnType("uuid");
+					.HasColumnType("uniqueidentifier");
 
 				b.Property<string>("DmeName")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<string>("EngineVersion")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<long?>("GitHubDeploymentId")
 					.HasColumnType("bigint");
@@ -147,14 +152,14 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasColumnType("bigint");
 
 				b.Property<int?>("MinimumSecurityLevel")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<string>("Output")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<string>("RepositoryOrigin")
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<long>("RevisionInformationId")
 					.HasColumnType("bigint");
@@ -177,24 +182,24 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<string>("AdditionalParameters")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<bool?>("AllowWebClient")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<bool?>("AutoStart")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<bool?>("DumpOnHealthCheckRestart")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<long>("HealthCheckSeconds")
 					.HasColumnType("bigint");
@@ -204,27 +209,27 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				b.Property<bool?>("LogOutput")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<long>("MapThreads")
 					.HasColumnType("bigint");
 
 				b.Property<bool?>("Minidumps")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<int>("OpenDreamTopicPort")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int>("Port")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int>("SecurityLevel")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<bool?>("StartProfiler")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<long>("StartupTimeout")
 					.HasColumnType("bigint");
@@ -233,7 +238,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasColumnType("bigint");
 
 				b.Property<int>("Visibility")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.HasKey("Id");
 
@@ -249,32 +254,32 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<int>("ApiValidationPort")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int>("ApiValidationSecurityLevel")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<string>("CompilerAdditionalArguments")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
 				b.Property<string>("ProjectName")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<bool?>("RequireDMApiValidation")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<TimeSpan?>("Timeout")
 					.IsRequired()
-					.HasColumnType("interval");
+					.HasColumnType("time");
 
 				b.HasKey("Id");
 
@@ -290,42 +295,43 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<string>("AutoUpdateCron")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<long>("AutoUpdateInterval")
 					.HasColumnType("bigint");
 
 				b.Property<int>("ChatBotLimit")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int>("ConfigurationType")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("nvarchar(100)");
 
 				b.Property<bool?>("Online")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<string>("Path")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(450)");
 
 				b.Property<string>("SwarmIdentifer")
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(450)");
 
 				b.HasKey("Id");
 
 				b.HasIndex("Path", "SwarmIdentifer")
-					.IsUnique();
+					.IsUnique()
+					.HasFilter("[SwarmIdentifer] IS NOT NULL");
 
 				b.ToTable("Instances");
 			});
@@ -336,34 +342,34 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<decimal>("ChatBotRights")
-					.HasColumnType("numeric(20,0)");
+					.HasColumnType("decimal(20,0)");
 
 				b.Property<decimal>("ConfigurationRights")
-					.HasColumnType("numeric(20,0)");
+					.HasColumnType("decimal(20,0)");
 
 				b.Property<decimal>("DreamDaemonRights")
-					.HasColumnType("numeric(20,0)");
+					.HasColumnType("decimal(20,0)");
 
 				b.Property<decimal>("DreamMakerRights")
-					.HasColumnType("numeric(20,0)");
+					.HasColumnType("decimal(20,0)");
 
 				b.Property<decimal>("EngineRights")
-					.HasColumnType("numeric(20,0)");
+					.HasColumnType("decimal(20,0)");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
 				b.Property<decimal>("InstancePermissionSetRights")
-					.HasColumnType("numeric(20,0)");
+					.HasColumnType("decimal(20,0)");
 
 				b.Property<long>("PermissionSetId")
 					.HasColumnType("bigint");
 
 				b.Property<decimal>("RepositoryRights")
-					.HasColumnType("numeric(20,0)");
+					.HasColumnType("decimal(20,0)");
 
 				b.HasKey("Id");
 
@@ -381,46 +387,46 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<decimal?>("CancelRight")
-					.HasColumnType("numeric(20,0)");
+					.HasColumnType("decimal(20,0)");
 
 				b.Property<decimal?>("CancelRightsType")
-					.HasColumnType("numeric(20,0)");
+					.HasColumnType("decimal(20,0)");
 
 				b.Property<bool?>("Cancelled")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<long?>("CancelledById")
 					.HasColumnType("bigint");
 
 				b.Property<string>("Description")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<long?>("ErrorCode")
 					.HasColumnType("bigint");
 
 				b.Property<string>("ExceptionDetails")
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
 				b.Property<byte>("JobCode")
-					.HasColumnType("smallint");
+					.HasColumnType("tinyint");
 
 				b.Property<DateTimeOffset?>("StartedAt")
 					.IsRequired()
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("datetimeoffset");
 
 				b.Property<long>("StartedById")
 					.HasColumnType("bigint");
 
 				b.Property<DateTimeOffset?>("StoppedAt")
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("datetimeoffset");
 
 				b.HasKey("Id");
 
@@ -439,15 +445,15 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<string>("ExternalUserId")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("nvarchar(100)");
 
 				b.Property<int>("Provider")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<long?>("UserId")
 					.HasColumnType("bigint");
@@ -468,16 +474,16 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<decimal>("AdministrationRights")
-					.HasColumnType("numeric(20,0)");
+					.HasColumnType("decimal(20,0)");
 
 				b.Property<long?>("GroupId")
 					.HasColumnType("bigint");
 
 				b.Property<decimal>("InstanceManagerRights")
-					.HasColumnType("numeric(20,0)");
+					.HasColumnType("decimal(20,0)");
 
 				b.Property<long?>("UserId")
 					.HasColumnType("bigint");
@@ -485,10 +491,12 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.HasKey("Id");
 
 				b.HasIndex("GroupId")
-					.IsUnique();
+					.IsUnique()
+					.HasFilter("[GroupId] IS NOT NULL");
 
 				b.HasIndex("UserId")
-					.IsUnique();
+					.IsUnique()
+					.HasFilter("[UserId] IS NOT NULL");
 
 				b.ToTable("PermissionSets");
 			});
@@ -499,11 +507,11 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<string>("AccessIdentifier")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<long>("CompileJobId")
 					.HasColumnType("bigint");
@@ -512,22 +520,22 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasColumnType("bigint");
 
 				b.Property<int>("LaunchSecurityLevel")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int>("LaunchVisibility")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int>("Port")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int>("ProcessId")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int>("RebootState")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int?>("TopicPort")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.HasKey("Id");
 
@@ -544,56 +552,56 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<string>("AccessToken")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<string>("AccessUser")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<bool?>("AutoUpdatesKeepTestMerges")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<bool?>("AutoUpdatesSynchronize")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<string>("CommitterEmail")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<string>("CommitterName")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<bool?>("CreateGitHubDeployments")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
 				b.Property<bool?>("PostTestMergeComment")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<bool?>("PushTestMergeCommits")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<bool?>("ShowTestMergeCommitters")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<bool?>("UpdateSubmodules")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.HasKey("Id");
 
@@ -609,7 +617,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<long>("RevisionInformationId")
 					.HasColumnType("bigint");
@@ -632,12 +640,12 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<string>("CommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("character varying(40)");
+					.HasColumnType("nvarchar(40)");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
@@ -645,10 +653,10 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.Property<string>("OriginCommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("character varying(40)");
+					.HasColumnType("nvarchar(40)");
 
 				b.Property<DateTimeOffset>("Timestamp")
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("datetimeoffset");
 
 				b.HasKey("Id");
 
@@ -664,28 +672,28 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<string>("Author")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<string>("BodyAtMerge")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<string>("Comment")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<DateTimeOffset>("MergedAt")
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("datetimeoffset");
 
 				b.Property<long>("MergedById")
 					.HasColumnType("bigint");
 
 				b.Property<int>("Number")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<long?>("PrimaryRevisionInformationId")
 					.IsRequired()
@@ -694,15 +702,15 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.Property<string>("TargetCommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("character varying(40)");
+					.HasColumnType("nvarchar(40)");
 
 				b.Property<string>("TitleAtMerge")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<string>("Url")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(max)");
 
 				b.HasKey("Id");
 
@@ -720,41 +728,41 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<string>("CanonicalName")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("nvarchar(100)");
 
 				b.Property<DateTimeOffset?>("CreatedAt")
 					.IsRequired()
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("datetimeoffset");
 
 				b.Property<long?>("CreatedById")
 					.HasColumnType("bigint");
 
 				b.Property<bool?>("Enabled")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<long?>("GroupId")
 					.HasColumnType("bigint");
 
 				b.Property<DateTimeOffset?>("LastPasswordUpdate")
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("datetimeoffset");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("nvarchar(100)");
 
 				b.Property<string>("PasswordHash")
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<string>("SystemIdentifier")
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("nvarchar(100)");
 
 				b.HasKey("Id");
 
@@ -766,7 +774,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.HasIndex("GroupId");
 
 				b.HasIndex("SystemIdentifier")
-					.IsUnique();
+					.IsUnique()
+					.HasFilter("[SystemIdentifier] IS NOT NULL");
 
 				b.ToTable("Users");
 			});
@@ -777,12 +786,12 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("nvarchar(100)");
 
 				b.HasKey("Id");
 
@@ -825,7 +834,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.HasOne("Tgstation.Server.Host.Models.RevisionInformation", "RevisionInformation")
 					.WithMany("CompileJobs")
 					.HasForeignKey("RevisionInformationId")
-					.OnDelete(DeleteBehavior.Cascade)
+					.OnDelete(DeleteBehavior.ClientNoAction)
 					.IsRequired();
 
 				b.Navigation("Job");

--- a/src/Tgstation.Server.Host/Database/Migrations/20240719010153_MSAddOpenDreamTopicPort.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20240719010153_MSAddOpenDreamTopicPort.cs
@@ -1,0 +1,33 @@
+﻿using System;
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Tgstation.Server.Host.Database.Migrations
+{
+	/// <inheritdoc />
+	public partial class MSAddOpenDreamTopicPort : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+			migrationBuilder.AddColumn<int>(
+				name: "OpenDreamTopicPort",
+				table: "DreamDaemonSettings",
+				type: "int",
+				nullable: false,
+				defaultValue: 0);
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+			migrationBuilder.DropColumn(
+				name: "OpenDreamTopicPort",
+				table: "DreamDaemonSettings");
+		}
+	}
+}

--- a/src/Tgstation.Server.Host/Database/Migrations/20240719010202_MYAddOpenDreamTopicPort.Designer.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20240719010202_MYAddOpenDreamTopicPort.Designer.cs
@@ -3,20 +3,23 @@ using System;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Tgstation.Server.Host.Database.Migrations
 {
-	[DbContext(typeof(PostgresSqlDatabaseContext))]
-	partial class PostgresSqlDatabaseContextModelSnapshot : ModelSnapshot
+	[DbContext(typeof(MySqlDatabaseContext))]
+	[Migration("20240719010202_MYAddOpenDreamTopicPort")]
+	partial class MYAddOpenDreamTopicPort
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		/// <inheritdoc />
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder
 				.HasAnnotation("ProductVersion", "8.0.7")
-				.HasAnnotation("Relational:MaxIdentifierLength", 63);
+				.HasAnnotation("Relational:MaxIdentifierLength", 64);
 
-			NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
+			MySqlModelBuilderExtensions.AutoIncrementColumns(modelBuilder);
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.ChatBot", b =>
 			{
@@ -24,18 +27,21 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long?>("Id"));
 
-				b.Property<int>("ChannelLimit")
-					.HasColumnType("integer");
+				b.Property<ushort?>("ChannelLimit")
+					.IsRequired()
+					.HasColumnType("smallint unsigned");
 
 				b.Property<string>("ConnectionString")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("ConnectionString"), "utf8mb4");
 
 				b.Property<bool?>("Enabled")
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
@@ -43,13 +49,14 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("varchar(100)");
 
 				b.Property<int>("Provider")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
-				b.Property<long>("ReconnectionInterval")
-					.HasColumnType("bigint");
+				b.Property<uint?>("ReconnectionInterval")
+					.IsRequired()
+					.HasColumnType("int unsigned");
 
 				b.HasKey("Id");
 
@@ -65,37 +72,41 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<long>("ChatSettingsId")
 					.HasColumnType("bigint");
 
-				b.Property<decimal?>("DiscordChannelId")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong?>("DiscordChannelId")
+					.HasColumnType("bigint unsigned");
 
 				b.Property<string>("IrcChannel")
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("varchar(100)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("IrcChannel"), "utf8mb4");
 
 				b.Property<bool?>("IsAdminChannel")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("IsSystemChannel")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("IsUpdatesChannel")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("IsWatchdogChannel")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<string>("Tag")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Tag"), "utf8mb4");
 
 				b.HasKey("Id");
 
@@ -114,28 +125,32 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<int?>("DMApiMajorVersion")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int?>("DMApiMinorVersion")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int?>("DMApiPatchVersion")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<Guid?>("DirectoryName")
 					.IsRequired()
-					.HasColumnType("uuid");
+					.HasColumnType("char(36)");
 
 				b.Property<string>("DmeName")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("DmeName"), "utf8mb4");
 
 				b.Property<string>("EngineVersion")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("EngineVersion"), "utf8mb4");
 
 				b.Property<long?>("GitHubDeploymentId")
 					.HasColumnType("bigint");
@@ -147,14 +162,18 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasColumnType("bigint");
 
 				b.Property<int?>("MinimumSecurityLevel")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<string>("Output")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Output"), "utf8mb4");
 
 				b.Property<string>("RepositoryOrigin")
-					.HasColumnType("text");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("RepositoryOrigin"), "utf8mb4");
 
 				b.Property<long>("RevisionInformationId")
 					.HasColumnType("bigint");
@@ -177,63 +196,71 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<string>("AdditionalParameters")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("AdditionalParameters"), "utf8mb4");
 
 				b.Property<bool?>("AllowWebClient")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("AutoStart")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("DumpOnHealthCheckRestart")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
-				b.Property<long>("HealthCheckSeconds")
-					.HasColumnType("bigint");
+				b.Property<uint?>("HealthCheckSeconds")
+					.IsRequired()
+					.HasColumnType("int unsigned");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
 				b.Property<bool?>("LogOutput")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
-				b.Property<long>("MapThreads")
-					.HasColumnType("bigint");
+				b.Property<uint?>("MapThreads")
+					.IsRequired()
+					.HasColumnType("int unsigned");
 
 				b.Property<bool?>("Minidumps")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
-				b.Property<int>("OpenDreamTopicPort")
-					.HasColumnType("integer");
+				b.Property<ushort?>("OpenDreamTopicPort")
+					.IsRequired()
+					.HasColumnType("smallint unsigned");
 
-				b.Property<int>("Port")
-					.HasColumnType("integer");
+				b.Property<ushort?>("Port")
+					.IsRequired()
+					.HasColumnType("smallint unsigned");
 
 				b.Property<int>("SecurityLevel")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<bool?>("StartProfiler")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
-				b.Property<long>("StartupTimeout")
-					.HasColumnType("bigint");
+				b.Property<uint?>("StartupTimeout")
+					.IsRequired()
+					.HasColumnType("int unsigned");
 
-				b.Property<long>("TopicRequestTimeout")
-					.HasColumnType("bigint");
+				b.Property<uint?>("TopicRequestTimeout")
+					.IsRequired()
+					.HasColumnType("int unsigned");
 
 				b.Property<int>("Visibility")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.HasKey("Id");
 
@@ -249,32 +276,35 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long>("Id"));
 
-				b.Property<int>("ApiValidationPort")
-					.HasColumnType("integer");
+				b.Property<ushort?>("ApiValidationPort")
+					.IsRequired()
+					.HasColumnType("smallint unsigned");
 
 				b.Property<int>("ApiValidationSecurityLevel")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<string>("CompilerAdditionalArguments")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("varchar(10000)");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
 				b.Property<string>("ProjectName")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("ProjectName"), "utf8mb4");
 
 				b.Property<bool?>("RequireDMApiValidation")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<TimeSpan?>("Timeout")
 					.IsRequired()
-					.HasColumnType("interval");
+					.HasColumnType("time(6)");
 
 				b.HasKey("Id");
 
@@ -290,37 +320,45 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<string>("AutoUpdateCron")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("varchar(10000)");
 
-				b.Property<long>("AutoUpdateInterval")
-					.HasColumnType("bigint");
+				b.Property<uint?>("AutoUpdateInterval")
+					.IsRequired()
+					.HasColumnType("int unsigned");
 
-				b.Property<int>("ChatBotLimit")
-					.HasColumnType("integer");
+				b.Property<ushort?>("ChatBotLimit")
+					.IsRequired()
+					.HasColumnType("smallint unsigned");
 
 				b.Property<int>("ConfigurationType")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("varchar(100)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Name"), "utf8mb4");
 
 				b.Property<bool?>("Online")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<string>("Path")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("varchar(255)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Path"), "utf8mb4");
 
 				b.Property<string>("SwarmIdentifer")
-					.HasColumnType("text");
+					.HasColumnType("varchar(255)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("SwarmIdentifer"), "utf8mb4");
 
 				b.HasKey("Id");
 
@@ -336,34 +374,34 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long>("Id"));
 
-				b.Property<decimal>("ChatBotRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("ChatBotRights")
+					.HasColumnType("bigint unsigned");
 
-				b.Property<decimal>("ConfigurationRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("ConfigurationRights")
+					.HasColumnType("bigint unsigned");
 
-				b.Property<decimal>("DreamDaemonRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("DreamDaemonRights")
+					.HasColumnType("bigint unsigned");
 
-				b.Property<decimal>("DreamMakerRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("DreamMakerRights")
+					.HasColumnType("bigint unsigned");
 
-				b.Property<decimal>("EngineRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("EngineRights")
+					.HasColumnType("bigint unsigned");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
-				b.Property<decimal>("InstancePermissionSetRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("InstancePermissionSetRights")
+					.HasColumnType("bigint unsigned");
 
 				b.Property<long>("PermissionSetId")
 					.HasColumnType("bigint");
 
-				b.Property<decimal>("RepositoryRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("RepositoryRights")
+					.HasColumnType("bigint unsigned");
 
 				b.HasKey("Id");
 
@@ -381,46 +419,50 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long?>("Id"));
 
-				b.Property<decimal?>("CancelRight")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong?>("CancelRight")
+					.HasColumnType("bigint unsigned");
 
-				b.Property<decimal?>("CancelRightsType")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong?>("CancelRightsType")
+					.HasColumnType("bigint unsigned");
 
 				b.Property<bool?>("Cancelled")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<long?>("CancelledById")
 					.HasColumnType("bigint");
 
 				b.Property<string>("Description")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("longtext");
 
-				b.Property<long?>("ErrorCode")
-					.HasColumnType("bigint");
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Description"), "utf8mb4");
+
+				b.Property<uint?>("ErrorCode")
+					.HasColumnType("int unsigned");
 
 				b.Property<string>("ExceptionDetails")
-					.HasColumnType("text");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("ExceptionDetails"), "utf8mb4");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
 				b.Property<byte>("JobCode")
-					.HasColumnType("smallint");
+					.HasColumnType("tinyint unsigned");
 
 				b.Property<DateTimeOffset?>("StartedAt")
 					.IsRequired()
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("datetime(6)");
 
 				b.Property<long>("StartedById")
 					.HasColumnType("bigint");
 
 				b.Property<DateTimeOffset?>("StoppedAt")
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("datetime(6)");
 
 				b.HasKey("Id");
 
@@ -439,15 +481,17 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<string>("ExternalUserId")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("varchar(100)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("ExternalUserId"), "utf8mb4");
 
 				b.Property<int>("Provider")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<long?>("UserId")
 					.HasColumnType("bigint");
@@ -468,16 +512,16 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long?>("Id"));
 
-				b.Property<decimal>("AdministrationRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("AdministrationRights")
+					.HasColumnType("bigint unsigned");
 
 				b.Property<long?>("GroupId")
 					.HasColumnType("bigint");
 
-				b.Property<decimal>("InstanceManagerRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("InstanceManagerRights")
+					.HasColumnType("bigint unsigned");
 
 				b.Property<long?>("UserId")
 					.HasColumnType("bigint");
@@ -499,11 +543,13 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<string>("AccessIdentifier")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("AccessIdentifier"), "utf8mb4");
 
 				b.Property<long>("CompileJobId")
 					.HasColumnType("bigint");
@@ -512,22 +558,22 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasColumnType("bigint");
 
 				b.Property<int>("LaunchSecurityLevel")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int>("LaunchVisibility")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
-				b.Property<int>("Port")
-					.HasColumnType("integer");
+				b.Property<ushort>("Port")
+					.HasColumnType("smallint unsigned");
 
 				b.Property<int>("ProcessId")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int>("RebootState")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
-				b.Property<int?>("TopicPort")
-					.HasColumnType("integer");
+				b.Property<ushort?>("TopicPort")
+					.HasColumnType("smallint unsigned");
 
 				b.HasKey("Id");
 
@@ -544,56 +590,64 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<string>("AccessToken")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("AccessToken"), "utf8mb4");
 
 				b.Property<string>("AccessUser")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("AccessUser"), "utf8mb4");
 
 				b.Property<bool?>("AutoUpdatesKeepTestMerges")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("AutoUpdatesSynchronize")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<string>("CommitterEmail")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("CommitterEmail"), "utf8mb4");
 
 				b.Property<string>("CommitterName")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("CommitterName"), "utf8mb4");
 
 				b.Property<bool?>("CreateGitHubDeployments")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
 				b.Property<bool?>("PostTestMergeComment")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("PushTestMergeCommits")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("ShowTestMergeCommitters")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("UpdateSubmodules")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.HasKey("Id");
 
@@ -609,7 +663,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<long>("RevisionInformationId")
 					.HasColumnType("bigint");
@@ -632,12 +686,14 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<string>("CommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("character varying(40)");
+					.HasColumnType("varchar(40)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("CommitSha"), "utf8mb4");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
@@ -645,10 +701,12 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.Property<string>("OriginCommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("character varying(40)");
+					.HasColumnType("varchar(40)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("OriginCommitSha"), "utf8mb4");
 
 				b.Property<DateTimeOffset>("Timestamp")
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("datetime(6)");
 
 				b.HasKey("Id");
 
@@ -664,28 +722,34 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<string>("Author")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Author"), "utf8mb4");
 
 				b.Property<string>("BodyAtMerge")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("BodyAtMerge"), "utf8mb4");
 
 				b.Property<string>("Comment")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Comment"), "utf8mb4");
 
 				b.Property<DateTimeOffset>("MergedAt")
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("datetime(6)");
 
 				b.Property<long>("MergedById")
 					.HasColumnType("bigint");
 
 				b.Property<int>("Number")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<long?>("PrimaryRevisionInformationId")
 					.IsRequired()
@@ -694,15 +758,21 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.Property<string>("TargetCommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("character varying(40)");
+					.HasColumnType("varchar(40)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("TargetCommitSha"), "utf8mb4");
 
 				b.Property<string>("TitleAtMerge")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("TitleAtMerge"), "utf8mb4");
 
 				b.Property<string>("Url")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Url"), "utf8mb4");
 
 				b.HasKey("Id");
 
@@ -720,41 +790,49 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<string>("CanonicalName")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("varchar(100)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("CanonicalName"), "utf8mb4");
 
 				b.Property<DateTimeOffset?>("CreatedAt")
 					.IsRequired()
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("datetime(6)");
 
 				b.Property<long?>("CreatedById")
 					.HasColumnType("bigint");
 
 				b.Property<bool?>("Enabled")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<long?>("GroupId")
 					.HasColumnType("bigint");
 
 				b.Property<DateTimeOffset?>("LastPasswordUpdate")
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("datetime(6)");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("varchar(100)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Name"), "utf8mb4");
 
 				b.Property<string>("PasswordHash")
-					.HasColumnType("text");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("PasswordHash"), "utf8mb4");
 
 				b.Property<string>("SystemIdentifier")
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("varchar(100)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("SystemIdentifier"), "utf8mb4");
 
 				b.HasKey("Id");
 
@@ -777,12 +855,14 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("varchar(100)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Name"), "utf8mb4");
 
 				b.HasKey("Id");
 

--- a/src/Tgstation.Server.Host/Database/Migrations/20240719010202_MYAddOpenDreamTopicPort.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20240719010202_MYAddOpenDreamTopicPort.cs
@@ -1,0 +1,33 @@
+﻿using System;
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Tgstation.Server.Host.Database.Migrations
+{
+	/// <inheritdoc />
+	public partial class MYAddOpenDreamTopicPort : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+			migrationBuilder.AddColumn<ushort>(
+				name: "OpenDreamTopicPort",
+				table: "DreamDaemonSettings",
+				type: "smallint unsigned",
+				nullable: false,
+				defaultValue: (ushort)0);
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+			migrationBuilder.DropColumn(
+				name: "OpenDreamTopicPort",
+				table: "DreamDaemonSettings");
+		}
+	}
+}

--- a/src/Tgstation.Server.Host/Database/Migrations/20240719010209_PGAddOpenDreamTopicPort.Designer.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20240719010209_PGAddOpenDreamTopicPort.Designer.cs
@@ -3,13 +3,16 @@ using System;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Tgstation.Server.Host.Database.Migrations
 {
 	[DbContext(typeof(PostgresSqlDatabaseContext))]
-	partial class PostgresSqlDatabaseContextModelSnapshot : ModelSnapshot
+	[Migration("20240719010209_PGAddOpenDreamTopicPort")]
+	partial class PGAddOpenDreamTopicPort
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		/// <inheritdoc />
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder

--- a/src/Tgstation.Server.Host/Database/Migrations/20240719010209_PGAddOpenDreamTopicPort.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20240719010209_PGAddOpenDreamTopicPort.cs
@@ -1,0 +1,33 @@
+﻿using System;
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Tgstation.Server.Host.Database.Migrations
+{
+	/// <inheritdoc />
+	public partial class PGAddOpenDreamTopicPort : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+			migrationBuilder.AddColumn<int>(
+				name: "OpenDreamTopicPort",
+				table: "DreamDaemonSettings",
+				type: "integer",
+				nullable: false,
+				defaultValue: 0);
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+			migrationBuilder.DropColumn(
+				name: "OpenDreamTopicPort",
+				table: "DreamDaemonSettings");
+		}
+	}
+}

--- a/src/Tgstation.Server.Host/Database/Migrations/20240719010216_SLAddOpenDreamTopicPort.Designer.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20240719010216_SLAddOpenDreamTopicPort.Designer.cs
@@ -3,53 +3,52 @@ using System;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Tgstation.Server.Host.Database.Migrations
 {
-	[DbContext(typeof(PostgresSqlDatabaseContext))]
-	partial class PostgresSqlDatabaseContextModelSnapshot : ModelSnapshot
+	[DbContext(typeof(SqliteDatabaseContext))]
+	[Migration("20240719010216_SLAddOpenDreamTopicPort")]
+	partial class SLAddOpenDreamTopicPort
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		/// <inheritdoc />
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
-			modelBuilder
-				.HasAnnotation("ProductVersion", "8.0.7")
-				.HasAnnotation("Relational:MaxIdentifierLength", 63);
-
-			NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
+			modelBuilder.HasAnnotation("ProductVersion", "8.0.7");
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.ChatBot", b =>
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
-
-				b.Property<int>("ChannelLimit")
-					.HasColumnType("integer");
+				b.Property<ushort?>("ChannelLimit")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("ConnectionString")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("TEXT");
 
 				b.Property<bool?>("Enabled")
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("TEXT");
 
 				b.Property<int>("Provider")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
-				b.Property<long>("ReconnectionInterval")
-					.HasColumnType("bigint");
+				b.Property<uint?>("ReconnectionInterval")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
 				b.HasKey("Id");
 
@@ -63,39 +62,37 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("ChatSettingsId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
-				b.Property<decimal?>("DiscordChannelId")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong?>("DiscordChannelId")
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("IrcChannel")
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("TEXT");
 
 				b.Property<bool?>("IsAdminChannel")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("IsSystemChannel")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("IsUpdatesChannel")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("IsWatchdogChannel")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("Tag")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("TEXT");
 
 				b.HasKey("Id");
 
@@ -112,52 +109,50 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<int?>("DMApiMajorVersion")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
 				b.Property<int?>("DMApiMinorVersion")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
 				b.Property<int?>("DMApiPatchVersion")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
 				b.Property<Guid?>("DirectoryName")
 					.IsRequired()
-					.HasColumnType("uuid");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("DmeName")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("EngineVersion")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
 				b.Property<long?>("GitHubDeploymentId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<long?>("GitHubRepoId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("JobId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<int?>("MinimumSecurityLevel")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("Output")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("RepositoryOrigin")
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
 				b.Property<long>("RevisionInformationId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.HasKey("Id");
 
@@ -175,65 +170,69 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("AdditionalParameters")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("TEXT");
 
 				b.Property<bool?>("AllowWebClient")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("AutoStart")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("DumpOnHealthCheckRestart")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
-				b.Property<long>("HealthCheckSeconds")
-					.HasColumnType("bigint");
+				b.Property<uint?>("HealthCheckSeconds")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("LogOutput")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
-				b.Property<long>("MapThreads")
-					.HasColumnType("bigint");
+				b.Property<uint?>("MapThreads")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("Minidumps")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
-				b.Property<int>("OpenDreamTopicPort")
-					.HasColumnType("integer");
+				b.Property<ushort?>("OpenDreamTopicPort")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
-				b.Property<int>("Port")
-					.HasColumnType("integer");
+				b.Property<ushort?>("Port")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
 				b.Property<int>("SecurityLevel")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("StartProfiler")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
-				b.Property<long>("StartupTimeout")
-					.HasColumnType("bigint");
+				b.Property<uint?>("StartupTimeout")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
-				b.Property<long>("TopicRequestTimeout")
-					.HasColumnType("bigint");
+				b.Property<uint?>("TopicRequestTimeout")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
 				b.Property<int>("Visibility")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
 				b.HasKey("Id");
 
@@ -247,34 +246,33 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
-
-				b.Property<int>("ApiValidationPort")
-					.HasColumnType("integer");
+				b.Property<ushort?>("ApiValidationPort")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
 				b.Property<int>("ApiValidationSecurityLevel")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("CompilerAdditionalArguments")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("TEXT");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("ProjectName")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("TEXT");
 
 				b.Property<bool?>("RequireDMApiValidation")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<TimeSpan?>("Timeout")
 					.IsRequired()
-					.HasColumnType("interval");
+					.HasColumnType("TEXT");
 
 				b.HasKey("Id");
 
@@ -288,39 +286,39 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("AutoUpdateCron")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("TEXT");
 
-				b.Property<long>("AutoUpdateInterval")
-					.HasColumnType("bigint");
+				b.Property<uint?>("AutoUpdateInterval")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
-				b.Property<int>("ChatBotLimit")
-					.HasColumnType("integer");
+				b.Property<ushort?>("ChatBotLimit")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
 				b.Property<int>("ConfigurationType")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("TEXT");
 
 				b.Property<bool?>("Online")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("Path")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("SwarmIdentifer")
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
 				b.HasKey("Id");
 
@@ -334,36 +332,34 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				b.Property<ulong>("ChatBotRights")
+					.HasColumnType("INTEGER");
 
-				b.Property<decimal>("ChatBotRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("ConfigurationRights")
+					.HasColumnType("INTEGER");
 
-				b.Property<decimal>("ConfigurationRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("DreamDaemonRights")
+					.HasColumnType("INTEGER");
 
-				b.Property<decimal>("DreamDaemonRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("DreamMakerRights")
+					.HasColumnType("INTEGER");
 
-				b.Property<decimal>("DreamMakerRights")
-					.HasColumnType("numeric(20,0)");
-
-				b.Property<decimal>("EngineRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("EngineRights")
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
-				b.Property<decimal>("InstancePermissionSetRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("InstancePermissionSetRights")
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("PermissionSetId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
-				b.Property<decimal>("RepositoryRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("RepositoryRights")
+					.HasColumnType("INTEGER");
 
 				b.HasKey("Id");
 
@@ -379,48 +375,46 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				b.Property<ulong?>("CancelRight")
+					.HasColumnType("INTEGER");
 
-				b.Property<decimal?>("CancelRight")
-					.HasColumnType("numeric(20,0)");
-
-				b.Property<decimal?>("CancelRightsType")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong?>("CancelRightsType")
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("Cancelled")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<long?>("CancelledById")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("Description")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
-				b.Property<long?>("ErrorCode")
-					.HasColumnType("bigint");
+				b.Property<uint?>("ErrorCode")
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("ExceptionDetails")
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<byte>("JobCode")
-					.HasColumnType("smallint");
+					.HasColumnType("INTEGER");
 
 				b.Property<DateTimeOffset?>("StartedAt")
 					.IsRequired()
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("TEXT");
 
 				b.Property<long>("StartedById")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<DateTimeOffset?>("StoppedAt")
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("TEXT");
 
 				b.HasKey("Id");
 
@@ -437,20 +431,18 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("ExternalUserId")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("TEXT");
 
 				b.Property<int>("Provider")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
 				b.Property<long?>("UserId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.HasKey("Id");
 
@@ -466,21 +458,19 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
-
-				b.Property<decimal>("AdministrationRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("AdministrationRights")
+					.HasColumnType("INTEGER");
 
 				b.Property<long?>("GroupId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
-				b.Property<decimal>("InstanceManagerRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("InstanceManagerRights")
+					.HasColumnType("INTEGER");
 
 				b.Property<long?>("UserId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.HasKey("Id");
 
@@ -497,37 +487,35 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("AccessIdentifier")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
 				b.Property<long>("CompileJobId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<long?>("InitialCompileJobId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<int>("LaunchSecurityLevel")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
 				b.Property<int>("LaunchVisibility")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
-				b.Property<int>("Port")
-					.HasColumnType("integer");
+				b.Property<ushort>("Port")
+					.HasColumnType("INTEGER");
 
 				b.Property<int>("ProcessId")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
 				b.Property<int>("RebootState")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
-				b.Property<int?>("TopicPort")
-					.HasColumnType("integer");
+				b.Property<ushort?>("TopicPort")
+					.HasColumnType("INTEGER");
 
 				b.HasKey("Id");
 
@@ -542,58 +530,56 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("AccessToken")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("AccessUser")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("TEXT");
 
 				b.Property<bool?>("AutoUpdatesKeepTestMerges")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("AutoUpdatesSynchronize")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("CommitterEmail")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("CommitterName")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("TEXT");
 
 				b.Property<bool?>("CreateGitHubDeployments")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("PostTestMergeComment")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("PushTestMergeCommits")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("ShowTestMergeCommitters")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("UpdateSubmodules")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.HasKey("Id");
 
@@ -607,15 +593,13 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("RevisionInformationId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("TestMergeId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.HasKey("Id");
 
@@ -630,25 +614,23 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("CommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("character varying(40)");
+					.HasColumnType("TEXT");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("OriginCommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("character varying(40)");
+					.HasColumnType("TEXT");
 
 				b.Property<DateTimeOffset>("Timestamp")
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("TEXT");
 
 				b.HasKey("Id");
 
@@ -662,47 +644,45 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("Author")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("BodyAtMerge")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("Comment")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("TEXT");
 
 				b.Property<DateTimeOffset>("MergedAt")
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("TEXT");
 
 				b.Property<long>("MergedById")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<int>("Number")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
 				b.Property<long?>("PrimaryRevisionInformationId")
 					.IsRequired()
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("TargetCommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("character varying(40)");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("TitleAtMerge")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("Url")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
 				b.HasKey("Id");
 
@@ -718,43 +698,41 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("CanonicalName")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("TEXT");
 
 				b.Property<DateTimeOffset?>("CreatedAt")
 					.IsRequired()
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("TEXT");
 
 				b.Property<long?>("CreatedById")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("Enabled")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<long?>("GroupId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<DateTimeOffset?>("LastPasswordUpdate")
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("PasswordHash")
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("SystemIdentifier")
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("TEXT");
 
 				b.HasKey("Id");
 
@@ -775,14 +753,12 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("TEXT");
 
 				b.HasKey("Id");
 
@@ -825,7 +801,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.HasOne("Tgstation.Server.Host.Models.RevisionInformation", "RevisionInformation")
 					.WithMany("CompileJobs")
 					.HasForeignKey("RevisionInformationId")
-					.OnDelete(DeleteBehavior.Cascade)
+					.OnDelete(DeleteBehavior.ClientNoAction)
 					.IsRequired();
 
 				b.Navigation("Job");

--- a/src/Tgstation.Server.Host/Database/Migrations/20240719010216_SLAddOpenDreamTopicPort.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20240719010216_SLAddOpenDreamTopicPort.cs
@@ -1,0 +1,33 @@
+﻿using System;
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Tgstation.Server.Host.Database.Migrations
+{
+	/// <inheritdoc />
+	public partial class SLAddOpenDreamTopicPort : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+			migrationBuilder.AddColumn<ushort>(
+				name: "OpenDreamTopicPort",
+				table: "DreamDaemonSettings",
+				type: "INTEGER",
+				nullable: false,
+				defaultValue: (ushort)0);
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+			migrationBuilder.DropColumn(
+				name: "OpenDreamTopicPort",
+				table: "DreamDaemonSettings");
+		}
+	}
+}

--- a/src/Tgstation.Server.Host/Database/Migrations/MySqlDatabaseContextModelSnapshot.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/MySqlDatabaseContextModelSnapshot.cs
@@ -13,7 +13,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 		{
 #pragma warning disable 612, 618
 			modelBuilder
-				.HasAnnotation("ProductVersion", "8.0.6")
+				.HasAnnotation("ProductVersion", "8.0.7")
 				.HasAnnotation("Relational:MaxIdentifierLength", 64);
 
 			MySqlModelBuilderExtensions.AutoIncrementColumns(modelBuilder);
@@ -232,6 +232,10 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.Property<bool?>("Minidumps")
 					.IsRequired()
 					.HasColumnType("tinyint(1)");
+
+				b.Property<ushort?>("OpenDreamTopicPort")
+					.IsRequired()
+					.HasColumnType("smallint unsigned");
 
 				b.Property<ushort?>("Port")
 					.IsRequired()

--- a/src/Tgstation.Server.Host/Database/Migrations/SqlServerDatabaseContextModelSnapshot.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/SqlServerDatabaseContextModelSnapshot.cs
@@ -13,7 +13,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 		{
 #pragma warning disable 612, 618
 			modelBuilder
-				.HasAnnotation("ProductVersion", "8.0.6")
+				.HasAnnotation("ProductVersion", "8.0.7")
 				.HasAnnotation("Relational:MaxIdentifierLength", 128);
 
 			SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
@@ -214,6 +214,9 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.Property<bool?>("Minidumps")
 					.IsRequired()
 					.HasColumnType("bit");
+
+				b.Property<int>("OpenDreamTopicPort")
+					.HasColumnType("int");
 
 				b.Property<int>("Port")
 					.HasColumnType("int");

--- a/src/Tgstation.Server.Host/Database/Migrations/SqliteDatabaseContextModelSnapshot.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/SqliteDatabaseContextModelSnapshot.cs
@@ -12,7 +12,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 		protected override void BuildModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
-			modelBuilder.HasAnnotation("ProductVersion", "8.0.6");
+			modelBuilder.HasAnnotation("ProductVersion", "8.0.7");
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.ChatBot", b =>
 			{
@@ -202,6 +202,10 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("Minidumps")
+					.IsRequired()
+					.HasColumnType("INTEGER");
+
+				b.Property<ushort?>("OpenDreamTopicPort")
 					.IsRequired()
 					.HasColumnType("INTEGER");
 

--- a/tests/Tgstation.Server.Tests/TestDatabase.cs
+++ b/tests/Tgstation.Server.Tests/TestDatabase.cs
@@ -115,6 +115,7 @@ namespace Tgstation.Server.Tests
 					HealthCheckSeconds = 0,
 					DumpOnHealthCheckRestart = false,
 					Port = 1447,
+					OpenDreamTopicPort = 0,
 					SecurityLevel = DreamDaemonSecurity.Safe,
 					Visibility = DreamDaemonVisibility.Public,
 					StartupTimeout = 1000,


### PR DESCRIPTION
Closes #1826

🆑 HTTP API
Added `openDreamTopicPort` to DreamDaemon model. Shares the same permission as `port`. Allows setting the port used for BYOND type topics in OpenDream servers.
Added `currentTopicPort` to DreamDaemon response models.
/🆑

:cl: Nuget: API
Added `OpenDreamTopicPort` to `DreamDaemonLaunchParameters`.
Added `currentTopicPort` to `DreamDaemonResponse`.
/:cl:

:cl: Nuget: Client
Update to API library version 13.5.0.
/:cl: