### PR TITLE
Fix DMAPI documentation comment typos

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -9,7 +9,7 @@
     <TgsCommonLibraryVersion>7.0.0</TgsCommonLibraryVersion>
     <TgsApiLibraryVersion>13.6.0</TgsApiLibraryVersion>
     <TgsClientVersion>15.6.0</TgsClientVersion>
-    <TgsDmapiVersion>7.2.0</TgsDmapiVersion>
+    <TgsDmapiVersion>7.2.1</TgsDmapiVersion>
     <TgsInteropVersion>5.9.0</TgsInteropVersion>
     <TgsHostWatchdogVersion>1.4.1</TgsHostWatchdogVersion>
     <TgsContainerScriptVersion>1.2.1</TgsContainerScriptVersion>

--- a/src/DMAPI/tgs.dm
+++ b/src/DMAPI/tgs.dm
@@ -1,7 +1,7 @@
 // tgstation-server DMAPI
 // The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in IETF RFC 2119.
 
-#define TGS_DMAPI_VERSION "7.2.0"
+#define TGS_DMAPI_VERSION "7.2.1"
 
 // All functions and datums outside this document are subject to change with any version and should not be relied on.
 
@@ -163,7 +163,7 @@
 	return
 
 /**
- * Consumers MUST this when your initializations are complete and your game is ready to play before any player interactions happen.
+ * Consumers MUST call this when world initializations are complete and the game is ready to play before any player interactions happen.
  *
  * This may use [/world/var/sleep_offline] to make this happen so ensure no changes are made to it while this call is running.
  * Afterwards, consider explicitly setting it to what you want to avoid this BYOND bug: http://www.byond.com/forum/post/2575184


### PR DESCRIPTION
:cl: DreamMaker API
Fixed a typo in documentation comments.
/:cl:

Merging with `[DMDeploy]`