### PR TITLE
Refactor IrcProvider just a little

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,8 @@ Create an `appsettings.Production.yml` file next to `appsettings.yml`. This will
 
 - `FileLogging:LogLevel`: Can be one of `Trace`, `Debug`, `Information`, `Warning`, `Error`, or `Critical`. Restricts what is put into the log files. Currently `Debug` is reccommended for help with error reporting.
 
+- `FileLogging:ProviderNetworkDebug`: Boolean controlling whether or not Chat bot providers should log their raw network traffic. Currently only applies to IrcProvider.
+
 - `Kestrel:Endpoints:Http:Url`: The URL (i.e. interface and ports) your application should listen on. General use case should be `http://localhost:<port>` for restricted local connections. See the Remote Access section for configuring public access to the World Wide Web. This doesn't need to be changed using the docker setup and should be mapped with the `-p` option instead
 
 - `Database:DatabaseType`: Can be one of `SqlServer`, `MariaDB`, `MySql`, `PostgresSql`, or `Sqlite`.

--- a/build/Version.props
+++ b/build/Version.props
@@ -4,7 +4,7 @@
   <Import Project="WebpanelVersion.props" />
   <PropertyGroup>
     <TgsCoreVersion>6.10.0</TgsCoreVersion>
-    <TgsConfigVersion>5.2.0</TgsConfigVersion>
+    <TgsConfigVersion>5.3.0</TgsConfigVersion>
     <TgsApiVersion>10.10.0</TgsApiVersion>
     <TgsCommonLibraryVersion>7.0.0</TgsCommonLibraryVersion>
     <TgsApiLibraryVersion>16.0.0</TgsApiLibraryVersion>

--- a/src/Tgstation.Server.Api/Models/IrcConnectionStringBuilder.cs
+++ b/src/Tgstation.Server.Api/Models/IrcConnectionStringBuilder.cs
@@ -88,6 +88,7 @@ namespace Tgstation.Server.Api.Models
 					case IrcPasswordType.NickServ:
 					case IrcPasswordType.Sasl:
 					case IrcPasswordType.Server:
+					case IrcPasswordType.Oper:
 						PasswordType = passwordType;
 						break;
 					default:

--- a/src/Tgstation.Server.Api/Models/IrcPasswordType.cs
+++ b/src/Tgstation.Server.Api/Models/IrcPasswordType.cs
@@ -19,5 +19,10 @@
 		/// Use NickServ authentication.
 		/// </summary>
 		NickServ,
+
+		/// <summary>
+		/// Use OPER authentication.
+		/// </summary>
+		Oper,
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/IrcProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/IrcProvider.cs
@@ -127,6 +127,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 			: base(jobManager, asyncDelayer, logger, chatBot)
 		{
 			ArgumentNullException.ThrowIfNull(assemblyInformationProvider);
+			ArgumentNullException.ThrowIfNull(loggingConfiguration);
 
 			var builder = chatBot.CreateConnectionStringBuilder();
 			if (builder == null || !builder.Valid || builder is not IrcConnectionStringBuilder ircBuilder)

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/IrcProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/IrcProvider.cs
@@ -747,10 +747,10 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 			}
 
 			newClient.OnError += (sender, e) =>
-					{
-						Logger.LogError("IRC ERROR: {error}", e.ErrorMessage);
-						newClient.Disconnect();
-					};
+			{
+				Logger.LogError("IRC ERROR: {error}", e.ErrorMessage);
+				newClient.Disconnect();
+			};
 
 			return newClient;
 		}

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/ProviderFactory.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/ProviderFactory.cs
@@ -41,6 +41,11 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		readonly GeneralConfiguration generalConfiguration;
 
 		/// <summary>
+		/// The <see cref="FileLoggingConfiguration"/> for the <see cref="ProviderFactory"/>.
+		/// </summary>
+		readonly FileLoggingConfiguration loggingConfiguration;
+
+		/// <summary>
 		/// Initializes a new instance of the <see cref="ProviderFactory"/> class.
 		/// </summary>
 		/// <param name="jobManager">The value of <see cref="jobManager"/>.</param>
