### PR TITLE
Some swarm mode improvements

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -12,6 +12,7 @@
     <TgsDmapiVersion>7.3.0</TgsDmapiVersion>
     <TgsInteropVersion>5.10.0</TgsInteropVersion>
     <TgsHostWatchdogVersion>1.5.0</TgsHostWatchdogVersion>
+    <TgsSwarmProtocolVersion>7.0.0</TgsSwarmProtocolVersion>
     <TgsContainerScriptVersion>1.2.1</TgsContainerScriptVersion>
     <TgsMigratorVersion>2.0.0</TgsMigratorVersion>
     <TgsNugetNetFramework>netstandard2.0</TgsNugetNetFramework>

--- a/src/Tgstation.Server.Host/Controllers/SwarmController.cs
+++ b/src/Tgstation.Server.Host/Controllers/SwarmController.cs
@@ -96,9 +96,9 @@ namespace Tgstation.Server.Host.Controllers
 				return StatusCode((int)HttpStatusCode.UpgradeRequired);
 
 			var registrationResult = await swarmOperations.RegisterNode(registrationRequest, RequestRegistrationId, cancellationToken);
-			if (!registrationResult)
+			if (registrationResult == null)
 				return Conflict();
-			return NoContent();
+			return Json(registrationResult);
 		}
 
 		/// <summary>

--- a/src/Tgstation.Server.Host/Controllers/SwarmController.cs
+++ b/src/Tgstation.Server.Host/Controllers/SwarmController.cs
@@ -14,8 +14,8 @@ using Serilog.Context;
 
 using Tgstation.Server.Host.Configuration;
 using Tgstation.Server.Host.Extensions;
+using Tgstation.Server.Host.Properties;
 using Tgstation.Server.Host.Swarm;
-using Tgstation.Server.Host.System;
 using Tgstation.Server.Host.Transfer;
 using Tgstation.Server.Host.Utils;
 
@@ -45,11 +45,6 @@ namespace Tgstation.Server.Host.Controllers
 		readonly IFileTransferStreamHandler transferService;
 
 		/// <summary>
-		/// The <see cref="IAssemblyInformationProvider"/> for the <see cref="SwarmController"/>.
-		/// </summary>
-		readonly IAssemblyInformationProvider assemblyInformationProvider;
-
-		/// <summary>
 		/// The <see cref="ILogger"/> for the <see cref="SwarmController"/>.
 		/// </summary>
 		readonly ILogger<SwarmController> logger;
@@ -63,19 +58,16 @@ namespace Tgstation.Server.Host.Controllers
 		/// Initializes a new instance of the <see cref="SwarmController"/> class.
 		/// </summary>
 		/// <param name="swarmOperations">The value of <see cref="swarmOperations"/>.</param>
