### PR TITLE
Allow DMAPI Validation to be fully skipped

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -5,10 +5,10 @@
   <PropertyGroup>
     <TgsCoreVersion>6.10.0</TgsCoreVersion>
     <TgsConfigVersion>5.2.0</TgsConfigVersion>
-    <TgsApiVersion>10.8.0</TgsApiVersion>
+    <TgsApiVersion>10.9.0</TgsApiVersion>
     <TgsCommonLibraryVersion>7.0.0</TgsCommonLibraryVersion>
-    <TgsApiLibraryVersion>14.0.0</TgsApiLibraryVersion>
-    <TgsClientVersion>17.0.0</TgsClientVersion>
+    <TgsApiLibraryVersion>14.1.0</TgsApiLibraryVersion>
+    <TgsClientVersion>17.1.0</TgsClientVersion>
     <TgsDmapiVersion>7.3.0</TgsDmapiVersion>
     <TgsInteropVersion>5.10.0</TgsInteropVersion>
     <TgsHostWatchdogVersion>1.5.0</TgsHostWatchdogVersion>

--- a/src/Tgstation.Server.Api/Models/DMApiValidationMode.cs
+++ b/src/Tgstation.Server.Api/Models/DMApiValidationMode.cs
@@ -1,0 +1,23 @@
+﻿namespace Tgstation.Server.Api.Models
+{
+	/// <summary>
+	/// The DMAPI validation setting for deployments.
+	/// </summary>
+	public enum DMApiValidationMode
+	{
+		/// <summary>
+		/// DMAPI validation is performed but not required for the deployment to succeed.
+		/// </summary>
+		Optional,
+
+		/// <summary>
+		/// DMAPI validation must suceed for the deployment to succeed.
+		/// </summary>
+		Required,
+
+		/// <summary>
+		/// DMAPI validation will not be performed and no DMAPI features will be available in the deployment.
+		/// </summary>
+		Skipped,
+	}
+}

--- a/src/Tgstation.Server.Api/Models/Internal/DreamMakerSettings.cs
+++ b/src/Tgstation.Server.Api/Models/Internal/DreamMakerSettings.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Tgstation.Server.Api.Models.Internal
 {
@@ -29,10 +30,18 @@ namespace Tgstation.Server.Api.Models.Internal
 		public DreamDaemonSecurity? ApiValidationSecurityLevel { get; set; }
 
 		/// <summary>
-		/// If API validation should be required for a deployment to succeed.
+		/// If API validation should be required for a deployment to succeed. Must not be set on mutation if <see cref="DMApiValidationMode"/> is set.
 		/// </summary>
 		[Required]
+		[NotMapped]
+		[Obsolete($"Use {nameof(DMApiValidationMode)} instead.")]
 		public bool? RequireDMApiValidation { get; set; }
+
+		/// <summary>
+		/// The current <see cref="Models.DMApiValidationMode"/>. Must not be set on mutation if <see cref="RequireDMApiValidation"/> is set.
+		/// </summary>
+		[Required]
+		public DMApiValidationMode? DMApiValidationMode { get; set; }
 
 		/// <summary>
 		/// Amount of time before an in-progress deployment is cancelled.

--- a/src/Tgstation.Server.Api/Rights/DreamMakerRights.cs
+++ b/src/Tgstation.Server.Api/Rights/DreamMakerRights.cs
@@ -49,7 +49,7 @@ namespace Tgstation.Server.Api.Rights
 		SetSecurityLevel = 1 << 6,
 
 		/// <summary>
-		/// User may modify <see cref="Models.Internal.DreamMakerSettings.RequireDMApiValidation"/>.
+		/// User may modify <see cref="Models.Internal.DreamMakerSettings.DMApiValidationMode"/> and <see cref="Models.Internal.DreamMakerSettings.RequireDMApiValidation"/>.
 		/// </summary>
 		SetApiValidationRequirement = 1 << 7,
 

--- a/src/Tgstation.Server.Host/Controllers/DreamMakerController.cs
+++ b/src/Tgstation.Server.Host/Controllers/DreamMakerController.cs
@@ -236,12 +236,28 @@ namespace Tgstation.Server.Host.Controllers
 				hostModel.ApiValidationSecurityLevel = model.ApiValidationSecurityLevel;
 			}
 
-			if (model.RequireDMApiValidation.HasValue)
+#pragma warning disable CS0618 // Type or member is obsolete
+			bool? legacyRequireDMApiValidation = model.RequireDMApiValidation;
+#pragma warning restore CS0618 // Type or member is obsolete
+			if (legacyRequireDMApiValidation.HasValue)
 			{
 				if (!dreamMakerRights.HasFlag(DreamMakerRights.SetApiValidationRequirement))
 					return Forbid();
 
-				hostModel.RequireDMApiValidation = model.RequireDMApiValidation;
+				hostModel.DMApiValidationMode = legacyRequireDMApiValidation.Value
+					? DMApiValidationMode.Required
+					: DMApiValidationMode.Optional;
+			}
+
+			if (model.DMApiValidationMode.HasValue)
+			{
+				if (legacyRequireDMApiValidation.HasValue)
+					return BadRequest(new ErrorMessageResponse(ErrorCode.ModelValidationFailure));
+
+				if (!dreamMakerRights.HasFlag(DreamMakerRights.SetApiValidationRequirement))
+					return Forbid();
+
+				hostModel.DMApiValidationMode = model.DMApiValidationMode;
 			}
 
 			if (model.Timeout.HasValue)

--- a/src/Tgstation.Server.Host/Controllers/InstanceController.cs
+++ b/src/Tgstation.Server.Host/Controllers/InstanceController.cs
@@ -760,7 +760,7 @@ namespace Tgstation.Server.Host.Controllers
 				{
 					ApiValidationPort = dmPort,
 					ApiValidationSecurityLevel = DreamDaemonSecurity.Safe,
-					RequireDMApiValidation = true,
+					DMApiValidationMode = DMApiValidationMode.Required,
 					Timeout = TimeSpan.FromHours(1),
 					CompilerAdditionalArguments = null,
 				},

--- a/src/Tgstation.Server.Host/Database/Migrations/20240907172236_MSAddDMApiValidationMode.Designer.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20240907172236_MSAddDMApiValidationMode.Designer.cs
@@ -3,49 +3,56 @@ using System;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Tgstation.Server.Host.Database.Migrations
 {
-	[DbContext(typeof(SqliteDatabaseContext))]
-	partial class SqliteDatabaseContextModelSnapshot : ModelSnapshot
+	[DbContext(typeof(SqlServerDatabaseContext))]
+	[Migration("20240907172236_MSAddDMApiValidationMode")]
+	partial class MSAddDMApiValidationMode
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		/// <inheritdoc />
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
-			modelBuilder.HasAnnotation("ProductVersion", "8.0.8");
+			modelBuilder
+				.HasAnnotation("ProductVersion", "8.0.8")
+				.HasAnnotation("Relational:MaxIdentifierLength", 128);
+
+			SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.ChatBot", b =>
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
-				b.Property<ushort?>("ChannelLimit")
-					.IsRequired()
-					.HasColumnType("INTEGER");
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
+
+				b.Property<int>("ChannelLimit")
+					.HasColumnType("int");
 
 				b.Property<string>("ConnectionString")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("TEXT");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<bool?>("Enabled")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bit");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("TEXT");
+					.HasColumnType("nvarchar(100)");
 
 				b.Property<int>("Provider")
-					.HasColumnType("INTEGER");
+					.HasColumnType("int");
 
-				b.Property<uint?>("ReconnectionInterval")
-					.IsRequired()
-					.HasColumnType("INTEGER");
+				b.Property<long>("ReconnectionInterval")
+					.HasColumnType("bigint");
 
 				b.HasKey("Id");
 
@@ -59,45 +66,49 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<long>("ChatSettingsId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
-				b.Property<ulong?>("DiscordChannelId")
-					.HasColumnType("INTEGER");
+				b.Property<decimal?>("DiscordChannelId")
+					.HasColumnType("decimal(20,0)");
 
 				b.Property<string>("IrcChannel")
 					.HasMaxLength(100)
-					.HasColumnType("TEXT");
+					.HasColumnType("nvarchar(100)");
 
 				b.Property<bool?>("IsAdminChannel")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bit");
 
 				b.Property<bool?>("IsSystemChannel")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bit");
 
 				b.Property<bool?>("IsUpdatesChannel")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bit");
 
 				b.Property<bool?>("IsWatchdogChannel")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bit");
 
 				b.Property<string>("Tag")
 					.HasMaxLength(10000)
-					.HasColumnType("TEXT");
+					.HasColumnType("nvarchar(max)");
 
 				b.HasKey("Id");
 
 				b.HasIndex("ChatSettingsId", "DiscordChannelId")
-					.IsUnique();
+					.IsUnique()
+					.HasFilter("[DiscordChannelId] IS NOT NULL");
 
 				b.HasIndex("ChatSettingsId", "IrcChannel")
-					.IsUnique();
+					.IsUnique()
+					.HasFilter("[IrcChannel] IS NOT NULL");
 
 				b.ToTable("ChatChannels");
 			});
@@ -106,50 +117,52 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<int?>("DMApiMajorVersion")
-					.HasColumnType("INTEGER");
+					.HasColumnType("int");
 
 				b.Property<int?>("DMApiMinorVersion")
-					.HasColumnType("INTEGER");
+					.HasColumnType("int");
 
 				b.Property<int?>("DMApiPatchVersion")
