### PR TITLE
Fix version reporting telemetry not creating directory

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -2156,9 +2156,17 @@ jobs:
       - name: Parse TGS version
         run: echo "TGS_VERSION=$(xmlstarlet sel -N X="http://schemas.microsoft.com/developer/msbuild/2003" --template --value-of /X:Project/X:PropertyGroup/X:TgsCoreVersion build/Version.props)" >> $GITHUB_ENV
 
+      - name: Generate App Token
+        id: app-token-generation
+        uses: actions/create-github-app-token@v1
+        with:
+          repositories: tgstation-ppa
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Trigger tgstation-ppa workflow
         run: |
-          curl -XPOST -u "${{ vars.DEV_PUSH_USERNAME }}:${{ secrets.DEV_PUSH_TOKEN }}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/tgstation/tgstation-ppa/actions/workflows/add_tgs_version.yml/dispatches --data '{"ref":"main","inputs":{"tgs_semver": "${{ env.TGS_VERSION }}"}}'
+          curl -XPOST -u "tgstation-server-ci:${{ steps.app-token-generation.outputs.token }}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/tgstation/tgstation-ppa/actions/workflows/add_tgs_version.yml/dispatches --data '{"ref":"main","inputs":{"tgs_semver": "${{ env.TGS_VERSION }}"}}'
 
   deploy-winget:
     name: Deploy TGS (winget)

--- a/.github/workflows/update-ss13-org-mirror.yml
+++ b/.github/workflows/update-ss13-org-mirror.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/create-github-app-token@v1
         with:
           owner: spacestation13
+          repositories: tgstation-server
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 

--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="WebpanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>6.9.1</TgsCoreVersion>
+    <TgsCoreVersion>6.9.2</TgsCoreVersion>
     <TgsConfigVersion>5.2.0</TgsConfigVersion>
     <TgsApiVersion>10.7.0</TgsApiVersion>
     <TgsCommonLibraryVersion>7.0.0</TgsCommonLibraryVersion>

--- a/src/Tgstation.Server.Host/Core/VersionReportingService.cs
+++ b/src/Tgstation.Server.Host/Core/VersionReportingService.cs
@@ -119,15 +119,17 @@ namespace Tgstation.Server.Host.Core
 
 			try
 			{
+				var telemetryIdDirectory = ioManager.GetPathInLocalDirectory(assemblyInformationProvider);
 				var telemetryIdFile = ioManager.ResolvePath(
 					ioManager.ConcatPath(
-						ioManager.GetPathInLocalDirectory(assemblyInformationProvider),
+						telemetryIdDirectory,
 						"telemetry.id"));
 
 				Guid telemetryId;
 				if (!await ioManager.FileExists(telemetryIdFile, stoppingToken))
 				{
 					telemetryId = Guid.NewGuid();
+					await ioManager.CreateDirectory(telemetryIdDirectory, stoppingToken);
 					await ioManager.WriteAllBytes(telemetryIdFile, Encoding.UTF8.GetBytes(telemetryId.ToString()), stoppingToken);
 					logger.LogInformation("Generated telemetry ID {telemetryId} and wrote to {file}", telemetryId, telemetryIdFile);
 				}


### PR DESCRIPTION
🆑
Fixed version reporting not working if the user directory for TGS didn't already exist.
/🆑

Merging with `[TGSDeploy]`