-		/// <param name="assemblyInformationProvider">The value of <see cref="assemblyInformationProvider"/>.</param>
 		/// <param name="transferService">The value of <see cref="transferService"/>.</param>
 		/// <param name="swarmConfigurationOptions">The <see cref="IOptions{TOptions}"/> containing the value of <see cref="swarmConfiguration"/>.</param>
 		/// <param name="logger">The value of <see cref="logger"/>.</param>
 		public SwarmController(
 			ISwarmOperations swarmOperations,
-			IAssemblyInformationProvider assemblyInformationProvider,
 			IFileTransferStreamHandler transferService,
 			IOptions<SwarmConfiguration> swarmConfigurationOptions,
 			ILogger<SwarmController> logger)
 		{
 			this.swarmOperations = swarmOperations ?? throw new ArgumentNullException(nameof(swarmOperations));
-			this.assemblyInformationProvider = assemblyInformationProvider ?? throw new ArgumentNullException(nameof(assemblyInformationProvider));
 			this.transferService = transferService ?? throw new ArgumentNullException(nameof(transferService));
 			swarmConfiguration = swarmConfigurationOptions?.Value ?? throw new ArgumentNullException(nameof(swarmConfigurationOptions));
 			this.logger = logger;
@@ -92,12 +84,17 @@ namespace Tgstation.Server.Host.Controllers
 		{
 			ArgumentNullException.ThrowIfNull(registrationRequest);
 
-			if (registrationRequest.ServerVersion != assemblyInformationProvider.Version)
+			var swarmProtocolVersion = Version.Parse(MasterVersionsAttribute.Instance.RawSwarmProtocolVersion);
+			if (registrationRequest.ServerVersion?.Major != swarmProtocolVersion.Major)
 				return StatusCode((int)HttpStatusCode.UpgradeRequired);
 
 			var registrationResult = await swarmOperations.RegisterNode(registrationRequest, RequestRegistrationId, cancellationToken);
 			if (registrationResult == null)
 				return Conflict();
+
+			if (registrationRequest.ServerVersion != swarmProtocolVersion)
+				logger.LogWarning("Allowed node {identifier} to register despite having a slightly different swarm protocol version!", registrationRequest.Identifier);
+
 			return Json(registrationResult);
 		}
 

--- a/src/Tgstation.Server.Host/Database/DatabaseContext.cs
+++ b/src/Tgstation.Server.Host/Database/DatabaseContext.cs
@@ -445,6 +445,7 @@ namespace Tgstation.Server.Host.Database
 		// HEY YOU
 		// IF YOU HAVE A TEST THAT'S CREATING ERRORS BECAUSE THESE VALUES AREN'T SET CORRECTLY THERE'S MORE TO FIXING IT THAN JUST UPDATING THEM
 		// IN THE FUNCTION BELOW YOU ALSO NEED TO CORRECTLY SET THE RIGHT MIGRATION TO DOWNGRADE TO FOR THE LAST TGS VERSION
+		// YOU ALSO NEED TO UPDATE THE SWARM PROTOCOL MAJOR VERSION
 		// IF THIS BREAKS AGAIN I WILL PERSONALLY HAUNT YOUR ASS WHEN I DIE
 
 		/// <summary>
@@ -480,6 +481,7 @@ namespace Tgstation.Server.Host.Database
 
 			string BadDatabaseType() => throw new ArgumentException($"Invalid DatabaseType: {currentDatabaseType}", nameof(currentDatabaseType));
 
+			// !!! DON'T FORGET TO UPDATE THE SWARM PROTOCOL MAJOR VERSION !!!
 			if (targetVersion < new Version(6, 7, 0))
 				targetMigration = currentDatabaseType switch
 				{

--- a/src/Tgstation.Server.Host/Properties/MasterVersionsAttribute.cs
+++ b/src/Tgstation.Server.Host/Properties/MasterVersionsAttribute.cs
@@ -42,6 +42,11 @@ namespace Tgstation.Server.Host.Properties
 		public string RawMariaDBRedistVersion { get; }
 
 		/// <summary>
+		/// The <see cref="Version"/> <see cref="string"/> of the MariaDB server bundled with TGS installs.
+		/// </summary>
+		public string RawSwarmProtocolVersion { get; }
+
+		/// <summary>
 		/// Initializes a new instance of the <see cref="MasterVersionsAttribute"/> class.
 		/// </summary>
 		/// <param name="rawConfigurationVersion">The value of <see cref="RawConfigurationVersion"/>.</param>
@@ -49,18 +54,21 @@ namespace Tgstation.Server.Host.Properties
 		/// <param name="rawWebpanelVersion">The value of <see cref="RawWebpanelVersion"/>.</param>
 		/// <param name="rawHostWatchdogVersion">The value of <see cref="RawHostWatchdogVersion"/>.</param>
 		/// <param name="rawMariaDBRedistVersion">The value of <see cref="RawMariaDBRedistVersion"/>.</param>
+		/// <param name="rawSwarmProtocolVersion">The value of <see cref="RawSwarmProtocolVersion"/>.</param>
 		public MasterVersionsAttribute(
 			string rawConfigurationVersion,
 			string rawInteropVersion,
 			string rawWebpanelVersion,
 			string rawHostWatchdogVersion,
-			string rawMariaDBRedistVersion)
+			string rawMariaDBRedistVersion,
+			string rawSwarmProtocolVersion)
 		{
 			RawConfigurationVersion = rawConfigurationVersion ?? throw new ArgumentNullException(nameof(rawConfigurationVersion));
 			RawInteropVersion = rawInteropVersion ?? throw new ArgumentNullException(nameof(rawInteropVersion));
 			RawWebpanelVersion = rawWebpanelVersion ?? throw new ArgumentNullException(nameof(rawWebpanelVersion));
 			RawHostWatchdogVersion = rawHostWatchdogVersion ?? throw new ArgumentNullException(nameof(rawHostWatchdogVersion));
 			RawMariaDBRedistVersion = rawMariaDBRedistVersion ?? throw new ArgumentNullException(nameof(rawMariaDBRedistVersion));
+			RawSwarmProtocolVersion = rawSwarmProtocolVersion ?? throw new ArgumentNullException(nameof(rawSwarmProtocolVersion));
 		}
 	}
 }