@@ -48,18 +53,21 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		/// <param name="asyncDelayer">The value of <see cref="asyncDelayer"/>.</param>
 		/// <param name="loggerFactory">The value of <see cref="loggerFactory"/>.</param>
 		/// <param name="generalConfigurationOptions">The <see cref="IOptions{TOptions}"/> containing the value of <see cref="generalConfiguration"/>.</param>
+		/// <param name="loggingConfigurationOptions">The <see cref="IOptions{TOptions}"/> containing the value of <see cref="loggingConfiguration"/>.</param>
 		public ProviderFactory(
 			IJobManager jobManager,
 			IAssemblyInformationProvider assemblyInformationProvider,
 			IAsyncDelayer asyncDelayer,
 			ILoggerFactory loggerFactory,
-			IOptions<GeneralConfiguration> generalConfigurationOptions)
+			IOptions<GeneralConfiguration> generalConfigurationOptions,
+			IOptions<FileLoggingConfiguration> loggingConfigurationOptions)
 		{
 			this.jobManager = jobManager ?? throw new ArgumentNullException(nameof(jobManager));
 			this.loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
 			this.asyncDelayer = asyncDelayer ?? throw new ArgumentNullException(nameof(asyncDelayer));
 			this.assemblyInformationProvider = assemblyInformationProvider ?? throw new ArgumentNullException(nameof(assemblyInformationProvider));
 			generalConfiguration = generalConfigurationOptions?.Value ?? throw new ArgumentNullException(nameof(generalConfigurationOptions));
+			loggingConfiguration = loggingConfigurationOptions?.Value ?? throw new ArgumentNullException(nameof(loggingConfigurationOptions));
 		}
 
 		/// <inheritdoc />
@@ -73,7 +81,8 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 					asyncDelayer,
 					loggerFactory.CreateLogger<IrcProvider>(),
 					assemblyInformationProvider,
