### PR TITLE
Do not attempt to checkout a detached SHA on reclone

### DIFF
--- a/src/Tgstation.Server.Host/Components/Repository/RepositoryUpdateService.cs
+++ b/src/Tgstation.Server.Host/Components/Repository/RepositoryUpdateService.cs
@@ -642,11 +642,10 @@ namespace Tgstation.Server.Host.Components.Repository
 				await deleteTask;
 			}
 
-			IRepository newRepo;
 			try
 			{
-				using var cloneReporter = progressReporter.CreateSection("Cloning New Repository", 0.8);
-				newRepo = await instance.RepositoryManager.CloneRepository(
+				using var cloneReporter = progressReporter.CreateSection("Cloning New Repository", 0.9);
+				using var newRepo = await instance.RepositoryManager.CloneRepository(
 					origin,
 					oldReference,
 					currentModel.AccessUser,
@@ -670,19 +669,6 @@ namespace Tgstation.Server.Host.Components.Repository
 				});
 
 				throw;
-			}
-
-			using (newRepo)
-			using (var checkoutReporter = progressReporter.CreateSection("Checking out previous Detached Commit", 0.1))
-			{
-				await newRepo.CheckoutObject(
-					oldSha,
-					currentModel.AccessUser,
-					currentModel.AccessToken,
-					false,
-					oldReference != null,
-					checkoutReporter,
-					cancellationToken);
 			}
 		}
 	}

--- a/tests/Tgstation.Server.Tests/Live/Instance/RepositoryTest.cs
+++ b/tests/Tgstation.Server.Tests/Live/Instance/RepositoryTest.cs
@@ -116,8 +116,6 @@ namespace Tgstation.Server.Tests.Live.Instance
 			await ApiAssert.ThrowsException<ApiConflictException, RepositoryResponse>(() => Checkout(new RepositoryUpdateRequest { Reference = "master", CheckoutSha = "286bb75" }, false, false, cancellationToken), ErrorCode.RepoMismatchShaAndReference);
 			var updated = await Checkout(new RepositoryUpdateRequest { CheckoutSha = "286bb75" }, false, false, cancellationToken);
 
-			await RecloneTest(cancellationToken);
-
 			// Fake SHA
 			updated = await Checkout(new RepositoryUpdateRequest { CheckoutSha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }, true, false, cancellationToken);
 
@@ -126,6 +124,8 @@ namespace Tgstation.Server.Tests.Live.Instance
 
 			// Back
 			updated = await Checkout(new RepositoryUpdateRequest { Reference = "master" }, false, true, cancellationToken);
+
+			await RecloneTest(cancellationToken);
 
 			// enable the good shit if possible
 			if (!String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("TGS_TEST_GITHUB_TOKEN"))


### PR DESCRIPTION
:cl:
Re-cloning a repository no longer attempts to checkout the exact SHA that it was previously on, rather using the reference instead. This was problematic with SHAs that were generated by test merges. If no reference is available, the default branch on the origin will be cloned.
/:cl:
