### PR TITLE
Guard against users using relative pathing to set the project name to the .dme in the repository

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -5,10 +5,10 @@
   <PropertyGroup>
     <TgsCoreVersion>6.7.0</TgsCoreVersion>
     <TgsConfigVersion>5.1.0</TgsConfigVersion>
-    <TgsApiVersion>10.5.0</TgsApiVersion>
+    <TgsApiVersion>10.6.0</TgsApiVersion>
     <TgsCommonLibraryVersion>7.0.0</TgsCommonLibraryVersion>
-    <TgsApiLibraryVersion>13.5.0</TgsApiLibraryVersion>
-    <TgsClientVersion>15.5.0</TgsClientVersion>
+    <TgsApiLibraryVersion>13.6.0</TgsApiLibraryVersion>
+    <TgsClientVersion>15.6.0</TgsClientVersion>
     <TgsDmapiVersion>7.1.3</TgsDmapiVersion>
     <TgsInteropVersion>5.9.0</TgsInteropVersion>
     <TgsHostWatchdogVersion>1.4.1</TgsHostWatchdogVersion>

--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="WebpanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>6.7.0</TgsCoreVersion>
+    <TgsCoreVersion>6.8.0</TgsCoreVersion>
     <TgsConfigVersion>5.1.0</TgsConfigVersion>
     <TgsApiVersion>10.6.0</TgsApiVersion>
     <TgsCommonLibraryVersion>7.0.0</TgsCommonLibraryVersion>

--- a/src/Tgstation.Server.Api/Models/ErrorCode.cs
+++ b/src/Tgstation.Server.Api/Models/ErrorCode.cs
@@ -651,5 +651,11 @@ namespace Tgstation.Server.Api.Models
 		/// </summary>
 		[Description("Could not create dump as dotnet diagnostics threw an exception!")]
 		DotnetDiagnosticsFailure,
+
+		/// <summary>
+		/// The configured .dme could not be found.
+		/// </summary>
+		[Description("Could not load configured .dme due to it being outside the deployment directory! This should be a relative path.")]
+		DeploymentWrongDme,
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
@@ -607,12 +607,12 @@ namespace Tgstation.Server.Host.Components.Deployment
 				else
 				{
 					var targetDme = ioManager.ConcatPath(outputDirectory, String.Join('.', job.DmeName, DmeExtension));
+					if (!await ioManager.PathIsChildOf(outputDirectory, targetDme, cancellationToken))
+						throw new JobException(ErrorCode.DeploymentWrongDme);
+
 					var targetDmeExists = await ioManager.FileExists(targetDme, cancellationToken);
 					if (!targetDmeExists)
 						throw new JobException(ErrorCode.DeploymentMissingDme);
-
-					if (!await ioManager.PathIsChildOf(outputDirectory, targetDme, cancellationToken))
-						throw new JobException(ErrorCode.DeploymentWrongDme);
 				}
 
 				logger.LogDebug("Selected \"{dmeName}.dme\" for compilation!", job.DmeName);

--- a/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
@@ -610,6 +610,9 @@ namespace Tgstation.Server.Host.Components.Deployment
 					var targetDmeExists = await ioManager.FileExists(targetDme, cancellationToken);
 					if (!targetDmeExists)
 						throw new JobException(ErrorCode.DeploymentMissingDme);
+
+					if (!await ioManager.PathIsChildOf(outputDirectory, targetDme, cancellationToken))
+						throw new JobException(ErrorCode.DeploymentWrongDme);
 				}
 
 				logger.LogDebug("Selected \"{dmeName}.dme\" for compilation!", job.DmeName);

--- a/src/Tgstation.Server.Host/Database/DatabaseSeeder.cs
+++ b/src/Tgstation.Server.Host/Database/DatabaseSeeder.cs
@@ -52,6 +52,11 @@ namespace Tgstation.Server.Host.Database
 		readonly DatabaseConfiguration databaseConfiguration;
 
 		/// <summary>
+		/// The <see cref="SwarmConfiguration"/> for the <see cref="DatabaseSeeder"/>.
+		/// </summary>
+		readonly SwarmConfiguration swarmConfiguration;
+
+		/// <summary>
 		/// Add a default system <see cref="User"/> to a given <paramref name="databaseContext"/>.
 		/// </summary>
 		/// <param name="databaseContext">The <see cref="IDatabaseContext"/> to add a system <see cref="User"/> to.</param>