-					settings),
+					settings,
+					loggingConfiguration),
 				ChatProvider.Discord => new DiscordProvider(
 					jobManager,
 					asyncDelayer,

--- a/src/Tgstation.Server.Host/Configuration/FileLoggingConfiguration.cs
+++ b/src/Tgstation.Server.Host/Configuration/FileLoggingConfiguration.cs
@@ -30,6 +30,11 @@ namespace Tgstation.Server.Host.Configuration
 		public bool Disable { get; set; }
 
 		/// <summary>
+		/// If Chat Providers should log their network traffic. Normally disabled because it is too noisy.
+		/// </summary>
+		public bool ProviderNetworkDebug { get; set; }
+
+		/// <summary>
 		/// The minimum <see cref="Microsoft.Extensions.Logging.LogLevel"/> to display in logs.
 		/// </summary>
 		[JsonConverter(typeof(StringEnumConverter))]

--- a/tests/Tgstation.Server.Host.Tests/Components/Chat/Providers/TestIrcProvider.cs
+++ b/tests/Tgstation.Server.Host.Tests/Components/Chat/Providers/TestIrcProvider.cs
@@ -9,6 +9,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 
 using Tgstation.Server.Api.Models;
+using Tgstation.Server.Host.Configuration;
 using Tgstation.Server.Host.Jobs;
 using Tgstation.Server.Host.Models;
 using Tgstation.Server.Host.System;
@@ -22,15 +23,15 @@ namespace Tgstation.Server.Host.Components.Chat.Providers.Tests
 		[TestMethod]
 		public async Task TestConstructionAndDisposal()
 		{
-			Assert.ThrowsException<ArgumentNullException>(() => new IrcProvider(null, null, null, null, null));
+			Assert.ThrowsException<ArgumentNullException>(() => new IrcProvider(null, null, null, null, null, null));
 			var mockJobManager = new Mock<IJobManager>();
-			Assert.ThrowsException<ArgumentNullException>(() => new IrcProvider(mockJobManager.Object, null, null, null, null));
+			Assert.ThrowsException<ArgumentNullException>(() => new IrcProvider(mockJobManager.Object, null, null, null, null, null));
 			var mockAsyncDelayer = new Mock<IAsyncDelayer>();
-			Assert.ThrowsException<ArgumentNullException>(() => new IrcProvider(mockJobManager.Object, mockAsyncDelayer.Object, null, null, null));
+			Assert.ThrowsException<ArgumentNullException>(() => new IrcProvider(mockJobManager.Object, mockAsyncDelayer.Object, null, null, null, null));
 			var mockLogger = new Mock<ILogger<IrcProvider>>();
-			Assert.ThrowsException<ArgumentNullException>(() => new IrcProvider(mockJobManager.Object, mockAsyncDelayer.Object, mockLogger.Object, null, null));
+			Assert.ThrowsException<ArgumentNullException>(() => new IrcProvider(mockJobManager.Object, mockAsyncDelayer.Object, mockLogger.Object, null, null, null));
 			var mockAss = new Mock<IAssemblyInformationProvider>();
-			Assert.ThrowsException<ArgumentNullException>(() => new IrcProvider(mockJobManager.Object, mockAsyncDelayer.Object, mockLogger.Object, mockAss.Object, null));
+			Assert.ThrowsException<ArgumentNullException>(() => new IrcProvider(mockJobManager.Object, mockAsyncDelayer.Object, mockLogger.Object, mockAss.Object, null, null));
 
 			var mockBot = new ChatBot
 			{
@@ -38,8 +39,10 @@ namespace Tgstation.Server.Host.Components.Chat.Providers.Tests
 				Instance = new Models.Instance(),
 				Provider = ChatProvider.Irc
 			};
+			Assert.ThrowsException<ArgumentNullException>(() => new IrcProvider(mockJobManager.Object, mockAsyncDelayer.Object, mockLogger.Object, mockAss.Object, mockBot, null));
 
-			Assert.ThrowsException<InvalidOperationException>(() => new IrcProvider(mockJobManager.Object, mockAsyncDelayer.Object, mockLogger.Object, mockAss.Object, mockBot));
+			var mockLogConf = new FileLoggingConfiguration();
+			Assert.ThrowsException<InvalidOperationException>(() => new IrcProvider(mockJobManager.Object, mockAsyncDelayer.Object, mockLogger.Object, mockAss.Object, mockBot, mockLogConf));
 
 			mockBot.ConnectionString = new IrcConnectionStringBuilder
 			{
@@ -49,7 +52,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers.Tests
 				Port = 6667
 			}.ToString();
 
-			await new IrcProvider(mockJobManager.Object, mockAsyncDelayer.Object, mockLogger.Object, mockAss.Object, mockBot).DisposeAsync();
+			await new IrcProvider(mockJobManager.Object, mockAsyncDelayer.Object, mockLogger.Object, mockAss.Object, mockBot, mockLogConf).DisposeAsync();
 		}
 
 		static ValueTask InvokeConnect(IProvider provider, CancellationToken cancellationToken = default) => (ValueTask)provider.GetType().GetMethod("Connect", BindingFlags.Instance | BindingFlags.NonPublic).Invoke(provider, new object[] { cancellationToken });
@@ -78,12 +81,15 @@ namespace Tgstation.Server.Host.Components.Chat.Providers.Tests
 				.Setup(x => x.WaitForJobCompletion(It.IsNotNull<Job>(), It.IsAny<User>(), It.IsAny<CancellationToken>(), It.IsAny<CancellationToken>()))
 				.Returns(ValueTask.FromResult<bool?>(true));
 			var mockJobManager = mockSetup.Object;
-			await using var provider = new IrcProvider(mockJobManager, new AsyncDelayer(), loggerFactory.CreateLogger<IrcProvider>(), Mock.Of<IAssemblyInformationProvider>(), new ChatBot
+
+			var chatBot = new ChatBot
 			{
 				ConnectionString = actualToken,
 				Provider = ChatProvider.Irc,
 				Instance = new Models.Instance(),
-			});
+			};
+
+			await using var provider = new IrcProvider(mockJobManager, new AsyncDelayer(), loggerFactory.CreateLogger<IrcProvider>(), Mock.Of<IAssemblyInformationProvider>(), chatBot, new FileLoggingConfiguration());
 			Assert.IsFalse(provider.Connected);
 			await InvokeConnect(provider);
 			Assert.IsTrue(provider.Connected);