--- a/src/Tgstation.Server.Host/Security/ITokenFactory.cs
+++ b/src/Tgstation.Server.Host/Security/ITokenFactory.cs
@@ -12,9 +12,9 @@ namespace Tgstation.Server.Host.Security
 	public interface ITokenFactory
 	{
 		/// <summary>
-		/// Gets or sets the <see cref="ITokenFactory"/>'s signing key.
+		/// Gets or sets the <see cref="ITokenFactory"/>'s signing key <see cref="byte"/>s.
 		/// </summary>
-		ReadOnlySpan<byte> SigningKey { get; set; }
+		ReadOnlySpan<byte> SigningKeyBytes { get; set; }
 
 		/// <summary>
 		/// The <see cref="TokenValidationParameters"/> for the <see cref="ITokenFactory"/>.

--- a/src/Tgstation.Server.Host/Security/ITokenFactory.cs
+++ b/src/Tgstation.Server.Host/Security/ITokenFactory.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.IdentityModel.Tokens;
+﻿using System;
+
+using Microsoft.IdentityModel.Tokens;
 
 using Tgstation.Server.Api.Models.Response;
 
@@ -9,6 +11,11 @@ namespace Tgstation.Server.Host.Security
 	/// </summary>
 	public interface ITokenFactory
 	{
+		/// <summary>
+		/// Gets or sets the <see cref="ITokenFactory"/>'s signing key.
+		/// </summary>
+		ReadOnlySpan<byte> SigningKey { get; set; }
+
 		/// <summary>
 		/// The <see cref="TokenValidationParameters"/> for the <see cref="ITokenFactory"/>.
 		/// </summary>

--- a/src/Tgstation.Server.Host/Swarm/ISwarmOperations.cs
+++ b/src/Tgstation.Server.Host/Swarm/ISwarmOperations.cs
@@ -39,8 +39,8 @@ namespace Tgstation.Server.Host.Swarm
 		/// <param name="node">The <see cref="SwarmServer"/> that is registering.</param>
 		/// <param name="registrationId">The registration <see cref="Guid"/>.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
-		/// <returns>A <see cref="ValueTask{TResult}"/> resulting in <see langword="true"/> if the registration was successful, <see langword="false"/> otherwise.</returns>
-		ValueTask<bool> RegisterNode(SwarmServer node, Guid registrationId, CancellationToken cancellationToken);
+		/// <returns>A <see cref="ValueTask{TResult}"/> resulting in a <see cref="SwarmRegistrationResponse"/> if the registration was successful, <see langword="null"/> otherwise.</returns>
+		ValueTask<SwarmRegistrationResponse?> RegisterNode(SwarmServer node, Guid registrationId, CancellationToken cancellationToken);
 
 		/// <summary>
 		/// Attempt to unregister a node with a given <paramref name="registrationId"/> with the controller.

--- a/src/Tgstation.Server.Host/Swarm/SwarmRegistrationRequest.cs
+++ b/src/Tgstation.Server.Host/Swarm/SwarmRegistrationRequest.cs
@@ -11,7 +11,7 @@ namespace Tgstation.Server.Host.Swarm
 	public sealed class SwarmRegistrationRequest : SwarmServer
 	{
 		/// <summary>
-		/// The TGS <see cref="Version"/> of the sending server.
+		/// The swarm protocol <see cref="Version"/> of the sending server. Named this way due to legacy reasons.
 		/// </summary>
 		[Required]
 		public Version ServerVersion { get; }

--- a/src/Tgstation.Server.Host/Swarm/SwarmRegistrationResponse.cs
+++ b/src/Tgstation.Server.Host/Swarm/SwarmRegistrationResponse.cs
@@ -1,0 +1,13 @@
+﻿namespace Tgstation.Server.Host.Swarm
+{
+	/// <summary>
+	/// Response for a <see cref="SwarmRegistrationRequest"/>.
+	/// </summary>
+	public sealed class SwarmRegistrationResponse
+	{
+		/// <summary>
+		/// The base64 encoded token signing key.
+		/// </summary>
+		public required string TokenSigningKeyBase64 { get; init; }
+	}
+}

--- a/src/Tgstation.Server.Host/Swarm/SwarmRegistrationResult.cs
+++ b/src/Tgstation.Server.Host/Swarm/SwarmRegistrationResult.cs
@@ -24,5 +24,10 @@
 		/// A communication error occurred.
 		/// </summary>
 		CommunicationFailure,
+
+		/// <summary>
+		/// Response could not be deserialized.
+		/// </summary>
+		PayloadFailure,
 	}
 }

--- a/src/Tgstation.Server.Host/Swarm/SwarmService.cs
+++ b/src/Tgstation.Server.Host/Swarm/SwarmService.cs
@@ -24,6 +24,7 @@ using Tgstation.Server.Host.Configuration;
 using Tgstation.Server.Host.Core;
 using Tgstation.Server.Host.Database;
 using Tgstation.Server.Host.IO;
+using Tgstation.Server.Host.Properties;
 using Tgstation.Server.Host.Security;
 using Tgstation.Server.Host.System;
 using Tgstation.Server.Host.Transfer;
@@ -34,7 +35,9 @@ namespace Tgstation.Server.Host.Swarm
 	/// <summary>
 	/// Helps keep servers connected to the same database in sync by coordinating updates.
 	/// </summary>
+#pragma warning disable CA1506 // TODO: Decomplexify
 	sealed class SwarmService : ISwarmService, ISwarmServiceController, ISwarmOperations, IDisposable
+#pragma warning restore CA1506
 	{
 		/// <inheritdoc />
 		public bool ExpectedNumberOfNodesConnected
@@ -1282,7 +1285,7 @@ namespace Tgstation.Server.Host.Swarm
 				null,
 				HttpMethod.Post,
 				SwarmConstants.RegisterRoute,
-				new SwarmRegistrationRequest(assemblyInformationProvider.Version)
+				new SwarmRegistrationRequest(Version.Parse(MasterVersionsAttribute.Instance.RawSwarmProtocolVersion))
 				{
 					Identifier = swarmConfiguration.Identifier,
 					Address = swarmConfiguration.Address,

--- a/src/Tgstation.Server.Host/Swarm/SwarmService.cs
+++ b/src/Tgstation.Server.Host/Swarm/SwarmService.cs
@@ -574,7 +574,7 @@ namespace Tgstation.Server.Host.Swarm
 
 			SwarmRegistrationResponse CreateResponse() => new()
 			{
-				TokenSigningKeyBase64 = Convert.ToBase64String(tokenFactory.SigningKey),
+				TokenSigningKeyBase64 = Convert.ToBase64String(tokenFactory.SigningKeyBytes),
 			};
 
 			var registrationIdsAndTimes = this.registrationIdsAndTimes!;
@@ -1320,7 +1320,7 @@ namespace Tgstation.Server.Host.Swarm
 							return SwarmRegistrationResult.PayloadFailure;
 						}
 
-						tokenFactory.SigningKey = Convert.FromBase64String(registrationResponse.TokenSigningKeyBase64);
+						tokenFactory.SigningKeyBytes = Convert.FromBase64String(registrationResponse.TokenSigningKeyBase64);
 					}
 					catch (Exception ex)
 					{

--- a/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
+++ b/src/Tgstation.Server.Host/Tgstation.Server.Host.csproj
@@ -56,6 +56,7 @@
         <_Parameter3>$(TgsWebpanelVersion)</_Parameter3>
         <_Parameter4>$(TgsHostWatchdogVersion)</_Parameter4>
         <_Parameter5>$(TgsMariaDBRedistVersion)</_Parameter5>
+        <_Parameter6>$(TgsSwarmProtocolVersion)</_Parameter6>
       </MasterVersionAssemblyAttributes>
     </ItemGroup>
     <WriteCodeFragment AssemblyAttributes="@(MasterVersionAssemblyAttributes)" Language="C#" OutputDirectory="$(IntermediateOutputPath)" OutputFile="MasterVersionsAssemblyInfo.cs">

--- a/tests/Tgstation.Server.Host.Tests/Swarm/SwarmRpcMapper.cs
+++ b/tests/Tgstation.Server.Host.Tests/Swarm/SwarmRpcMapper.cs
@@ -219,6 +219,11 @@ namespace Tgstation.Server.Host.Swarm.Tests
 				// Fobid, NoContent, Conflict, StatusCode
 				if (result is ForbidResult forbidResult)
 					response.StatusCode = HttpStatusCode.Forbidden;
+				else if (result is JsonResult jsonResult)
+				{
+					response.StatusCode = HttpStatusCode.OK;
+					response.Content = new StringContent(JsonConvert.SerializeObject(jsonResult.Value));
+				}
 				else if (result is IStatusCodeActionResult statusCodeResult)
 					response.StatusCode = (HttpStatusCode)statusCodeResult.StatusCode;
 				else if (result is LimitedStreamResult streamResult)

--- a/tests/Tgstation.Server.Host.Tests/Swarm/TestableSwarmNode.cs
+++ b/tests/Tgstation.Server.Host.Tests/Swarm/TestableSwarmNode.cs
@@ -79,7 +79,7 @@ namespace Tgstation.Server.Host.Swarm.Tests
 
 		private class MockTokenFactory : ITokenFactory
 		{
-			public ReadOnlySpan<byte> SigningKey
+			public ReadOnlySpan<byte> SigningKeyBytes
 			{
 				get => [0, 1, 2, 3, 4];
 				set

--- a/tests/Tgstation.Server.Host.Tests/Swarm/TestableSwarmNode.cs
+++ b/tests/Tgstation.Server.Host.Tests/Swarm/TestableSwarmNode.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
@@ -20,6 +21,7 @@ using Tgstation.Server.Host.Controllers;
 using Tgstation.Server.Host.Core;
 using Tgstation.Server.Host.Database;
 using Tgstation.Server.Host.IO;
+using Tgstation.Server.Host.Models;
 using Tgstation.Server.Host.Security;
 using Tgstation.Server.Host.System;
 using Tgstation.Server.Host.Transfer;
@@ -72,6 +74,24 @@ namespace Tgstation.Server.Host.Swarm.Tests
 			{
 				node.Config.UpdateRequiredNodeCount = (uint)nodes.Length - 1;
 				node.RpcMapper.Register(configControllerSet);
+			}
+		}
+
+		private class MockTokenFactory : ITokenFactory
+		{
+			public ReadOnlySpan<byte> SigningKey
+			{
+				get => [0, 1, 2, 3, 4];
+				set
+				{
+				}
+			}
+
+			public TokenValidationParameters ValidationParameters => throw new NotSupportedException();
+
+			public TokenResponse CreateToken(User user, bool oAuth)
+			{
+				throw new NotSupportedException();
 			}
 		}
 
@@ -138,7 +158,6 @@ namespace Tgstation.Server.Host.Swarm.Tests
 			RpcMapper = new SwarmRpcMapper(
 				(targetService, targetTransfer) => new SwarmController(
 					targetService,
-					mockAssemblyInformationProvider.Object,
 					targetTransfer,
 					mockOptions.Object,
 					loggerFactory.CreateLogger<SwarmController>()),
@@ -153,6 +172,8 @@ namespace Tgstation.Server.Host.Swarm.Tests
 			UpdateCommits = true;
 
 			logger = loggerFactory.CreateLogger($"TestableSwarmNode-{swarmConfiguration.Identifier}");
+
+			var mockTokenFactory = new MockTokenFactory();
 
 			var runCount = 0;
 			void RecreateControllerAndService()
@@ -180,6 +201,7 @@ namespace Tgstation.Server.Host.Swarm.Tests
 					mockAsyncDelayer.Object,
 					mockServerUpdater.Object,
 					TransferService,
+					mockTokenFactory,
 					mockOptions.Object,
 					serviceLogger);
 			}

--- a/tests/Tgstation.Server.Tests/Live/TestLiveServer.cs
+++ b/tests/Tgstation.Server.Tests/Live/TestLiveServer.cs
@@ -670,8 +670,8 @@ namespace Tgstation.Server.Tests.Live
 						newUser.Name,
 						"asdfasdfasdfasdf");
 
-					await using var node1BadClient = clientFactory.CreateFromToken(node1.RootUrl, controllerUserClient.Token);
-					await ApiAssert.ThrowsException<UnauthorizedException, AdministrationResponse>(() => node1BadClient.Administration.Read(false, cancellationToken));
+					await using var node1TokenCopiedClient = clientFactory.CreateFromToken(node1.RootUrl, controllerUserClient.Token);
+					await node1TokenCopiedClient.Administration.Read(false, cancellationToken);
 
 					// check instance info is not shared
 					var controllerInstance = await controllerClient.Instances.CreateOrAttach(


### PR DESCRIPTION
🆑
Swarm server nodes now inherit the token signing key of the controller, meaning that an authentication token generated on one server will work for all servers in the swarm. This behavior occurs for all swarm nodes regardless of `Security` configuration settings.
The swarm protocol is now versioned separately from the TGS core version. This allows for slightly differing servers to group together in a swarm. Updates will still synchronize all servers to the same version. **It is still recommended that all servers in the swarm run the same TGS version.**
/🆑