@@ -83,6 +88,7 @@ namespace Tgstation.Server.Host.Database
 		/// <param name="platformIdentifier">The value of <see cref="platformIdentifier"/>.</param>
 		/// <param name="generalConfigurationOptions">The <see cref="IOptions{TOptions}"/> containing the value of <see cref="generalConfiguration"/>.</param>
 		/// <param name="databaseConfigurationOptions">The <see cref="IOptions{TOptions}"/> containing the value of <see cref="databaseConfiguration"/>.</param>
+		/// <param name="swarmConfigurationOptions">The <see cref="IOptions{TOptions}"/> containing the value of <see cref="swarmConfiguration"/>.</param>
 		/// <param name="databaseLogger">The value of <see cref="databaseLogger"/>.</param>
 		/// <param name="logger">The value of <see cref="logger"/>.</param>
 		public DatabaseSeeder(
@@ -90,6 +96,7 @@ namespace Tgstation.Server.Host.Database
 			IPlatformIdentifier platformIdentifier,
 			IOptions<GeneralConfiguration> generalConfigurationOptions,
 			IOptions<DatabaseConfiguration> databaseConfigurationOptions,
+			IOptions<SwarmConfiguration> swarmConfigurationOptions,
 			ILogger<DatabaseContext> databaseLogger,
 			ILogger<DatabaseSeeder> logger)
 		{
@@ -97,6 +104,7 @@ namespace Tgstation.Server.Host.Database
 			this.platformIdentifier = platformIdentifier ?? throw new ArgumentNullException(nameof(platformIdentifier));
 			databaseConfiguration = databaseConfigurationOptions?.Value ?? throw new ArgumentNullException(nameof(databaseConfigurationOptions));
 			generalConfiguration = generalConfigurationOptions?.Value ?? throw new ArgumentNullException(nameof(generalConfigurationOptions));
+			swarmConfiguration = swarmConfigurationOptions?.Value ?? throw new ArgumentNullException(nameof(swarmConfigurationOptions));
 			this.databaseLogger = databaseLogger ?? throw new ArgumentNullException(nameof(databaseLogger));
 			this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
 		}
@@ -227,6 +235,7 @@ namespace Tgstation.Server.Host.Database
 			var allInstances = await databaseContext
 				.Instances
 				.AsQueryable()
+				.Where(instance => instance.SwarmIdentifer == swarmConfiguration.Identifier)
 				.ToListAsync(cancellationToken);
 			foreach (var instance in allInstances)
 				instance.Path = platformIdentifier.NormalizePath(instance.Path!.Replace('\\', '/'));

--- a/src/Tgstation.Server.Host/Database/DatabaseSeeder.cs
+++ b/src/Tgstation.Server.Host/Database/DatabaseSeeder.cs
@@ -223,16 +223,13 @@ namespace Tgstation.Server.Host.Database
 				}
 			}
 
-			if (platformIdentifier.IsWindows)
-			{
-				// normalize backslashes to forward slashes
-				var allInstances = await databaseContext
-					.Instances
-					.AsQueryable()
-					.ToListAsync(cancellationToken);
-				foreach (var instance in allInstances)
-					instance.Path = instance.Path!.Replace('\\', '/');
-			}
+			// normalize backslashes to forward slashes
+			var allInstances = await databaseContext
+				.Instances
+				.AsQueryable()
+				.ToListAsync(cancellationToken);
+			foreach (var instance in allInstances)
+				instance.Path = platformIdentifier.NormalizePath(instance.Path!.Replace('\\', '/'));
 
 			if (generalConfiguration.ByondTopicTimeout != 0)
 			{

--- a/src/Tgstation.Server.Host/IO/DefaultIOManager.cs
+++ b/src/Tgstation.Server.Host/IO/DefaultIOManager.cs
@@ -358,6 +358,33 @@ namespace Tgstation.Server.Host.IO
 			DefaultBufferSize,
 			true);
 