-					.HasColumnType("INTEGER");
+					.HasColumnType("int");
 
 				b.Property<Guid?>("DirectoryName")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("uniqueidentifier");
 
 				b.Property<string>("DmeName")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<string>("EngineVersion")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<long?>("GitHubDeploymentId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<long?>("GitHubRepoId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<long>("JobId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<int?>("MinimumSecurityLevel")
-					.HasColumnType("INTEGER");
+					.HasColumnType("int");
 
 				b.Property<string>("Output")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<string>("RepositoryOrigin")
-					.HasColumnType("TEXT");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<long>("RevisionInformationId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.HasKey("Id");
 
@@ -167,69 +180,65 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<string>("AdditionalParameters")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("TEXT");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<bool?>("AllowWebClient")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bit");
 
 				b.Property<bool?>("AutoStart")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bit");
 
 				b.Property<bool?>("DumpOnHealthCheckRestart")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bit");
 
-				b.Property<uint?>("HealthCheckSeconds")
-					.IsRequired()
-					.HasColumnType("INTEGER");
+				b.Property<long>("HealthCheckSeconds")
+					.HasColumnType("bigint");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<bool?>("LogOutput")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bit");
 
-				b.Property<uint?>("MapThreads")
-					.IsRequired()
-					.HasColumnType("INTEGER");
+				b.Property<long>("MapThreads")
+					.HasColumnType("bigint");
 
 				b.Property<bool?>("Minidumps")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bit");
 
-				b.Property<ushort?>("OpenDreamTopicPort")
-					.IsRequired()
-					.HasColumnType("INTEGER");
+				b.Property<int>("OpenDreamTopicPort")
+					.HasColumnType("int");
 
-				b.Property<ushort?>("Port")
-					.IsRequired()
-					.HasColumnType("INTEGER");
+				b.Property<int>("Port")
+					.HasColumnType("int");
 
 				b.Property<int>("SecurityLevel")
-					.HasColumnType("INTEGER");
+					.HasColumnType("int");
 
 				b.Property<bool?>("StartProfiler")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bit");
 
-				b.Property<uint?>("StartupTimeout")
-					.IsRequired()
-					.HasColumnType("INTEGER");
+				b.Property<long>("StartupTimeout")
+					.HasColumnType("bigint");
 
-				b.Property<uint?>("TopicRequestTimeout")
-					.IsRequired()
-					.HasColumnType("INTEGER");
+				b.Property<long>("TopicRequestTimeout")
+					.HasColumnType("bigint");
 
 				b.Property<int>("Visibility")
-					.HasColumnType("INTEGER");
+					.HasColumnType("int");
 
 				b.HasKey("Id");
 
@@ -243,32 +252,33 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
-				b.Property<ushort?>("ApiValidationPort")
-					.IsRequired()
-					.HasColumnType("INTEGER");
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
+
+				b.Property<int>("ApiValidationPort")
+					.HasColumnType("int");
 
 				b.Property<int>("ApiValidationSecurityLevel")
-					.HasColumnType("INTEGER");
+					.HasColumnType("int");
 
 				b.Property<string>("CompilerAdditionalArguments")
 					.HasMaxLength(10000)
-					.HasColumnType("TEXT");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<int>("DMApiValidationMode")
-					.HasColumnType("INTEGER");
+					.HasColumnType("int");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<string>("ProjectName")
 					.HasMaxLength(10000)
-					.HasColumnType("TEXT");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<TimeSpan?>("Timeout")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("time");
 
 				b.HasKey("Id");
 
@@ -282,44 +292,45 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<string>("AutoUpdateCron")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("TEXT");
+					.HasColumnType("nvarchar(max)");
 
-				b.Property<uint?>("AutoUpdateInterval")
-					.IsRequired()
-					.HasColumnType("INTEGER");
+				b.Property<long>("AutoUpdateInterval")
+					.HasColumnType("bigint");
 
-				b.Property<ushort?>("ChatBotLimit")
-					.IsRequired()
-					.HasColumnType("INTEGER");
+				b.Property<int>("ChatBotLimit")
+					.HasColumnType("int");
 
 				b.Property<int>("ConfigurationType")
-					.HasColumnType("INTEGER");
+					.HasColumnType("int");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("TEXT");
+					.HasColumnType("nvarchar(100)");
 
 				b.Property<bool?>("Online")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bit");
 
 				b.Property<string>("Path")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("nvarchar(450)");
 
 				b.Property<string>("SwarmIdentifer")
-					.HasColumnType("TEXT");
+					.HasColumnType("nvarchar(450)");
 
 				b.HasKey("Id");
 
 				b.HasIndex("Path", "SwarmIdentifer")
-					.IsUnique();
+					.IsUnique()
+					.HasFilter("[SwarmIdentifer] IS NOT NULL");
 
 				b.ToTable("Instances");
 			});
@@ -328,34 +339,36 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
-				b.Property<ulong>("ChatBotRights")
-					.HasColumnType("INTEGER");
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
 
-				b.Property<ulong>("ConfigurationRights")
-					.HasColumnType("INTEGER");
+				b.Property<decimal>("ChatBotRights")
+					.HasColumnType("decimal(20,0)");
 
-				b.Property<ulong>("DreamDaemonRights")
-					.HasColumnType("INTEGER");
+				b.Property<decimal>("ConfigurationRights")
+					.HasColumnType("decimal(20,0)");
 
-				b.Property<ulong>("DreamMakerRights")
-					.HasColumnType("INTEGER");
+				b.Property<decimal>("DreamDaemonRights")
+					.HasColumnType("decimal(20,0)");
 
-				b.Property<ulong>("EngineRights")
-					.HasColumnType("INTEGER");
+				b.Property<decimal>("DreamMakerRights")
+					.HasColumnType("decimal(20,0)");
+
+				b.Property<decimal>("EngineRights")
+					.HasColumnType("decimal(20,0)");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
-				b.Property<ulong>("InstancePermissionSetRights")
-					.HasColumnType("INTEGER");
+				b.Property<decimal>("InstancePermissionSetRights")
+					.HasColumnType("decimal(20,0)");
 
 				b.Property<long>("PermissionSetId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
-				b.Property<ulong>("RepositoryRights")
-					.HasColumnType("INTEGER");
+				b.Property<decimal>("RepositoryRights")
+					.HasColumnType("decimal(20,0)");
 
 				b.HasKey("Id");
 
@@ -371,46 +384,48 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
-				b.Property<ulong?>("CancelRight")
-					.HasColumnType("INTEGER");
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
 
-				b.Property<ulong?>("CancelRightsType")
-					.HasColumnType("INTEGER");
+				b.Property<decimal?>("CancelRight")
+					.HasColumnType("decimal(20,0)");
+
+				b.Property<decimal?>("CancelRightsType")
+					.HasColumnType("decimal(20,0)");
 
 				b.Property<bool?>("Cancelled")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bit");
 
 				b.Property<long?>("CancelledById")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<string>("Description")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("nvarchar(max)");
 
-				b.Property<uint?>("ErrorCode")
-					.HasColumnType("INTEGER");
+				b.Property<long?>("ErrorCode")
+					.HasColumnType("bigint");
 
 				b.Property<string>("ExceptionDetails")
-					.HasColumnType("TEXT");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<byte>("JobCode")
-					.HasColumnType("INTEGER");
+					.HasColumnType("tinyint");
 
 				b.Property<DateTimeOffset?>("StartedAt")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("datetimeoffset");
 
 				b.Property<long>("StartedById")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<DateTimeOffset?>("StoppedAt")
-					.HasColumnType("TEXT");
+					.HasColumnType("datetimeoffset");
 
 				b.HasKey("Id");
 
@@ -427,18 +442,20 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<string>("ExternalUserId")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("TEXT");
+					.HasColumnType("nvarchar(100)");
 
 				b.Property<int>("Provider")
-					.HasColumnType("INTEGER");
+					.HasColumnType("int");
 
 				b.Property<long?>("UserId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.HasKey("Id");
 
@@ -454,27 +471,31 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
-				b.Property<ulong>("AdministrationRights")
-					.HasColumnType("INTEGER");
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
+
+				b.Property<decimal>("AdministrationRights")
+					.HasColumnType("decimal(20,0)");
 
 				b.Property<long?>("GroupId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
-				b.Property<ulong>("InstanceManagerRights")
-					.HasColumnType("INTEGER");
+				b.Property<decimal>("InstanceManagerRights")
+					.HasColumnType("decimal(20,0)");
 
 				b.Property<long?>("UserId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.HasKey("Id");
 
 				b.HasIndex("GroupId")
-					.IsUnique();
+					.IsUnique()
+					.HasFilter("[GroupId] IS NOT NULL");
 
 				b.HasIndex("UserId")
-					.IsUnique();
+					.IsUnique()
+					.HasFilter("[UserId] IS NOT NULL");
 
 				b.ToTable("PermissionSets");
 			});
@@ -483,35 +504,37 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<string>("AccessIdentifier")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<long>("CompileJobId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<long?>("InitialCompileJobId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<int>("LaunchSecurityLevel")
-					.HasColumnType("INTEGER");
+					.HasColumnType("int");
 
 				b.Property<int>("LaunchVisibility")
-					.HasColumnType("INTEGER");
+					.HasColumnType("int");
 
-				b.Property<ushort>("Port")
-					.HasColumnType("INTEGER");
+				b.Property<int>("Port")
+					.HasColumnType("int");
 
 				b.Property<int>("ProcessId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("int");
 
 				b.Property<int>("RebootState")
-					.HasColumnType("INTEGER");
+					.HasColumnType("int");
 
-				b.Property<ushort?>("TopicPort")
-					.HasColumnType("INTEGER");
+				b.Property<int?>("TopicPort")
+					.HasColumnType("int");
 
 				b.HasKey("Id");
 
@@ -526,56 +549,58 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<string>("AccessToken")
 					.HasMaxLength(10000)
-					.HasColumnType("TEXT");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<string>("AccessUser")
 					.HasMaxLength(10000)
-					.HasColumnType("TEXT");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<bool?>("AutoUpdatesKeepTestMerges")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bit");
 
 				b.Property<bool?>("AutoUpdatesSynchronize")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bit");
 
 				b.Property<string>("CommitterEmail")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("TEXT");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<string>("CommitterName")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("TEXT");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<bool?>("CreateGitHubDeployments")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bit");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<bool?>("PostTestMergeComment")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bit");
 
 				b.Property<bool?>("PushTestMergeCommits")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bit");
 
 				b.Property<bool?>("ShowTestMergeCommitters")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bit");
 
 				b.Property<bool?>("UpdateSubmodules")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bit");
 
 				b.HasKey("Id");
 
@@ -589,13 +614,15 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<long>("RevisionInformationId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<long>("TestMergeId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.HasKey("Id");
 
@@ -610,23 +637,25 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<string>("CommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("TEXT");
+					.HasColumnType("nvarchar(40)");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<string>("OriginCommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("TEXT");
+					.HasColumnType("nvarchar(40)");
 
 				b.Property<DateTimeOffset>("Timestamp")
-					.HasColumnType("TEXT");
+					.HasColumnType("datetimeoffset");
 
 				b.HasKey("Id");
 
@@ -640,45 +669,47 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<string>("Author")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<string>("BodyAtMerge")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<string>("Comment")
 					.HasMaxLength(10000)
-					.HasColumnType("TEXT");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<DateTimeOffset>("MergedAt")
-					.HasColumnType("TEXT");
+					.HasColumnType("datetimeoffset");
 
 				b.Property<long>("MergedById")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<int>("Number")
-					.HasColumnType("INTEGER");
+					.HasColumnType("int");
 
 				b.Property<long?>("PrimaryRevisionInformationId")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<string>("TargetCommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("TEXT");
+					.HasColumnType("nvarchar(40)");
 
 				b.Property<string>("TitleAtMerge")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<string>("Url")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("nvarchar(max)");
 
 				b.HasKey("Id");
 
@@ -694,41 +725,43 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<string>("CanonicalName")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("TEXT");
+					.HasColumnType("nvarchar(100)");
 
 				b.Property<DateTimeOffset?>("CreatedAt")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("datetimeoffset");
 
 				b.Property<long?>("CreatedById")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<bool?>("Enabled")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bit");
 
 				b.Property<long?>("GroupId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<DateTimeOffset?>("LastPasswordUpdate")
-					.HasColumnType("TEXT");
+					.HasColumnType("datetimeoffset");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("TEXT");
+					.HasColumnType("nvarchar(100)");
 
 				b.Property<string>("PasswordHash")
-					.HasColumnType("TEXT");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<string>("SystemIdentifier")
 					.HasMaxLength(100)
-					.HasColumnType("TEXT");
+					.HasColumnType("nvarchar(100)");
 
 				b.HasKey("Id");
 
@@ -740,7 +773,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.HasIndex("GroupId");
 
 				b.HasIndex("SystemIdentifier")
-					.IsUnique();
+					.IsUnique()
+					.HasFilter("[SystemIdentifier] IS NOT NULL");
 
 				b.ToTable("Users");
 			});
@@ -749,12 +783,14 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("TEXT");
+					.HasColumnType("nvarchar(100)");
 
 				b.HasKey("Id");
 

--- a/src/Tgstation.Server.Host/Database/Migrations/20240907172236_MSAddDMApiValidationMode.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20240907172236_MSAddDMApiValidationMode.cs
@@ -1,0 +1,49 @@
+﻿using System;
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Tgstation.Server.Host.Database.Migrations
+{
+	/// <inheritdoc />
+	public partial class MSAddDMApiValidationMode : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+			migrationBuilder.AddColumn<int>(
+				name: "DMApiValidationMode",
+				table: "DreamMakerSettings",
+				type: "int",
+				nullable: false,
+				defaultValue: 0);
+
+			migrationBuilder.Sql("UPDATE DreamMakerSettings SET DMApiValidationMode = RequireDMApiValidation");
+
+			migrationBuilder.DropColumn(
+				name: "RequireDMApiValidation",
+				table: "DreamMakerSettings");
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+			migrationBuilder.AddColumn<bool>(
+				name: "RequireDMApiValidation",
+				table: "DreamMakerSettings",
+				type: "bit",
+				nullable: false,
+				defaultValue: false);
+
+			migrationBuilder.Sql("UPDATE DreamMakerSettings SET RequireDMApiValidation = 1 WHERE DMApiValidationMode != 0");
+			migrationBuilder.Sql("UPDATE DreamMakerSettings SET RequireDMApiValidation = 0 WHERE DMApiValidationMode = 0");
+
+			migrationBuilder.DropColumn(
+				name: "DMApiValidationMode",
+				table: "DreamMakerSettings");
+		}
+	}
+}

--- a/src/Tgstation.Server.Host/Database/Migrations/20240907172244_MYAddDMApiValidationMode.Designer.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20240907172244_MYAddDMApiValidationMode.Designer.cs
@@ -3,49 +3,60 @@ using System;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Tgstation.Server.Host.Database.Migrations
 {
-	[DbContext(typeof(SqliteDatabaseContext))]
-	partial class SqliteDatabaseContextModelSnapshot : ModelSnapshot
+	[DbContext(typeof(MySqlDatabaseContext))]
+	[Migration("20240907172244_MYAddDMApiValidationMode")]
+	partial class MYAddDMApiValidationMode
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		/// <inheritdoc />
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
-			modelBuilder.HasAnnotation("ProductVersion", "8.0.8");
+			modelBuilder
+				.HasAnnotation("ProductVersion", "8.0.8")
+				.HasAnnotation("Relational:MaxIdentifierLength", 64);
+
+			MySqlModelBuilderExtensions.AutoIncrementColumns(modelBuilder);
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.ChatBot", b =>
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<ushort?>("ChannelLimit")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("smallint unsigned");
 
 				b.Property<string>("ConnectionString")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("TEXT");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("ConnectionString"), "utf8mb4");
 
 				b.Property<bool?>("Enabled")
-					.HasColumnType("INTEGER");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("TEXT");
+					.HasColumnType("varchar(100)");
 
 				b.Property<int>("Provider")
-					.HasColumnType("INTEGER");
+					.HasColumnType("int");
 
 				b.Property<uint?>("ReconnectionInterval")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("int unsigned");
 
 				b.HasKey("Id");
 
@@ -59,37 +70,43 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<long>("ChatSettingsId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<ulong?>("DiscordChannelId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint unsigned");
 
 				b.Property<string>("IrcChannel")
 					.HasMaxLength(100)
-					.HasColumnType("TEXT");
+					.HasColumnType("varchar(100)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("IrcChannel"), "utf8mb4");
 
 				b.Property<bool?>("IsAdminChannel")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("IsSystemChannel")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("IsUpdatesChannel")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("IsWatchdogChannel")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<string>("Tag")
 					.HasMaxLength(10000)
-					.HasColumnType("TEXT");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Tag"), "utf8mb4");
 
 				b.HasKey("Id");
 
@@ -106,50 +123,60 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<int?>("DMApiMajorVersion")
-					.HasColumnType("INTEGER");
+					.HasColumnType("int");
 
 				b.Property<int?>("DMApiMinorVersion")
-					.HasColumnType("INTEGER");
+					.HasColumnType("int");
 
 				b.Property<int?>("DMApiPatchVersion")
-					.HasColumnType("INTEGER");
+					.HasColumnType("int");
 
 				b.Property<Guid?>("DirectoryName")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("char(36)");
 
 				b.Property<string>("DmeName")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("DmeName"), "utf8mb4");
 
 				b.Property<string>("EngineVersion")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("EngineVersion"), "utf8mb4");
 
 				b.Property<long?>("GitHubDeploymentId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<long?>("GitHubRepoId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<long>("JobId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<int?>("MinimumSecurityLevel")
-					.HasColumnType("INTEGER");
+					.HasColumnType("int");
 
 				b.Property<string>("Output")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Output"), "utf8mb4");
 
 				b.Property<string>("RepositoryOrigin")
-					.HasColumnType("TEXT");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("RepositoryOrigin"), "utf8mb4");
 
 				b.Property<long>("RevisionInformationId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.HasKey("Id");
 
@@ -167,69 +194,73 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<string>("AdditionalParameters")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("TEXT");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("AdditionalParameters"), "utf8mb4");
 
 				b.Property<bool?>("AllowWebClient")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("AutoStart")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("DumpOnHealthCheckRestart")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<uint?>("HealthCheckSeconds")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("int unsigned");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<bool?>("LogOutput")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<uint?>("MapThreads")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("int unsigned");
 
 				b.Property<bool?>("Minidumps")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<ushort?>("OpenDreamTopicPort")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("smallint unsigned");
 
 				b.Property<ushort?>("Port")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("smallint unsigned");
 
 				b.Property<int>("SecurityLevel")
-					.HasColumnType("INTEGER");
+					.HasColumnType("int");
 
 				b.Property<bool?>("StartProfiler")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<uint?>("StartupTimeout")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("int unsigned");
 
 				b.Property<uint?>("TopicRequestTimeout")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("int unsigned");
 
 				b.Property<int>("Visibility")
-					.HasColumnType("INTEGER");
+					.HasColumnType("int");
 
 				b.HasKey("Id");
 
@@ -243,32 +274,36 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<ushort?>("ApiValidationPort")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("smallint unsigned");
 
 				b.Property<int>("ApiValidationSecurityLevel")
-					.HasColumnType("INTEGER");
+					.HasColumnType("int");
 
 				b.Property<string>("CompilerAdditionalArguments")
 					.HasMaxLength(10000)
-					.HasColumnType("TEXT");
+					.HasColumnType("varchar(10000)");
 
 				b.Property<int>("DMApiValidationMode")
-					.HasColumnType("INTEGER");
+					.HasColumnType("int");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<string>("ProjectName")
 					.HasMaxLength(10000)
-					.HasColumnType("TEXT");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("ProjectName"), "utf8mb4");
 
 				b.Property<TimeSpan?>("Timeout")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("time(6)");
 
 				b.HasKey("Id");
 
@@ -282,39 +317,47 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<string>("AutoUpdateCron")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("TEXT");
+					.HasColumnType("varchar(10000)");
 
 				b.Property<uint?>("AutoUpdateInterval")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("int unsigned");
 
 				b.Property<ushort?>("ChatBotLimit")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("smallint unsigned");
 
 				b.Property<int>("ConfigurationType")
-					.HasColumnType("INTEGER");
+					.HasColumnType("int");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("TEXT");
+					.HasColumnType("varchar(100)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Name"), "utf8mb4");
 
 				b.Property<bool?>("Online")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<string>("Path")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("varchar(255)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Path"), "utf8mb4");
 
 				b.Property<string>("SwarmIdentifer")
-					.HasColumnType("TEXT");
+					.HasColumnType("varchar(255)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("SwarmIdentifer"), "utf8mb4");
 
 				b.HasKey("Id");
 
@@ -328,34 +371,36 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<ulong>("ChatBotRights")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint unsigned");
 
 				b.Property<ulong>("ConfigurationRights")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint unsigned");
 
 				b.Property<ulong>("DreamDaemonRights")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint unsigned");
 
 				b.Property<ulong>("DreamMakerRights")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint unsigned");
 
 				b.Property<ulong>("EngineRights")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint unsigned");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<ulong>("InstancePermissionSetRights")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint unsigned");
 
 				b.Property<long>("PermissionSetId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<ulong>("RepositoryRights")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint unsigned");
 
 				b.HasKey("Id");
 
@@ -371,46 +416,52 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<ulong?>("CancelRight")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint unsigned");
 
 				b.Property<ulong?>("CancelRightsType")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint unsigned");
 
 				b.Property<bool?>("Cancelled")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<long?>("CancelledById")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<string>("Description")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Description"), "utf8mb4");
 
 				b.Property<uint?>("ErrorCode")
-					.HasColumnType("INTEGER");
+					.HasColumnType("int unsigned");
 
 				b.Property<string>("ExceptionDetails")
-					.HasColumnType("TEXT");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("ExceptionDetails"), "utf8mb4");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<byte>("JobCode")
-					.HasColumnType("INTEGER");
+					.HasColumnType("tinyint unsigned");
 
 				b.Property<DateTimeOffset?>("StartedAt")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("datetime(6)");
 
 				b.Property<long>("StartedById")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<DateTimeOffset?>("StoppedAt")
-					.HasColumnType("TEXT");
+					.HasColumnType("datetime(6)");
 
 				b.HasKey("Id");
 
@@ -427,18 +478,22 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<string>("ExternalUserId")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("TEXT");
+					.HasColumnType("varchar(100)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("ExternalUserId"), "utf8mb4");
 
 				b.Property<int>("Provider")
-					.HasColumnType("INTEGER");
+					.HasColumnType("int");
 
 				b.Property<long?>("UserId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.HasKey("Id");
 
@@ -454,19 +509,21 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<ulong>("AdministrationRights")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint unsigned");
 
 				b.Property<long?>("GroupId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<ulong>("InstanceManagerRights")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint unsigned");
 
 				b.Property<long?>("UserId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.HasKey("Id");
 
@@ -483,35 +540,39 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<string>("AccessIdentifier")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("AccessIdentifier"), "utf8mb4");
 
 				b.Property<long>("CompileJobId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<long?>("InitialCompileJobId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<int>("LaunchSecurityLevel")
-					.HasColumnType("INTEGER");
+					.HasColumnType("int");
 
 				b.Property<int>("LaunchVisibility")
-					.HasColumnType("INTEGER");
+					.HasColumnType("int");
 
 				b.Property<ushort>("Port")
-					.HasColumnType("INTEGER");
+					.HasColumnType("smallint unsigned");
 
 				b.Property<int>("ProcessId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("int");
 
 				b.Property<int>("RebootState")
-					.HasColumnType("INTEGER");
+					.HasColumnType("int");
 
 				b.Property<ushort?>("TopicPort")
-					.HasColumnType("INTEGER");
+					.HasColumnType("smallint unsigned");
 
 				b.HasKey("Id");
 
@@ -526,56 +587,66 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<string>("AccessToken")
 					.HasMaxLength(10000)
-					.HasColumnType("TEXT");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("AccessToken"), "utf8mb4");
 
 				b.Property<string>("AccessUser")
 					.HasMaxLength(10000)
-					.HasColumnType("TEXT");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("AccessUser"), "utf8mb4");
 
 				b.Property<bool?>("AutoUpdatesKeepTestMerges")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("AutoUpdatesSynchronize")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<string>("CommitterEmail")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("TEXT");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("CommitterEmail"), "utf8mb4");
 
 				b.Property<string>("CommitterName")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("TEXT");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("CommitterName"), "utf8mb4");
 
 				b.Property<bool?>("CreateGitHubDeployments")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<bool?>("PostTestMergeComment")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("PushTestMergeCommits")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("ShowTestMergeCommitters")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("UpdateSubmodules")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("tinyint(1)");
 
 				b.HasKey("Id");
 
@@ -589,13 +660,15 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<long>("RevisionInformationId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<long>("TestMergeId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.HasKey("Id");
 
@@ -610,23 +683,29 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<string>("CommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("TEXT");
+					.HasColumnType("varchar(40)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("CommitSha"), "utf8mb4");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<string>("OriginCommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("TEXT");
+					.HasColumnType("varchar(40)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("OriginCommitSha"), "utf8mb4");
 
 				b.Property<DateTimeOffset>("Timestamp")
-					.HasColumnType("TEXT");
+					.HasColumnType("datetime(6)");
 
 				b.HasKey("Id");
 
@@ -640,45 +719,59 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<string>("Author")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Author"), "utf8mb4");
 
 				b.Property<string>("BodyAtMerge")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("BodyAtMerge"), "utf8mb4");
 
 				b.Property<string>("Comment")
 					.HasMaxLength(10000)
-					.HasColumnType("TEXT");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Comment"), "utf8mb4");
 
 				b.Property<DateTimeOffset>("MergedAt")
-					.HasColumnType("TEXT");
+					.HasColumnType("datetime(6)");
 
 				b.Property<long>("MergedById")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<int>("Number")
-					.HasColumnType("INTEGER");
+					.HasColumnType("int");
 
 				b.Property<long?>("PrimaryRevisionInformationId")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<string>("TargetCommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("TEXT");
+					.HasColumnType("varchar(40)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("TargetCommitSha"), "utf8mb4");
 
 				b.Property<string>("TitleAtMerge")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("TitleAtMerge"), "utf8mb4");
 
 				b.Property<string>("Url")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Url"), "utf8mb4");
 
 				b.HasKey("Id");
 
@@ -694,41 +787,51 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<string>("CanonicalName")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("TEXT");
+					.HasColumnType("varchar(100)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("CanonicalName"), "utf8mb4");
 
 				b.Property<DateTimeOffset?>("CreatedAt")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("datetime(6)");
 
 				b.Property<long?>("CreatedById")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<bool?>("Enabled")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<long?>("GroupId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<DateTimeOffset?>("LastPasswordUpdate")
-					.HasColumnType("TEXT");
+					.HasColumnType("datetime(6)");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("TEXT");
+					.HasColumnType("varchar(100)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Name"), "utf8mb4");
 
 				b.Property<string>("PasswordHash")
-					.HasColumnType("TEXT");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("PasswordHash"), "utf8mb4");
 
 				b.Property<string>("SystemIdentifier")
 					.HasMaxLength(100)
-					.HasColumnType("TEXT");
+					.HasColumnType("varchar(100)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("SystemIdentifier"), "utf8mb4");
 
 				b.HasKey("Id");
 
@@ -749,12 +852,16 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("TEXT");
+					.HasColumnType("varchar(100)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Name"), "utf8mb4");
 
 				b.HasKey("Id");
 
@@ -797,7 +904,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.HasOne("Tgstation.Server.Host.Models.RevisionInformation", "RevisionInformation")
 					.WithMany("CompileJobs")
 					.HasForeignKey("RevisionInformationId")
-					.OnDelete(DeleteBehavior.ClientNoAction)
+					.OnDelete(DeleteBehavior.Cascade)
 					.IsRequired();
 
 				b.Navigation("Job");

--- a/src/Tgstation.Server.Host/Database/Migrations/20240907172244_MYAddDMApiValidationMode.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20240907172244_MYAddDMApiValidationMode.cs
@@ -1,0 +1,49 @@
+﻿using System;
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Tgstation.Server.Host.Database.Migrations
+{
+	/// <inheritdoc />
+	public partial class MYAddDMApiValidationMode : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+			migrationBuilder.AddColumn<int>(
+				name: "DMApiValidationMode",
+				table: "DreamMakerSettings",
+				type: "int",
+				nullable: false,
+				defaultValue: 0);
+
+			migrationBuilder.Sql("UPDATE DreamMakerSettings SET DMApiValidationMode = RequireDMApiValidation");
+
+			migrationBuilder.DropColumn(
+				name: "RequireDMApiValidation",
+				table: "DreamMakerSettings");
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+			migrationBuilder.AddColumn<bool>(
+				name: "RequireDMApiValidation",
+				table: "DreamMakerSettings",
+				type: "tinyint(1)",
+				nullable: false,
+				defaultValue: false);
+
+			migrationBuilder.Sql("UPDATE DreamMakerSettings SET RequireDMApiValidation = 1 WHERE DMApiValidationMode != 0");
+			migrationBuilder.Sql("UPDATE DreamMakerSettings SET RequireDMApiValidation = 0 WHERE DMApiValidationMode = 0");
+
+			migrationBuilder.DropColumn(
+				name: "DMApiValidationMode",
+				table: "DreamMakerSettings");
+		}
+	}
+}

--- a/src/Tgstation.Server.Host/Database/Migrations/20240907172251_PGAddDMApiValidationMode.Designer.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20240907172251_PGAddDMApiValidationMode.Designer.cs
@@ -3,49 +3,56 @@ using System;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Tgstation.Server.Host.Database.Migrations
 {
-	[DbContext(typeof(SqliteDatabaseContext))]
-	partial class SqliteDatabaseContextModelSnapshot : ModelSnapshot
+	[DbContext(typeof(PostgresSqlDatabaseContext))]
+	[Migration("20240907172251_PGAddDMApiValidationMode")]
+	partial class PGAddDMApiValidationMode
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		/// <inheritdoc />
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
-			modelBuilder.HasAnnotation("ProductVersion", "8.0.8");
+			modelBuilder
+				.HasAnnotation("ProductVersion", "8.0.8")
+				.HasAnnotation("Relational:MaxIdentifierLength", 63);
+
+			NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.ChatBot", b =>
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
-				b.Property<ushort?>("ChannelLimit")
-					.IsRequired()
-					.HasColumnType("INTEGER");
+				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+
+				b.Property<int>("ChannelLimit")
+					.HasColumnType("integer");
 
 				b.Property<string>("ConnectionString")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("TEXT");
+					.HasColumnType("character varying(10000)");
 
 				b.Property<bool?>("Enabled")
-					.HasColumnType("INTEGER");
+					.HasColumnType("boolean");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("TEXT");
+					.HasColumnType("character varying(100)");
 
 				b.Property<int>("Provider")
-					.HasColumnType("INTEGER");
+					.HasColumnType("integer");
 
-				b.Property<uint?>("ReconnectionInterval")
-					.IsRequired()
-					.HasColumnType("INTEGER");
+				b.Property<long>("ReconnectionInterval")
+					.HasColumnType("bigint");
 
 				b.HasKey("Id");
 
@@ -59,37 +66,39 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
 
 				b.Property<long>("ChatSettingsId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
-				b.Property<ulong?>("DiscordChannelId")
-					.HasColumnType("INTEGER");
+				b.Property<decimal?>("DiscordChannelId")
+					.HasColumnType("numeric(20,0)");
 
 				b.Property<string>("IrcChannel")
 					.HasMaxLength(100)
-					.HasColumnType("TEXT");
+					.HasColumnType("character varying(100)");
 
 				b.Property<bool?>("IsAdminChannel")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("boolean");
 
 				b.Property<bool?>("IsSystemChannel")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("boolean");
 
 				b.Property<bool?>("IsUpdatesChannel")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("boolean");
 
 				b.Property<bool?>("IsWatchdogChannel")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("boolean");
 
 				b.Property<string>("Tag")
 					.HasMaxLength(10000)
-					.HasColumnType("TEXT");
+					.HasColumnType("character varying(10000)");
 
 				b.HasKey("Id");
 
@@ -106,50 +115,52 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
 
 				b.Property<int?>("DMApiMajorVersion")
-					.HasColumnType("INTEGER");
+					.HasColumnType("integer");
 
 				b.Property<int?>("DMApiMinorVersion")
-					.HasColumnType("INTEGER");
+					.HasColumnType("integer");
 
 				b.Property<int?>("DMApiPatchVersion")
-					.HasColumnType("INTEGER");
+					.HasColumnType("integer");
 
 				b.Property<Guid?>("DirectoryName")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("uuid");
 
 				b.Property<string>("DmeName")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("text");
 
 				b.Property<string>("EngineVersion")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("text");
 
 				b.Property<long?>("GitHubDeploymentId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<long?>("GitHubRepoId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<long>("JobId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<int?>("MinimumSecurityLevel")
-					.HasColumnType("INTEGER");
+					.HasColumnType("integer");
 
 				b.Property<string>("Output")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("text");
 
 				b.Property<string>("RepositoryOrigin")
-					.HasColumnType("TEXT");
+					.HasColumnType("text");
 
 				b.Property<long>("RevisionInformationId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.HasKey("Id");
 
@@ -167,69 +178,65 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
 
 				b.Property<string>("AdditionalParameters")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("TEXT");
+					.HasColumnType("character varying(10000)");
 
 				b.Property<bool?>("AllowWebClient")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("boolean");
 
 				b.Property<bool?>("AutoStart")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("boolean");
 
 				b.Property<bool?>("DumpOnHealthCheckRestart")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("boolean");
 
-				b.Property<uint?>("HealthCheckSeconds")
-					.IsRequired()
-					.HasColumnType("INTEGER");
+				b.Property<long>("HealthCheckSeconds")
+					.HasColumnType("bigint");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<bool?>("LogOutput")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("boolean");
 
-				b.Property<uint?>("MapThreads")
-					.IsRequired()
-					.HasColumnType("INTEGER");
+				b.Property<long>("MapThreads")
+					.HasColumnType("bigint");
 
 				b.Property<bool?>("Minidumps")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("boolean");
 
-				b.Property<ushort?>("OpenDreamTopicPort")
-					.IsRequired()
-					.HasColumnType("INTEGER");
+				b.Property<int>("OpenDreamTopicPort")
+					.HasColumnType("integer");
 
-				b.Property<ushort?>("Port")
-					.IsRequired()
-					.HasColumnType("INTEGER");
+				b.Property<int>("Port")
+					.HasColumnType("integer");
 
 				b.Property<int>("SecurityLevel")
-					.HasColumnType("INTEGER");
+					.HasColumnType("integer");
 
 				b.Property<bool?>("StartProfiler")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("boolean");
 
-				b.Property<uint?>("StartupTimeout")
-					.IsRequired()
-					.HasColumnType("INTEGER");
+				b.Property<long>("StartupTimeout")
+					.HasColumnType("bigint");
 
-				b.Property<uint?>("TopicRequestTimeout")
-					.IsRequired()
-					.HasColumnType("INTEGER");
+				b.Property<long>("TopicRequestTimeout")
+					.HasColumnType("bigint");
 
 				b.Property<int>("Visibility")
-					.HasColumnType("INTEGER");
+					.HasColumnType("integer");
 
 				b.HasKey("Id");
 
@@ -243,32 +250,33 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
-				b.Property<ushort?>("ApiValidationPort")
-					.IsRequired()
-					.HasColumnType("INTEGER");
+				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+
+				b.Property<int>("ApiValidationPort")
+					.HasColumnType("integer");
 
 				b.Property<int>("ApiValidationSecurityLevel")
-					.HasColumnType("INTEGER");
+					.HasColumnType("integer");
 
 				b.Property<string>("CompilerAdditionalArguments")
 					.HasMaxLength(10000)
-					.HasColumnType("TEXT");
+					.HasColumnType("character varying(10000)");
 
 				b.Property<int>("DMApiValidationMode")
-					.HasColumnType("INTEGER");
+					.HasColumnType("integer");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<string>("ProjectName")
 					.HasMaxLength(10000)
-					.HasColumnType("TEXT");
+					.HasColumnType("character varying(10000)");
 
 				b.Property<TimeSpan?>("Timeout")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("interval");
 
 				b.HasKey("Id");
 
@@ -282,39 +290,39 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
 
 				b.Property<string>("AutoUpdateCron")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("TEXT");
+					.HasColumnType("character varying(10000)");
 
-				b.Property<uint?>("AutoUpdateInterval")
-					.IsRequired()
-					.HasColumnType("INTEGER");
+				b.Property<long>("AutoUpdateInterval")
+					.HasColumnType("bigint");
 
-				b.Property<ushort?>("ChatBotLimit")
-					.IsRequired()
-					.HasColumnType("INTEGER");
+				b.Property<int>("ChatBotLimit")
+					.HasColumnType("integer");
 
 				b.Property<int>("ConfigurationType")
-					.HasColumnType("INTEGER");
+					.HasColumnType("integer");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("TEXT");
+					.HasColumnType("character varying(100)");
 
 				b.Property<bool?>("Online")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("boolean");
 
 				b.Property<string>("Path")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("text");
 
 				b.Property<string>("SwarmIdentifer")
-					.HasColumnType("TEXT");
+					.HasColumnType("text");
 
 				b.HasKey("Id");
 
@@ -328,34 +336,36 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
-				b.Property<ulong>("ChatBotRights")
-					.HasColumnType("INTEGER");
+				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
 
-				b.Property<ulong>("ConfigurationRights")
-					.HasColumnType("INTEGER");
+				b.Property<decimal>("ChatBotRights")
+					.HasColumnType("numeric(20,0)");
 
-				b.Property<ulong>("DreamDaemonRights")
-					.HasColumnType("INTEGER");
+				b.Property<decimal>("ConfigurationRights")
+					.HasColumnType("numeric(20,0)");
 
-				b.Property<ulong>("DreamMakerRights")
-					.HasColumnType("INTEGER");
+				b.Property<decimal>("DreamDaemonRights")
+					.HasColumnType("numeric(20,0)");
 
-				b.Property<ulong>("EngineRights")
-					.HasColumnType("INTEGER");
+				b.Property<decimal>("DreamMakerRights")
+					.HasColumnType("numeric(20,0)");
+
+				b.Property<decimal>("EngineRights")
+					.HasColumnType("numeric(20,0)");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
-				b.Property<ulong>("InstancePermissionSetRights")
-					.HasColumnType("INTEGER");
+				b.Property<decimal>("InstancePermissionSetRights")
+					.HasColumnType("numeric(20,0)");
 
 				b.Property<long>("PermissionSetId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
-				b.Property<ulong>("RepositoryRights")
-					.HasColumnType("INTEGER");
+				b.Property<decimal>("RepositoryRights")
+					.HasColumnType("numeric(20,0)");
 
 				b.HasKey("Id");
 
@@ -371,46 +381,48 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
-				b.Property<ulong?>("CancelRight")
-					.HasColumnType("INTEGER");
+				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
 
-				b.Property<ulong?>("CancelRightsType")
-					.HasColumnType("INTEGER");
+				b.Property<decimal?>("CancelRight")
+					.HasColumnType("numeric(20,0)");
+
+				b.Property<decimal?>("CancelRightsType")
+					.HasColumnType("numeric(20,0)");
 
 				b.Property<bool?>("Cancelled")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("boolean");
 
 				b.Property<long?>("CancelledById")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<string>("Description")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("text");
 
-				b.Property<uint?>("ErrorCode")
-					.HasColumnType("INTEGER");
+				b.Property<long?>("ErrorCode")
+					.HasColumnType("bigint");
 
 				b.Property<string>("ExceptionDetails")
-					.HasColumnType("TEXT");
+					.HasColumnType("text");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<byte>("JobCode")
-					.HasColumnType("INTEGER");
+					.HasColumnType("smallint");
 
 				b.Property<DateTimeOffset?>("StartedAt")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("timestamp with time zone");
 
 				b.Property<long>("StartedById")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<DateTimeOffset?>("StoppedAt")
-					.HasColumnType("TEXT");
+					.HasColumnType("timestamp with time zone");
 
 				b.HasKey("Id");
 
@@ -427,18 +439,20 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
 
 				b.Property<string>("ExternalUserId")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("TEXT");
+					.HasColumnType("character varying(100)");
 
 				b.Property<int>("Provider")
-					.HasColumnType("INTEGER");
+					.HasColumnType("integer");
 
 				b.Property<long?>("UserId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.HasKey("Id");
 
@@ -454,19 +468,21 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
-				b.Property<ulong>("AdministrationRights")
-					.HasColumnType("INTEGER");
+				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+
+				b.Property<decimal>("AdministrationRights")
+					.HasColumnType("numeric(20,0)");
 
 				b.Property<long?>("GroupId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
-				b.Property<ulong>("InstanceManagerRights")
-					.HasColumnType("INTEGER");
+				b.Property<decimal>("InstanceManagerRights")
+					.HasColumnType("numeric(20,0)");
 
 				b.Property<long?>("UserId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.HasKey("Id");
 
@@ -483,35 +499,37 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
 
 				b.Property<string>("AccessIdentifier")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("text");
 
 				b.Property<long>("CompileJobId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<long?>("InitialCompileJobId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<int>("LaunchSecurityLevel")
-					.HasColumnType("INTEGER");
+					.HasColumnType("integer");
 
 				b.Property<int>("LaunchVisibility")
-					.HasColumnType("INTEGER");
+					.HasColumnType("integer");
 
-				b.Property<ushort>("Port")
-					.HasColumnType("INTEGER");
+				b.Property<int>("Port")
+					.HasColumnType("integer");
 
 				b.Property<int>("ProcessId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("integer");
 
 				b.Property<int>("RebootState")
-					.HasColumnType("INTEGER");
+					.HasColumnType("integer");
 
-				b.Property<ushort?>("TopicPort")
-					.HasColumnType("INTEGER");
+				b.Property<int?>("TopicPort")
+					.HasColumnType("integer");
 
 				b.HasKey("Id");
 
@@ -526,56 +544,58 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
 
 				b.Property<string>("AccessToken")
 					.HasMaxLength(10000)
-					.HasColumnType("TEXT");
+					.HasColumnType("character varying(10000)");
 
 				b.Property<string>("AccessUser")
 					.HasMaxLength(10000)
-					.HasColumnType("TEXT");
+					.HasColumnType("character varying(10000)");
 
 				b.Property<bool?>("AutoUpdatesKeepTestMerges")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("boolean");
 
 				b.Property<bool?>("AutoUpdatesSynchronize")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("boolean");
 
 				b.Property<string>("CommitterEmail")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("TEXT");
+					.HasColumnType("character varying(10000)");
 
 				b.Property<string>("CommitterName")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("TEXT");
+					.HasColumnType("character varying(10000)");
 
 				b.Property<bool?>("CreateGitHubDeployments")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("boolean");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<bool?>("PostTestMergeComment")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("boolean");
 
 				b.Property<bool?>("PushTestMergeCommits")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("boolean");
 
 				b.Property<bool?>("ShowTestMergeCommitters")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("boolean");
 
 				b.Property<bool?>("UpdateSubmodules")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("boolean");
 
 				b.HasKey("Id");
 
@@ -589,13 +609,15 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
 
 				b.Property<long>("RevisionInformationId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<long>("TestMergeId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.HasKey("Id");
 
@@ -610,23 +632,25 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
 
 				b.Property<string>("CommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("TEXT");
+					.HasColumnType("character varying(40)");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<string>("OriginCommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("TEXT");
+					.HasColumnType("character varying(40)");
 
 				b.Property<DateTimeOffset>("Timestamp")
-					.HasColumnType("TEXT");
+					.HasColumnType("timestamp with time zone");
 
 				b.HasKey("Id");
 
@@ -640,45 +664,47 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
 
 				b.Property<string>("Author")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("text");
 
 				b.Property<string>("BodyAtMerge")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("text");
 
 				b.Property<string>("Comment")
 					.HasMaxLength(10000)
-					.HasColumnType("TEXT");
+					.HasColumnType("character varying(10000)");
 
 				b.Property<DateTimeOffset>("MergedAt")
-					.HasColumnType("TEXT");
+					.HasColumnType("timestamp with time zone");
 
 				b.Property<long>("MergedById")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<int>("Number")
-					.HasColumnType("INTEGER");
+					.HasColumnType("integer");
 
 				b.Property<long?>("PrimaryRevisionInformationId")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<string>("TargetCommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("TEXT");
+					.HasColumnType("character varying(40)");
 
 				b.Property<string>("TitleAtMerge")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("text");
 
 				b.Property<string>("Url")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("text");
 
 				b.HasKey("Id");
 
@@ -694,41 +720,43 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
 
 				b.Property<string>("CanonicalName")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("TEXT");
+					.HasColumnType("character varying(100)");
 
 				b.Property<DateTimeOffset?>("CreatedAt")
 					.IsRequired()
-					.HasColumnType("TEXT");
+					.HasColumnType("timestamp with time zone");
 
 				b.Property<long?>("CreatedById")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<bool?>("Enabled")
 					.IsRequired()
-					.HasColumnType("INTEGER");
+					.HasColumnType("boolean");
 
 				b.Property<long?>("GroupId")
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
 
 				b.Property<DateTimeOffset?>("LastPasswordUpdate")
-					.HasColumnType("TEXT");
+					.HasColumnType("timestamp with time zone");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("TEXT");
+					.HasColumnType("character varying(100)");
 
 				b.Property<string>("PasswordHash")
-					.HasColumnType("TEXT");
+					.HasColumnType("text");
 
 				b.Property<string>("SystemIdentifier")
 					.HasMaxLength(100)
-					.HasColumnType("TEXT");
+					.HasColumnType("character varying(100)");
 
 				b.HasKey("Id");
 
@@ -749,12 +777,14 @@ namespace Tgstation.Server.Host.Database.Migrations
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("INTEGER");
+					.HasColumnType("bigint");
+
+				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("TEXT");
+					.HasColumnType("character varying(100)");
 
 				b.HasKey("Id");
 
@@ -797,7 +827,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.HasOne("Tgstation.Server.Host.Models.RevisionInformation", "RevisionInformation")
 					.WithMany("CompileJobs")
 					.HasForeignKey("RevisionInformationId")
-					.OnDelete(DeleteBehavior.ClientNoAction)
+					.OnDelete(DeleteBehavior.Cascade)
 					.IsRequired();
 
 				b.Navigation("Job");

--- a/src/Tgstation.Server.Host/Database/Migrations/20240907172251_PGAddDMApiValidationMode.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20240907172251_PGAddDMApiValidationMode.cs
@@ -1,0 +1,49 @@
+﻿using System;
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Tgstation.Server.Host.Database.Migrations
+{
+	/// <inheritdoc />
+	public partial class PGAddDMApiValidationMode : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+			migrationBuilder.AddColumn<int>(
+				name: "DMApiValidationMode",
+				table: "DreamMakerSettings",
+				type: "integer",
+				nullable: false,
+				defaultValue: 0);
+
+			migrationBuilder.Sql("UPDATE \"DreamMakerSettings\" SET \"DMApiValidationMode\" = \"RequireDMApiValidation\"::int");
+
+			migrationBuilder.DropColumn(
+				name: "RequireDMApiValidation",
+				table: "DreamMakerSettings");
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+			migrationBuilder.AddColumn<bool>(
+				name: "RequireDMApiValidation",
+				table: "DreamMakerSettings",
+				type: "boolean",
+				nullable: false,
+				defaultValue: false);
+
+			migrationBuilder.Sql("UPDATE \"DreamMakerSettings\" SET \"RequireDMApiValidation\" = true WHERE \"DMApiValidationMode\" != 0");
+			migrationBuilder.Sql("UPDATE \"DreamMakerSettings\" SET \"RequireDMApiValidation\" = false WHERE \"DMApiValidationMode\" = 0");
+
+			migrationBuilder.DropColumn(
+				name: "DMApiValidationMode",
+				table: "DreamMakerSettings");
+		}
+	}
+}

--- a/src/Tgstation.Server.Host/Database/Migrations/20240907172259_SLAddDMApiValidationMode.Designer.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20240907172259_SLAddDMApiValidationMode.Designer.cs
@@ -3,13 +3,16 @@ using System;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Tgstation.Server.Host.Database.Migrations
 {
 	[DbContext(typeof(SqliteDatabaseContext))]
-	partial class SqliteDatabaseContextModelSnapshot : ModelSnapshot
+	[Migration("20240907172259_SLAddDMApiValidationMode")]
+	partial class SLAddDMApiValidationMode
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		/// <inheritdoc />
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder.HasAnnotation("ProductVersion", "8.0.8");

--- a/src/Tgstation.Server.Host/Database/Migrations/20240907172259_SLAddDMApiValidationMode.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20240907172259_SLAddDMApiValidationMode.cs
@@ -1,0 +1,34 @@
+﻿using System;
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Tgstation.Server.Host.Database.Migrations
+{
+	/// <inheritdoc />
+	public partial class SLAddDMApiValidationMode : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+			migrationBuilder.RenameColumn(
+				name: "RequireDMApiValidation",
+				table: "DreamMakerSettings",
+				newName: "DMApiValidationMode");
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+			migrationBuilder.RenameColumn(
+				name: "DMApiValidationMode",
+				table: "DreamMakerSettings",
+				newName: "RequireDMApiValidation");
+
+			migrationBuilder.Sql("UPDATE DreamMakerSettings SET RequireDMApiValidation = 0 WHERE RequireDMApiValidation = 2");
+		}
+	}
+}

--- a/src/Tgstation.Server.Host/Database/Migrations/MySqlDatabaseContextModelSnapshot.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/MySqlDatabaseContextModelSnapshot.cs
@@ -13,7 +13,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 		{
 #pragma warning disable 612, 618
 			modelBuilder
-				.HasAnnotation("ProductVersion", "8.0.7")
+				.HasAnnotation("ProductVersion", "8.0.8")
 				.HasAnnotation("Relational:MaxIdentifierLength", 64);
 
 			MySqlModelBuilderExtensions.AutoIncrementColumns(modelBuilder);
@@ -286,6 +286,9 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasMaxLength(10000)
 					.HasColumnType("varchar(10000)");
 
+				b.Property<int>("DMApiValidationMode")
+					.HasColumnType("int");
+
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
@@ -294,10 +297,6 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasColumnType("longtext");
 
 				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("ProjectName"), "utf8mb4");
-
-				b.Property<bool?>("RequireDMApiValidation")
-					.IsRequired()
-					.HasColumnType("tinyint(1)");
 
 				b.Property<TimeSpan?>("Timeout")
 					.IsRequired()

--- a/src/Tgstation.Server.Host/Database/Migrations/PostgresSqlDatabaseContextModelSnapshot.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/PostgresSqlDatabaseContextModelSnapshot.cs
@@ -13,7 +13,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 		{
 #pragma warning disable 612, 618
 			modelBuilder
-				.HasAnnotation("ProductVersion", "8.0.7")
+				.HasAnnotation("ProductVersion", "8.0.8")
 				.HasAnnotation("Relational:MaxIdentifierLength", 63);
 
 			NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
@@ -261,16 +261,15 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasMaxLength(10000)
 					.HasColumnType("character varying(10000)");
 
+				b.Property<int>("DMApiValidationMode")
+					.HasColumnType("integer");
+
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
 				b.Property<string>("ProjectName")
 					.HasMaxLength(10000)
 					.HasColumnType("character varying(10000)");
-
-				b.Property<bool?>("RequireDMApiValidation")
-					.IsRequired()
-					.HasColumnType("boolean");
 
 				b.Property<TimeSpan?>("Timeout")
 					.IsRequired()

--- a/src/Tgstation.Server.Host/Database/Migrations/SqlServerDatabaseContextModelSnapshot.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/SqlServerDatabaseContextModelSnapshot.cs
@@ -13,7 +13,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 		{
 #pragma warning disable 612, 618
 			modelBuilder
-				.HasAnnotation("ProductVersion", "8.0.7")
+				.HasAnnotation("ProductVersion", "8.0.8")
 				.HasAnnotation("Relational:MaxIdentifierLength", 128);
 
 			SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
@@ -263,16 +263,15 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.HasMaxLength(10000)
 					.HasColumnType("nvarchar(max)");
 
+				b.Property<int>("DMApiValidationMode")
+					.HasColumnType("int");
+
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
 				b.Property<string>("ProjectName")
 					.HasMaxLength(10000)
 					.HasColumnType("nvarchar(max)");
-
-				b.Property<bool?>("RequireDMApiValidation")
-					.IsRequired()
-					.HasColumnType("bit");
 
 				b.Property<TimeSpan?>("Timeout")
 					.IsRequired()

--- a/src/Tgstation.Server.Host/Models/DreamMakerSettings.cs
+++ b/src/Tgstation.Server.Host/Models/DreamMakerSettings.cs
@@ -29,7 +29,10 @@ namespace Tgstation.Server.Host.Models
 			ProjectName = ProjectName,
 			ApiValidationPort = ApiValidationPort,
 			ApiValidationSecurityLevel = ApiValidationSecurityLevel,
-			RequireDMApiValidation = RequireDMApiValidation,
+#pragma warning disable CS0618 // Type or member is obsolete
+			RequireDMApiValidation = DMApiValidationMode == Api.Models.DMApiValidationMode.Required,
+#pragma warning restore CS0618 // Type or member is obsolete
+			DMApiValidationMode = DMApiValidationMode,
 			Timeout = Timeout,
 			CompilerAdditionalArguments = CompilerAdditionalArguments,
 		};

--- a/tests/DMAPI/BasicOperation/Config.dm
+++ b/tests/DMAPI/BasicOperation/Config.dm
@@ -1,3 +1,3 @@
 #define TGS_INFO_LOG(message) world.log << "Info: [##message]"
-#define TGS_ERROR_LOG(message) world.log << "Err: [##message]"
+#define TGS_ERROR_LOG(message) TgsError("[##message]")
 #define TGS_V3_API

--- a/tests/DMAPI/BasicOperation/Test.dm
+++ b/tests/DMAPI/BasicOperation/Test.dm
@@ -15,7 +15,9 @@
 	var/ibf = message == "Failed initial bridge request!"
 	if(ibf || message == "Failed bridge request, bad json: null" || findtext(message, "byond_world_export: Failed request: ") || message == "Failed to activate API!")
 		if(ibf)
-			text2file("yes", "initial_bridge_failed.txt")
+			world.log << "Writing test fail file..."
+			text2file("BRIDGE FAILED", "initial_bridge_failed.txt")
+			world.log << "File exists: [fexists("initial_bridge_failed.txt")]"
 			del(world)
 			sleep(1)
 

--- a/tests/DMAPI/BasicOperation/Test.dm
+++ b/tests/DMAPI/BasicOperation/Test.dm
@@ -10,6 +10,19 @@
 	set waitfor = FALSE
 	Run()
 
+/proc/TgsError(message)
+	world.log << "TGS Error: [message]"
+	var/ibf = message == "Failed initial bridge request!"
+	if(ibf || message == "Failed bridge request, bad json: null" || findtext(message, "byond_world_export: Failed request: ") || message == "Failed to activate API!")
+		if(ibf)
+			text2file("yes", "initial_bridge_failed.txt")
+			del(world)
+			sleep(1)
+
+		return
+
+	FailTest("DMAPI Error: [message]")
+
 /proc/Run()
 	world.log << "sleep"
 	sleep(50)

--- a/tests/DMAPI/BasicOperation/basic operation_test_nov3.dme
+++ b/tests/DMAPI/BasicOperation/basic operation_test_nov3.dme
@@ -1,0 +1,18 @@
+// Hand crafted DME, will not work if saved with DreamMaker
+
+// BEGIN_INTERNALS
+// END_INTERNALS
+
+// BEGIN_FILE_DIR
+#define FILE_DIR .
+// END_FILE_DIR
+
+// BEGIN_PREFERENCES
+// END_PREFERENCES
+
+// BEGIN_INCLUDE
+#include "Config.dm"
+#undef TGS_V3_API
+#include "../test_prelude.dm"
+#include "Test.dm"
+// END_INCLUDE

--- a/tests/Tgstation.Server.Tests/Live/Instance/DeploymentTest.cs
+++ b/tests/Tgstation.Server.Tests/Live/Instance/DeploymentTest.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Tgstation.Server.Api.Models;
+using Tgstation.Server.Api.Models.Internal;
 using Tgstation.Server.Api.Models.Request;
 using Tgstation.Server.Api.Models.Response;
 using Tgstation.Server.Api.Rights;
@@ -58,8 +59,69 @@ namespace Tgstation.Server.Tests.Live.Instance
 			Assert.IsTrue(deployJob.ErrorCode == ErrorCode.RepoCloning || deployJob.ErrorCode == ErrorCode.RepoMissing);
 
 			var dmSettings = await dreamMakerClient.Read(cancellationToken);
+#pragma warning disable CS0618 // Type or member is obsolete
 			Assert.AreEqual(true, dmSettings.RequireDMApiValidation);
+#pragma warning restore CS0618 // Type or member is obsolete
+			Assert.AreEqual(DMApiValidationMode.Required, dmSettings.DMApiValidationMode);
 			Assert.AreEqual(null, dmSettings.ProjectName);
+
+			// test legacy back and forth
+			dmSettings = await dreamMakerClient.Update(new DreamMakerRequest
+			{
+				DMApiValidationMode = DMApiValidationMode.Optional,
+			}, cancellationToken);
+			Assert.AreEqual(DMApiValidationMode.Optional, dmSettings.DMApiValidationMode);
+#pragma warning disable CS0618 // Type or member is obsolete
+			Assert.AreEqual(false, dmSettings.RequireDMApiValidation);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+			dmSettings = await dreamMakerClient.Update(new DreamMakerRequest
+			{
+				DMApiValidationMode = DMApiValidationMode.Skipped,
+			}, cancellationToken);
+			Assert.AreEqual(DMApiValidationMode.Skipped, dmSettings.DMApiValidationMode);
+#pragma warning disable CS0618 // Type or member is obsolete
+			Assert.AreEqual(false, dmSettings.RequireDMApiValidation);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+			dmSettings = await dreamMakerClient.Update(new DreamMakerRequest
+			{
+				DMApiValidationMode = DMApiValidationMode.Required,
+			}, cancellationToken);
+			Assert.AreEqual(DMApiValidationMode.Required, dmSettings.DMApiValidationMode);
+#pragma warning disable CS0618 // Type or member is obsolete
+			Assert.AreEqual(true, dmSettings.RequireDMApiValidation);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+			dmSettings = await dreamMakerClient.Update(new DreamMakerRequest
+			{
+#pragma warning disable CS0618 // Type or member is obsolete
+				RequireDMApiValidation = false,
+#pragma warning restore CS0618 // Type or member is obsolete
+			}, cancellationToken);
+			Assert.AreEqual(DMApiValidationMode.Optional, dmSettings.DMApiValidationMode);
+#pragma warning disable CS0618 // Type or member is obsolete
+			Assert.AreEqual(false, dmSettings.RequireDMApiValidation);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+			dmSettings = await dreamMakerClient.Update(new DreamMakerRequest
+			{
+#pragma warning disable CS0618 // Type or member is obsolete
+				RequireDMApiValidation = true,
+#pragma warning restore CS0618 // Type or member is obsolete
+			}, cancellationToken);
+			Assert.AreEqual(DMApiValidationMode.Required, dmSettings.DMApiValidationMode);
+#pragma warning disable CS0618 // Type or member is obsolete
+			Assert.AreEqual(true, dmSettings.RequireDMApiValidation);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+			await ApiAssert.ThrowsException<ApiConflictException, DreamMakerResponse>(() => dreamMakerClient.Update(new DreamMakerRequest
+			{
+#pragma warning disable CS0618 // Type or member is obsolete
+				RequireDMApiValidation = true,
+				DMApiValidationMode = DMApiValidationMode.Required,
+#pragma warning restore CS0618 // Type or member is obsolete
+			}, cancellationToken), ErrorCode.ModelValidationFailure);
 		}
 
 		async ValueTask CheckDreamDaemonPriority(Task deploymentJobWaitTask, CancellationToken cancellationToken)

--- a/tests/Tgstation.Server.Tests/Live/Instance/WatchdogTest.cs
+++ b/tests/Tgstation.Server.Tests/Live/Instance/WatchdogTest.cs
@@ -698,6 +698,7 @@ namespace Tgstation.Server.Tests.Live.Instance
 			Assert.IsFalse(daemonStatus.SessionId.HasValue);
 			Assert.IsFalse(daemonStatus.LaunchTime.HasValue);
 			Assert.IsNull(daemonStatus.StagedCompileJob);
+			Assert.AreNotEqual(DreamDaemonSecurity.Ultrasafe, daemonStatus.SecurityLevel);
 
 			await ExpectGameDirectoryCount(1, cancellationToken);
 
@@ -1606,7 +1607,10 @@ namespace Tgstation.Server.Tests.Live.Instance
 			{
 				var bridgeFailFile = Path.Combine(gameDir, "initial_bridge_failed.txt");
 				var initialBridgeFailed = File.Exists(bridgeFailFile);
-				Assert.AreEqual(expectInitialBridgeFailure, initialBridgeFailed, "Initial bridge failure expectancy not met");
+
+				System.Console.WriteLine($"Files in game dir:{Environment.NewLine}{String.Join(Environment.NewLine, Directory.GetFiles(gameDir))}");
+
+				Assert.AreEqual(expectInitialBridgeFailure, initialBridgeFailed, $"Initial bridge failure expectancy not met in {gameDir}");
 
 				var successFile = Path.Combine(gameDir, "test_success.txt");
 				Assert.IsTrue(File.Exists(successFile));

--- a/tests/Tgstation.Server.Tests/Live/Instance/WatchdogTest.cs
+++ b/tests/Tgstation.Server.Tests/Live/Instance/WatchdogTest.cs
@@ -187,7 +187,13 @@ namespace Tgstation.Server.Tests.Live.Instance
 				ApiAssert.ThrowsException<ConflictException, JobResponse>(() => instanceClient.DreamDaemon.Restart(cancellationToken), ErrorCode.WatchdogNotRunning).AsTask());
 
 			await RunBasicTest(false, cancellationToken);
-			await RunBasicTest(true, cancellationToken);
+
+			// hardlinks and DMAPI checks don't play well together
+			bool linuxAdvancedWatchdogWeirdness = testVersion.Engine.Value == EngineType.Byond
+				&& !new PlatformIdentifier().IsWindows
+				&& !watchdogRestartsProcess;
+			if (!linuxAdvancedWatchdogWeirdness)
+				await RunBasicTest(true, cancellationToken);
 
 			await TestDMApiFreeDeploy(cancellationToken);
 

--- a/tests/Tgstation.Server.Tests/TestDatabase.cs
+++ b/tests/Tgstation.Server.Tests/TestDatabase.cs
@@ -13,6 +13,7 @@ using Tgstation.Server.Host.Database.Migrations;
 using Tgstation.Server.Host.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Tgstation.Server.Api.Models.Internal;
 
 namespace Tgstation.Server.Tests
 {
@@ -130,7 +131,7 @@ namespace Tgstation.Server.Tests
 				{
 					ApiValidationPort = 1557,
 					ApiValidationSecurityLevel = DreamDaemonSecurity.Trusted,
-					RequireDMApiValidation = false,
+					DMApiValidationMode = DMApiValidationMode.Skipped,
 					Timeout = TimeSpan.FromSeconds(13),
 				},
 				InstancePermissionSets = new List<Host.Models.InstancePermissionSet>

--- a/tgstation-server.sln
+++ b/tgstation-server.sln
@@ -176,6 +176,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "BasicOperation", "BasicOperation", "{F32B9514-AAD9-429D-841A-ED810FC2598C}"
 	ProjectSection(SolutionItems) = preProject
 		tests\DMAPI\BasicOperation\basic operation_test.dme = tests\DMAPI\BasicOperation\basic operation_test.dme
+		tests\DMAPI\BasicOperation\basic operation_test_nov3.dme = tests\DMAPI\BasicOperation\basic operation_test_nov3.dme
 		tests\DMAPI\BasicOperation\Config.dm = tests\DMAPI\BasicOperation\Config.dm
 		tests\DMAPI\BasicOperation\Test.dm = tests\DMAPI\BasicOperation\Test.dm
 		tests\DMAPI\BasicOperation\test_event-qwer.bat = tests\DMAPI\BasicOperation\test_event-qwer.bat

--- a/tgstation-server.sln
+++ b/tgstation-server.sln
@@ -77,6 +77,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tgs", "tgs", "{F7765A4B-021
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "core", "core", "{DCCBA9DA-47BA-4C70-823B-E99A3ACA0377}"
 	ProjectSection(SolutionItems) = preProject
+		src\DMAPI\tgs\core\byond_world_export.dm = src\DMAPI\tgs\core\byond_world_export.dm
 		src\DMAPI\tgs\core\core.dm = src\DMAPI\tgs\core\core.dm
 		src\DMAPI\tgs\core\datum.dm = src\DMAPI\tgs\core\datum.dm
 		src\DMAPI\tgs\core\README.md = src\DMAPI\tgs\core\README.md

--- a/tools/Tgstation.Server.ReleaseNotes/Program.cs
+++ b/tools/Tgstation.Server.ReleaseNotes/Program.cs
@@ -4,20 +4,16 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IdentityModel.Tokens.Jwt;
 using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Sockets;
 using System.Security;
-using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Xml.Linq;
-
-using Microsoft.IdentityModel.Tokens;
 
 using Newtonsoft.Json;
 


### PR DESCRIPTION
Fuck you @AffectedArc07

:cl:
Allowed DMAPI validation to be skipped. Note that skipping DMAPI validation disables all DMAPI functionality for a deployment, even if it is present in your DM code.

🆑 HTTP API
Added `dmApiValidationMode` to `/api/DreamMaker` request and response model. This enum can either be `0` for validation optional, `1` for validation required, or `2` for validation skipped.
**Deprecation:** `requireDMApiValidation` in the `/api/DreamMaker` request and response models is now deprecated, use `dmApiValidationMode` instead.
/🆑

🆑 Nuget: API
Added `Tgstation.Server.Api.Models.DMApiValidationMode`.
Added `DreamMakerSettings.DMApiValidationMode`.
**Deprecation:** Make `DreamMakerSettings.RequireDMApiValidation` obsolete. Use `DreamMakerSettings.DMApiValidationMode` instead.
/🆑

🆑 Nuget: Client
Updated `Tgstation.Server.Api` dependency to 14.1.0 for TGS API version 10.9.0.
/🆑