--- a/tests/Tgstation.Server.Host.Tests/Components/Chat/Providers/TestIrcProvider.cs
+++ b/tests/Tgstation.Server.Host.Tests/Components/Chat/Providers/TestIrcProvider.cs
@@ -88,6 +88,17 @@ namespace Tgstation.Server.Host.Components.Chat.Providers.Tests
 			await InvokeConnect(provider);
 			Assert.IsTrue(provider.Connected);
 
+			await Task.Delay(2000); // IRC servers do not like it when you connect and disconnect in rapid succession
+
+			await provider.Disconnect(default);
+			Assert.IsFalse(provider.Connected);
+
+			await Task.Delay(2000); // same as above
+
+			await InvokeConnect(provider);
+			await Task.Delay(2000); // make sure it stays connected after a reconnect attempt
+			Assert.IsTrue(provider.Connected);
+
 			await provider.Disconnect(default);
 			Assert.IsFalse(provider.Connected);
 		}


### PR DESCRIPTION
[Base Branch]: # (Please set the base branch of your pull request appropriately. If you only made a patch, code improvement, non-server code change, or comment/documentation update please target the `master` branch. Otherwise, target the `dev` branch.)

[Release Notes]: # (Your PR should contain a detailed list of notable changes, titled appropriately. This includes any observable changes to the server or DMAPI. See examples below.)

🆑 Core
Refactors the IrcProvider to be a bit more resilient.
Fixes the IrcProvider getting permanently stuck if the connection between TGS and IRC is ever severed.
Adds the OPER Irc authentication mode, helpful for anyone running their own IRC servers.
/🆑

🆑 Nuget: API
Adds IrcPasswordType.Oper for /OPER authentication
/🆑

🆑 HTTP API
Adds new IRC authentication type with index 3 for /OPER authentication
/🆑

🆑 Configuration
**The new configuration version is 5.3.0.**
Adds a new `ProviderNetworkDebug` flag in `FileLogging` to debug IRC traffic.
/🆑


[Why]: # (If this does not close or work on an existing GitHub issue, please add a short description [two lines down] of why you think these changes would benefit the server. If you can't justify it in words, it might not be worth adding.)


Related to #1085 but I don't think it should close it.
IrcProvider would break entirely if it ever got disconnected, stuck in a weird infinite loop of trying to connect but aborting of its own accord. This solves that issue by minting a new IrcFeatures client every time a connection attempt is made.
Additionally, the implementation was slightly flaky and would emit useless and broken bytes at the start of every session, this confuses irc servers and should be avoided. IrcProvider will now actually wait for a successful registration instead of just absolutely bean blasting the server and hoping it works. 
The test has been amended to wait and check to ensure the IrcProvider actually stays connected to a server for atleast 2 seconds, and does this test twice. This amended test would have caught the issue in the original IrcProvider.

Also adds a new authentication mode OPER which, as the name implies will do an IRC /OPER at connect. Maybe i'm just the only weirdo who needs that, if so, i'll gladly strip it out if needed. My only justification is that I run a irc server without services and just use the +O (ircop only) channel mode to restrict people getting into my admin channel.

Tested over 2 days, atleast from what I can see is fully functioning and not causing any issues.