+		/// <inheritdoc />
+		public Task<bool> PathIsChildOf(string parentPath, string childPath, CancellationToken cancellationToken) => Task.Factory.StartNew(
+			() =>
+			{
+				parentPath = ResolvePath(parentPath);
+				childPath = ResolvePath(childPath);
+
+				if (parentPath == childPath)
+					return true;
+
+				// https://stackoverflow.com/questions/5617320/given-full-path-check-if-path-is-subdirectory-of-some-other-path-or-otherwise?lq=1
+				var di1 = new DirectoryInfo(parentPath);
+				var di2 = new DirectoryInfo(childPath);
+				while (di2.Parent != null)
+				{
+					if (di2.Parent.FullName == di1.FullName)
+						return true;
+
+					di2 = di2.Parent;
+				}
+
+				return false;
+			},
+			cancellationToken,
+			BlockingTaskCreationOptions,
+			TaskScheduler.Current);
+
 		/// <summary>
 		/// Copies a directory from <paramref name="src"/> to <paramref name="dest"/>.
 		/// </summary>

--- a/src/Tgstation.Server.Host/IO/IIOManager.cs
+++ b/src/Tgstation.Server.Host/IO/IIOManager.cs
@@ -46,6 +46,15 @@ namespace Tgstation.Server.Host.IO
 		bool PathContainsParentAccess(string path);
 
 		/// <summary>
+		/// Check if a given <paramref name="parentPath"/> is a parent of a given <paramref name="parentPath"/>.
+		/// </summary>
+		/// <param name="parentPath">The parent path.</param>
+		/// <param name="childPath">The child path.</param>
+		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
+		/// <returns>A <see cref="Task{TResult}"/> resulting in <see langword="true"/> if <paramref name="childPath"/> is a child of <paramref name="parentPath"/> or they are equivalent.</returns>
+		Task<bool> PathIsChildOf(string parentPath, string childPath, CancellationToken cancellationToken);
+
+		/// <summary>
 		/// Copies a directory from <paramref name="src"/> to <paramref name="dest"/>.
 		/// </summary>
 		/// <param name="ignore">Files and folders to ignore at the root level.</param>
@@ -68,7 +77,7 @@ namespace Tgstation.Server.Host.IO
 		/// </summary>
 		/// <param name="path">The file to check for existence.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
-		/// <returns>A <see cref="Task"/> resulting in <see langword="true"/> if the file at <paramref name="path"/> exists, <see langword="false"/> otherwise.</returns>
+		/// <returns>A <see cref="Task{TResult}"/> resulting in <see langword="true"/> if the file at <paramref name="path"/> exists, <see langword="false"/> otherwise.</returns>
 		Task<bool> FileExists(string path, CancellationToken cancellationToken);
 
 		/// <summary>

--- a/src/Tgstation.Server.Host/System/IPlatformIdentifier.cs
+++ b/src/Tgstation.Server.Host/System/IPlatformIdentifier.cs
@@ -17,5 +17,12 @@ namespace Tgstation.Server.Host.System
 		/// The extension of executable script files for the system.
 		/// </summary>
 		string ScriptFileExtension { get; }
+
+		/// <summary>
+		/// Normalize a path for consistency.
+		/// </summary>
+		/// <param name="path">The path to normalize.</param>
+		/// <returns>The normalized path.</returns>
+		string NormalizePath(string path);
 	}
 }

--- a/src/Tgstation.Server.Host/System/PlatformIdentifier.cs
+++ b/src/Tgstation.Server.Host/System/PlatformIdentifier.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿using System;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 
 namespace Tgstation.Server.Host.System
@@ -20,6 +21,16 @@ namespace Tgstation.Server.Host.System
 		{
 			IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 			ScriptFileExtension = IsWindows ? "bat" : "sh";
+		}
+
+		/// <inheritdoc />
+		public string NormalizePath(string path)
+		{
+			ArgumentNullException.ThrowIfNull(path);
+			if (IsWindows)
+				path = path.Replace('\\', '/');
+
+			return path;
 		}
 	}
 }


### PR DESCRIPTION
PRs I shouldn't have to make.

🆑
You can no longer deploy a .dme file outside of the deployment directory.
Fixed Windows path normalization applying to Linux instances in the same swarm.
/🆑

🆑 HTTP API
Added ErrorCode 107 for if a deployment is attempted with a project outside the deployment directory.
/🆑