### PR TITLE
Instance Start/Stop crons + Fixes

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -5,15 +5,15 @@
   <PropertyGroup>
     <TgsCoreVersion>6.12.0</TgsCoreVersion>
     <TgsConfigVersion>5.4.0</TgsConfigVersion>
-    <TgsRestVersion>10.11.0</TgsRestVersion>
+    <TgsRestVersion>10.12.0</TgsRestVersion>
     <TgsGraphQLVersion>0.5.0</TgsGraphQLVersion>
     <TgsCommonLibraryVersion>7.0.0</TgsCommonLibraryVersion>
-    <TgsApiLibraryVersion>16.2.0</TgsApiLibraryVersion>
-    <TgsClientVersion>19.2.0</TgsClientVersion>
+    <TgsApiLibraryVersion>16.3.0</TgsApiLibraryVersion>
+    <TgsClientVersion>19.3.0</TgsClientVersion>
     <TgsDmapiVersion>7.3.0</TgsDmapiVersion>
     <TgsInteropVersion>5.10.0</TgsInteropVersion>
     <TgsHostWatchdogVersion>1.5.0</TgsHostWatchdogVersion>
-    <TgsSwarmProtocolVersion>7.0.0</TgsSwarmProtocolVersion>
+    <TgsSwarmProtocolVersion>8.0.0</TgsSwarmProtocolVersion>
     <TgsContainerScriptVersion>1.2.1</TgsContainerScriptVersion>
     <TgsMigratorVersion>2.0.0</TgsMigratorVersion>
     <TgsNugetNetFramework>netstandard2.0</TgsNugetNetFramework>

--- a/src/Tgstation.Server.Api/Models/Instance.cs
+++ b/src/Tgstation.Server.Api/Models/Instance.cs
@@ -40,7 +40,7 @@ namespace Tgstation.Server.Api.Models
 		/// </summary>
 		/// <remarks>Updates will not be triggered if the previous update is still running. Incompatible with <see cref="AutoUpdateInterval"/>.</remarks>
 		[Required]
-		[StringLength(Limits.MaximumStringLength)]
+		[StringLength(Limits.CronStringLength)]
 		public string? AutoUpdateCron { get; set; }
 
 		/// <summary>
@@ -48,5 +48,21 @@ namespace Tgstation.Server.Api.Models
 		/// </summary>
 		[Required]
 		public ushort? ChatBotLimit { get; set; }
+
+		/// <summary>
+		/// A cron expression indicating when the game server should start. Must be a valid 6 part cron schedule (SECONDS MINUTES HOURS DAY/MONTH MONTH DAY/WEEK). Empty <see cref="string"/> disables.
+		/// </summary>
+		/// <remarks>This will have no effect if the game server is already running when it fires.</remarks>
+		[Required]
+		[StringLength(Limits.CronStringLength)]
+		public string? AutoStartCron { get; set; }
+
+		/// <summary>
+		/// A cron expression indicating when the game server should stop. Must be a valid 6 part cron schedule (SECONDS MINUTES HOURS DAY/MONTH MONTH DAY/WEEK). Empty <see cref="string"/> disables.
+		/// </summary>
+		/// <remarks>This will have no effect if the game server is not running when it fires.</remarks>
+		[Required]
+		[StringLength(Limits.CronStringLength)]
+		public string? AutoStopCron { get; set; }
 	}
 }

--- a/src/Tgstation.Server.Api/Models/Limits.cs
+++ b/src/Tgstation.Server.Api/Models/Limits.cs
@@ -13,6 +13,11 @@ namespace Tgstation.Server.Api.Models
 		public const int MaximumStringLength = 10000;
 
 		/// <summary>
+		/// Length limit for cron strings in fields.
+		/// </summary>
+		public const int CronStringLength = 1000;
+
+		/// <summary>
 		/// Length limit for <see cref="NamedEntity.Name"/>s.
 		/// </summary>
 		public const int MaximumIndexableStringLength = 100;

--- a/src/Tgstation.Server.Api/Rights/InstanceManagerRights.cs
+++ b/src/Tgstation.Server.Api/Rights/InstanceManagerRights.cs
@@ -67,5 +67,15 @@ namespace Tgstation.Server.Api.Rights
 		/// User can give themselves or their group full <see cref="InstancePermissionSetRights"/> on ALL instances.
 		/// </summary>
 		GrantPermissions = 1 << 10,
+
+		/// <summary>
+		/// User can change <see cref="Models.Instance.AutoStartCron"/>.
+		/// </summary>
+		SetAutoStart = 1 << 11,
+
+		/// <summary>
+		/// User can change <see cref="Models.Instance.AutoStopCron"/>.
+		/// </summary>
+		SetAutoStop = 1 << 12,
 	}
 }

--- a/src/Tgstation.Server.Host/Authority/AdministrationAuthority.cs
+++ b/src/Tgstation.Server.Host/Authority/AdministrationAuthority.cs
@@ -98,11 +98,12 @@ namespace Tgstation.Server.Host.Authority
 				{
 					Version? greatestVersion = null;
 					Uri? repoUrl = null;
+					var scopeCancellationToken = CancellationToken.None; // DCT: None available
 					try
 					{
-						var gitHubService = await gitHubServiceFactory.CreateService(cancellationToken);
-						var repositoryUrlTask = gitHubService.GetUpdatesRepositoryUrl(cancellationToken);
-						var releases = await gitHubService.GetTgsReleases(cancellationToken);
+						var gitHubService = await gitHubServiceFactory.CreateService(scopeCancellationToken);
+						var repositoryUrlTask = gitHubService.GetUpdatesRepositoryUrl(scopeCancellationToken);
+						var releases = await gitHubService.GetTgsReleases(scopeCancellationToken);
 
 						foreach (var kvp in releases)
 						{
@@ -139,7 +140,8 @@ namespace Tgstation.Server.Host.Authority
 				else
 					task = (Task<AdministrationResponse>)rawCacheObject!;
 
-				return new AuthorityResponse<AdministrationResponse>(await task);
+				var result = await task.WaitAsync(cancellationToken);
+				return new AuthorityResponse<AdministrationResponse>(result);
 			}
 			catch (RateLimitExceededException e)
 			{

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/IrcProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/IrcProvider.cs
@@ -710,7 +710,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 				Task.WhenAll(
 					disconnectTask,
 					listenTask ?? Task.CompletedTask),
-				AsyncDelayer.Delay(TimeSpan.FromSeconds(5), cancellationToken));
+				AsyncDelayer.Delay(TimeSpan.FromSeconds(5), cancellationToken).AsTask());
 		}
 
 		/// <summary>

--- a/src/Tgstation.Server.Host/Components/Engine/OpenDreamInstallation.cs
+++ b/src/Tgstation.Server.Host/Components/Engine/OpenDreamInstallation.cs
@@ -135,7 +135,7 @@ namespace Tgstation.Server.Host.Components.Engine
 			const int MaximumTerminationSeconds = 5;
 
 			logger.LogTrace("Attempting Robust.Server graceful exit (Timeout: {seconds}s)...", MaximumTerminationSeconds);
-			var timeout = asyncDelayer.Delay(TimeSpan.FromSeconds(MaximumTerminationSeconds), cancellationToken);
+			var timeout = asyncDelayer.Delay(TimeSpan.FromSeconds(MaximumTerminationSeconds), cancellationToken).AsTask();
 			var lifetime = process.Lifetime;
 			if (lifetime.IsCompleted)
 				logger.LogTrace("Robust.Server already exited");

--- a/src/Tgstation.Server.Host/Components/IInstanceCore.cs
+++ b/src/Tgstation.Server.Host/Components/IInstanceCore.cs
@@ -51,5 +51,19 @@ namespace Tgstation.Server.Host.Components
 		/// <param name="newCron">The new auto-update cron schedule.</param>
 		/// <returns>A <see cref="ValueTask"/> representing the running operation.</returns>
 		ValueTask ScheduleAutoUpdate(uint newInterval, string? newCron);
+
+		/// <summary>
+		/// Change the server auto-start timing for the <see cref="IInstanceCore"/>.
+		/// </summary>
+		/// <param name="newCron">The new auto-start cron schedule.</param>
+		/// <returns>A <see cref="ValueTask"/> representing the running operation.</returns>
+		ValueTask ScheduleServerStart(string? newCron);
+
+		/// <summary>
+		/// Change the server auto-stop timing for the <see cref="IInstanceCore"/>.
+		/// </summary>
+		/// <param name="newCron">The new auto-stop cron schedule.</param>
+		/// <returns>A <see cref="ValueTask"/> representing the running operation.</returns>
+		ValueTask ScheduleServerStop(string? newCron);
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Instance.cs
+++ b/src/Tgstation.Server.Host/Components/Instance.cs
@@ -89,19 +89,39 @@ namespace Tgstation.Server.Host.Components
 		readonly Api.Models.Instance metadata;
 
 		/// <summary>
-		/// <see langword="lock"/> <see cref="object"/> for <see cref="timerCts"/> and <see cref="timerTask"/>.
+		/// <see langword="lock"/> <see cref="object"/> for <see cref="autoUpdateCts"/> and <see cref="autoUpdateTask"/>.
 		/// </summary>
 		readonly object timerLock;
 
 		/// <summary>
-		/// The auto update <see cref="Task"/>.
+		/// The auto-update <see cref="Task"/>.
 		/// </summary>
-		Task? timerTask;
+		Task? autoUpdateTask;
 
 		/// <summary>
-		/// <see cref="CancellationTokenSource"/> for <see cref="timerTask"/>.
+		/// <see cref="CancellationTokenSource"/> for <see cref="autoUpdateTask"/>.
 		/// </summary>
-		CancellationTokenSource? timerCts;
+		CancellationTokenSource? autoUpdateCts;
+
+		/// <summary>
+		/// The auto-start <see cref="Task"/>.
+		/// </summary>
+		Task? autoStartTask;
+
+		/// <summary>
+		/// <see cref="CancellationTokenSource"/> for <see cref="autoStartTask"/>.
+		/// </summary>
+		CancellationTokenSource? autoStartCts;
+
+		/// <summary>
+		/// The auto-stop <see cref="Task"/>.
+		/// </summary>
+		Task? autoStopTask;
+
+		/// <summary>
+		/// <see cref="CancellationTokenSource"/> for <see cref="autoStopTask"/>.
+		/// </summary>
+		CancellationTokenSource? autoStopCts;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Instance"/> class.
@@ -159,7 +179,9 @@ namespace Tgstation.Server.Host.Components
 			{
 				var chatDispose = Chat.DisposeAsync();
 				var watchdogDispose = Watchdog.DisposeAsync();
-				timerCts?.Dispose();
+				autoUpdateCts?.Dispose();
+				autoStartCts?.Dispose();
+				autoStopCts?.Dispose();
 				Configuration.Dispose();
 				dmbFactory.Dispose();
 				RepositoryManager.Dispose();
@@ -187,6 +209,8 @@ namespace Tgstation.Server.Host.Components
 			{
 				await Task.WhenAll(
 					ScheduleAutoUpdate(metadata.Require(x => x.AutoUpdateInterval), metadata.AutoUpdateCron).AsTask(),
+					ScheduleServerStart(null).AsTask(),
+					ScheduleServerStop(null).AsTask(),
 					Configuration.StartAsync(cancellationToken),
 					EngineManager.StartAsync(cancellationToken),
 					Chat.StartAsync(cancellationToken),
@@ -223,14 +247,14 @@ namespace Tgstation.Server.Host.Components
 
 			Task toWait;
 			lock (timerLock)
-				if (timerTask != null)
+				if (autoUpdateTask != null)
 				{
 					logger.LogTrace("Cancelling auto-update task");
-					timerCts!.Cancel();
-					timerCts.Dispose();
-					toWait = timerTask;
-					timerTask = null;
-					timerCts = null;
+					autoUpdateCts!.Cancel();
+					autoUpdateCts.Dispose();
+					toWait = autoUpdateTask;
+					autoUpdateTask = null;
+					autoUpdateCts = null;
 				}
 				else
 					toWait = Task.CompletedTask;
@@ -245,14 +269,95 @@ namespace Tgstation.Server.Host.Components
 			lock (timerLock)
 			{
 				// race condition, just quit
-				if (timerTask != null)
+				if (autoUpdateTask != null)
 				{
 					logger.LogWarning("Aborting auto-update scheduling change due to race condition!");
 					return;
 				}
 
-				timerCts = new CancellationTokenSource();
-				timerTask = TimerLoop(newInterval, newCron, timerCts.Token);
+				autoUpdateCts = new CancellationTokenSource();
+				autoUpdateTask = TimerLoop(AutoUpdateAction, "auto-update", newInterval, newCron, autoUpdateCts.Token);
+			}
+		}
+
+		/// <inheritdoc />
+		public async ValueTask ScheduleServerStart(string? newCron)
+		{
+			Task toWait;
+			lock (timerLock)
+				if (autoStartTask != null)
+				{
+					logger.LogTrace("Cancelling auto-start task");
+					autoStartCts!.Cancel();
+					autoStartCts.Dispose();
+					toWait = autoStartTask;
+					autoStartTask = null;
+					autoStartCts = null;
+				}
+				else
+					toWait = Task.CompletedTask;
+
+			await toWait;
+			if (String.IsNullOrWhiteSpace(newCron))
+			{
+				logger.LogTrace("Auto-start disabled. Not starting task.");
+				return;
+			}
+
+			lock (timerLock)
+			{
+				// race condition, just quit
+				if (autoStartTask != null)
+				{
+					logger.LogWarning("Aborting auto-start scheduling change due to race condition!");
+					return;
+				}
+
+				autoStartCts = new CancellationTokenSource();
+				autoStartTask = TimerLoop(Watchdog.Launch, "auto-start", 0, newCron, autoStartCts.Token);
+			}
+		}
+
+		/// <inheritdoc />
+		public async ValueTask ScheduleServerStop(string? newCron)
+		{
+			Task toWait;
+			lock (timerLock)
+				if (autoStopTask != null)
+				{
+					logger.LogTrace("Cancelling auto-stop task");
+					autoStopCts!.Cancel();
+					autoStopCts.Dispose();
+					toWait = autoStopTask;
+					autoStopTask = null;
+					autoStopCts = null;
+				}
+				else
+					toWait = Task.CompletedTask;
+
+			await toWait;
+			if (String.IsNullOrWhiteSpace(newCron))
+			{
+				logger.LogTrace("Auto-stop disabled. Not stoping task.");
+				return;
+			}
+
+			lock (timerLock)
+			{
+				// race condition, just quit
+				if (autoStopTask != null)
+				{
+					logger.LogWarning("Aborting auto-stop scheduling change due to race condition!");
+					return;
+				}
+
+				autoStopCts = new CancellationTokenSource();
+				autoStopTask = TimerLoop(
+					async cancellationToken => await Watchdog.Terminate(true, cancellationToken),
+					"auto-stop",
+					0,
+					newCron,
+					autoStopCts.Token);
 			}
 		}
 
@@ -485,14 +590,15 @@ namespace Tgstation.Server.Host.Components
 #pragma warning restore CA1502   // Cyclomatic complexity
 
 		/// <summary>
-		/// Pull the repository and compile for every set of given <paramref name="minutes"/>.
+		/// Runs a <paramref name="timerAction"/> every set of given <paramref name="minutes"/> or on a given <paramref name="cron"/> schedule.
 		/// </summary>
+		/// <param name="timerAction">The action to take when the timer elapses.</param>
+		/// <param name="description">A description of the <paramref name="timerAction"/>.</param>
 		/// <param name="minutes">How many minutes the operation should repeat. Does not include running time.</param>
 		/// <param name="cron">Alternative cron schedule.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="Task"/> representing the running operation.</returns>
-#pragma warning disable CA1502 // TODO: Decomplexify
-		async Task TimerLoop(uint minutes, string? cron, CancellationToken cancellationToken)
+		async Task TimerLoop(Func<CancellationToken, ValueTask> timerAction, string description, uint minutes, string? cron, CancellationToken cancellationToken)
 		{
 			logger.LogDebug("Entering auto-update loop");
 			while (true)
@@ -519,76 +625,86 @@ namespace Tgstation.Server.Host.Components
 						delay = TimeSpan.FromMinutes(minutes);
 					}
 
-					logger.LogInformation("Next auto-update will occur at {time}", DateTimeOffset.UtcNow + delay);
+					logger.LogInformation("Next {desc} will occur at {time}", description, DateTimeOffset.UtcNow + delay);
 
 					await asyncDelayer.Delay(delay, cancellationToken);
-					logger.LogInformation("Beginning auto update...");
-					await eventConsumer.HandleEvent(EventType.InstanceAutoUpdateStart, Enumerable.Empty<string>(), true, cancellationToken);
 
-					var repositoryUpdateJob = Job.Create(Api.Models.JobCode.RepositoryAutoUpdate, null, metadata, RepositoryRights.CancelPendingChanges);
-					await jobManager.RegisterOperation(
-						repositoryUpdateJob,
-						RepositoryAutoUpdateJob,
-						cancellationToken);
-
-					var repoUpdateJobResult = await jobManager.WaitForJobCompletion(repositoryUpdateJob, null, cancellationToken, cancellationToken);
-					if (repoUpdateJobResult == false)
-					{
-						logger.LogWarning("Aborting auto-update due to repository update error!");
-						continue;
-					}
-
-					Job compileProcessJob;
-					using (var repo = await RepositoryManager.LoadRepository(cancellationToken))
-					{
-						if (repo == null)
-							throw new JobException(Api.Models.ErrorCode.RepoMissing);
-
-						var deploySha = repo.Head;
-						if (deploySha == null)
-						{
-							logger.LogTrace("Aborting auto update, repository error!");
-							continue;
-						}
-
-						if (deploySha == (await LatestCompileJob())?.RevisionInformation.CommitSha)
-						{
-							logger.LogTrace("Aborting auto update, same revision as latest CompileJob");
-							continue;
-						}
-
-						// finally set up the job
-						compileProcessJob = Job.Create(Api.Models.JobCode.AutomaticDeployment, null, metadata, DreamMakerRights.CancelCompile);
-						await jobManager.RegisterOperation(
-							compileProcessJob,
-							(core, databaseContextFactory, job, progressReporter, jobCancellationToken) =>
-							{
-								if (core != this)
-									throw new InvalidOperationException(DifferentCoreExceptionMessage);
-								return DreamMaker.DeploymentProcess(
-									job,
-									databaseContextFactory,
-									progressReporter,
-									jobCancellationToken);
-							},
-							cancellationToken);
-					}
-
-					await jobManager.WaitForJobCompletion(compileProcessJob, null, default, cancellationToken);
+					await timerAction(cancellationToken);
 				}
 				catch (OperationCanceledException)
 				{
-					logger.LogDebug("Cancelled auto update loop!");
+					logger.LogDebug("Cancelled {desc} loop!", description);
 					break;
 				}
 				catch (Exception e)
 				{
-					logger.LogError(e, "Error in auto update loop!");
+					logger.LogError(e, "Error in {desc} loop!", description);
 					continue;
 				}
 
-			logger.LogTrace("Leaving auto update loop...");
+			logger.LogTrace("Leaving {desc} loop...", description);
 		}
-#pragma warning restore CA1502
+
+		/// <summary>
+		/// Pulls the repository and compiles.
+		/// </summary>
+		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
+		/// <returns>A <see cref="ValueTask"/> representing the running operation.</returns>
+		async ValueTask AutoUpdateAction(CancellationToken cancellationToken)
+		{
+			logger.LogInformation("Beginning auto update...");
+			await eventConsumer.HandleEvent(EventType.InstanceAutoUpdateStart, Enumerable.Empty<string>(), true, cancellationToken);
+
+			var repositoryUpdateJob = Job.Create(Api.Models.JobCode.RepositoryAutoUpdate, null, metadata, RepositoryRights.CancelPendingChanges);
+			await jobManager.RegisterOperation(
+				repositoryUpdateJob,
+				RepositoryAutoUpdateJob,
+				cancellationToken);
+
+			var repoUpdateJobResult = await jobManager.WaitForJobCompletion(repositoryUpdateJob, null, cancellationToken, cancellationToken);
+			if (repoUpdateJobResult == false)
+			{
+				logger.LogWarning("Aborting auto-update due to repository update error!");
+				return;
+			}
+
+			Job compileProcessJob;
+			using (var repo = await RepositoryManager.LoadRepository(cancellationToken))
+			{
+				if (repo == null)
+					throw new JobException(Api.Models.ErrorCode.RepoMissing);
+
+				var deploySha = repo.Head;
+				if (deploySha == null)
+				{
+					logger.LogTrace("Aborting auto update, repository error!");
+					return;
+				}
+
+				if (deploySha == (await LatestCompileJob())?.RevisionInformation.CommitSha)
+				{
+					logger.LogTrace("Aborting auto update, same revision as latest CompileJob");
+					return;
+				}
+
+				// finally set up the job
+				compileProcessJob = Job.Create(Api.Models.JobCode.AutomaticDeployment, null, metadata, DreamMakerRights.CancelCompile);
+				await jobManager.RegisterOperation(
+					compileProcessJob,
+					(core, databaseContextFactory, job, progressReporter, jobCancellationToken) =>
+					{
+						if (core != this)
+							throw new InvalidOperationException(DifferentCoreExceptionMessage);
+						return DreamMaker.DeploymentProcess(
+							job,
+							databaseContextFactory,
+							progressReporter,
+							jobCancellationToken);
+					},
+					cancellationToken);
+			}
+
+			await jobManager.WaitForJobCompletion(compileProcessJob, null, default, cancellationToken);
+		}
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Instance.cs
+++ b/src/Tgstation.Server.Host/Components/Instance.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -521,30 +520,6 @@ namespace Tgstation.Server.Host.Components
 					}
 
 					logger.LogInformation("Next auto-update will occur at {time}", DateTimeOffset.UtcNow + delay);
-
-					// https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task.delay?view=net-8.0#system-threading-tasks-task-delay(system-timespan)
-					const uint DelayMinutesLimit = UInt32.MaxValue - 1;
-					Debug.Assert(DelayMinutesLimit == 4294967294, "Delay limit assertion failure!");
-
-					var maxDelayIterations = 0UL;
-					if (delay.TotalMilliseconds >= UInt32.MaxValue)
-					{
-						maxDelayIterations = (ulong)Math.Floor(delay.TotalMilliseconds / DelayMinutesLimit);
-						logger.LogDebug("Breaking interval into {iterationCount} iterations", maxDelayIterations + 1);
-						delay = TimeSpan.FromMilliseconds(delay.TotalMilliseconds - (maxDelayIterations * DelayMinutesLimit));
-					}
-
-					if (maxDelayIterations > 0)
-					{
-						var longDelayTimeSpan = TimeSpan.FromMilliseconds(DelayMinutesLimit);
-						for (var i = 0UL; i < maxDelayIterations; ++i)
-						{
-							logger.LogTrace("Long delay #{iteration}...", i + 1);
-							await asyncDelayer.Delay(longDelayTimeSpan, cancellationToken);
-						}
-
-						logger.LogTrace("Final delay iteration #{iteration}...", maxDelayIterations + 1);
-					}
 
 					await asyncDelayer.Delay(delay, cancellationToken);
 					logger.LogInformation("Beginning auto update...");

--- a/src/Tgstation.Server.Host/Components/InstanceManager.cs
+++ b/src/Tgstation.Server.Host/Components/InstanceManager.cs
@@ -541,7 +541,7 @@ namespace Tgstation.Server.Host.Components
 							loggedDelay = true;
 						}
 
-						delayTask = asyncDelayer.Delay(TimeSpan.FromMilliseconds(100), cancellationToken);
+						delayTask = asyncDelayer.Delay(TimeSpan.FromMilliseconds(100), cancellationToken).AsTask();
 					}
 
 				await delayTask;

--- a/src/Tgstation.Server.Host/Components/InstanceWrapper.cs
+++ b/src/Tgstation.Server.Host/Components/InstanceWrapper.cs
@@ -59,5 +59,11 @@ namespace Tgstation.Server.Host.Components
 
 		/// <inheritdoc />
 		public ValueTask<CompileJob?> LatestCompileJob() => Instance.LatestCompileJob();
+
+		/// <inheritdoc />
+		public ValueTask ScheduleServerStart(string? newCron) => Instance.ScheduleServerStart(newCron);
+
+		/// <inheritdoc />
+		public ValueTask ScheduleServerStop(string? newCron) => Instance.ScheduleServerStop(newCron);
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Session/SessionController.cs
+++ b/src/Tgstation.Server.Host/Components/Session/SessionController.cs
@@ -547,7 +547,8 @@ namespace Tgstation.Server.Host.Components.Session
 					toAwait,
 					asyncDelayer.Delay(
 						TimeSpan.FromSeconds(startupTimeout.Value),
-						CancellationToken.None)); // DCT: None available, task will clean up after delay
+						CancellationToken.None)
+					.AsTask()); // DCT: None available, task will clean up after delay
 
 			Logger.LogTrace(
 				"Waiting for LaunchResult based on {launchResultCompletionCause}{possibleTimeout}...",
@@ -611,7 +612,7 @@ namespace Tgstation.Server.Host.Components.Session
 
 			const int GracePeriodSeconds = 30;
 			Logger.LogDebug("Server will terminated in {gracePeriodSeconds}s if it does not exit...", GracePeriodSeconds);
-			var delayTask = asyncDelayer.Delay(TimeSpan.FromSeconds(GracePeriodSeconds), CancellationToken.None); // DCT: None available
+			var delayTask = asyncDelayer.Delay(TimeSpan.FromSeconds(GracePeriodSeconds), CancellationToken.None).AsTask(); // DCT: None available
 			await Task.WhenAny(process.Lifetime, delayTask);
 
 			if (!process.Lifetime.IsCompleted)

--- a/src/Tgstation.Server.Host/Components/Watchdog/AdvancedWatchdog.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/AdvancedWatchdog.cs
@@ -185,7 +185,7 @@ namespace Tgstation.Server.Host.Components.Watchdog
 						lingeringDeploymentExpirySeconds);
 
 					// DCT: A cancel firing here can result in us leaving a dmbprovider undisposed, localDeploymentCleanupGate will always fire in that case
-					var timeout = AsyncDelayer.Delay(TimeSpan.FromSeconds(lingeringDeploymentExpirySeconds), CancellationToken.None);
+					var timeout = AsyncDelayer.Delay(TimeSpan.FromSeconds(lingeringDeploymentExpirySeconds), CancellationToken.None).AsTask();
 
 					var completedTask = await Task.WhenAny(
 						localDeploymentCleanupGate.Task,

--- a/src/Tgstation.Server.Host/Controllers/AdministrationController.cs
+++ b/src/Tgstation.Server.Host/Controllers/AdministrationController.cs
@@ -124,7 +124,7 @@ namespace Tgstation.Server.Host.Controllers
 		/// Attempt to perform a server upgrade.
 		/// </summary>
 		/// <param name="model">The <see cref="ServerUpdateRequest"/>.</param>
-		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
+		/// <param name="cancellationToken">The <see cref="Cancellati6onToken"/> for the operation.</param>
 		/// <returns>A <see cref="ValueTask{TResult}"/> resulting in the <see cref="IActionResult"/> for the operation.</returns>
 		/// <response code="202">Update has been started successfully.</response>
 		/// <response code="410">The requested release version could not be found in the target GitHub repository.</response>

--- a/src/Tgstation.Server.Host/Controllers/AdministrationController.cs
+++ b/src/Tgstation.Server.Host/Controllers/AdministrationController.cs
@@ -124,7 +124,7 @@ namespace Tgstation.Server.Host.Controllers
 		/// Attempt to perform a server upgrade.
 		/// </summary>
 		/// <param name="model">The <see cref="ServerUpdateRequest"/>.</param>
-		/// <param name="cancellationToken">The <see cref="Cancellati6onToken"/> for the operation.</param>
+		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
 		/// <returns>A <see cref="ValueTask{TResult}"/> resulting in the <see cref="IActionResult"/> for the operation.</returns>
 		/// <response code="202">Update has been started successfully.</response>
 		/// <response code="410">The requested release version could not be found in the target GitHub repository.</response>

--- a/src/Tgstation.Server.Host/Database/DatabaseContext.cs
+++ b/src/Tgstation.Server.Host/Database/DatabaseContext.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
@@ -485,7 +485,7 @@ namespace Tgstation.Server.Host.Database
 			if (targetVersion < new Version(6, 7, 0))
 				targetMigration = currentDatabaseType switch
 				{
-					DatabaseType.MySql => nameof(MSAddCronAutoUpdates),
+					DatabaseType.MySql => nameof(MYAddCronAutoUpdates),
 					DatabaseType.PostgresSql => nameof(PGAddCronAutoUpdates),
 					DatabaseType.SqlServer => nameof(MSAddCronAutoUpdates),
 					DatabaseType.Sqlite => nameof(SLAddCronAutoUpdates),

--- a/src/Tgstation.Server.Host/Database/DatabaseContext.cs
+++ b/src/Tgstation.Server.Host/Database/DatabaseContext.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
@@ -451,22 +451,22 @@ namespace Tgstation.Server.Host.Database
 		/// <summary>
 		/// Used by unit tests to remind us to setup the correct MSSQL migration downgrades.
 		/// </summary>
-		internal static readonly Type MSLatestMigration = typeof(MSAddDMApiValidationMode);
+		internal static readonly Type MSLatestMigration = typeof(MSAddAutoStartAndStop);
 
 		/// <summary>
 		/// Used by unit tests to remind us to setup the correct MYSQL migration downgrades.
 		/// </summary>
-		internal static readonly Type MYLatestMigration = typeof(MYAddDMApiValidationMode);
+		internal static readonly Type MYLatestMigration = typeof(MYAddAutoStartAndStop);
 
 		/// <summary>
 		/// Used by unit tests to remind us to setup the correct PostgresSQL migration downgrades.
 		/// </summary>
-		internal static readonly Type PGLatestMigration = typeof(PGAddDMApiValidationMode);
+		internal static readonly Type PGLatestMigration = typeof(PGAddAutoStartAndStop);
 
 		/// <summary>
 		/// Used by unit tests to remind us to setup the correct SQLite migration downgrades.
 		/// </summary>
-		internal static readonly Type SLLatestMigration = typeof(SLAddDMApiValidationMode);
+		internal static readonly Type SLLatestMigration = typeof(SLAddAutoStartAndStop);
 
 		/// <summary>
 		/// Gets the name of the migration to run for migrating down to a given <paramref name="targetVersion"/> for the <paramref name="currentDatabaseType"/>.
@@ -482,6 +482,16 @@ namespace Tgstation.Server.Host.Database
 			string BadDatabaseType() => throw new ArgumentException($"Invalid DatabaseType: {currentDatabaseType}", nameof(currentDatabaseType));
 
 			// !!! DON'T FORGET TO UPDATE THE SWARM PROTOCOL MAJOR VERSION !!!
+			if (targetVersion < new Version(6, 12, 0))
+				targetMigration = currentDatabaseType switch
+				{
+					DatabaseType.MySql => nameof(MYAddDMApiValidationMode),
+					DatabaseType.PostgresSql => nameof(PGAddDMApiValidationMode),
+					DatabaseType.SqlServer => nameof(MSAddDMApiValidationMode),
+					DatabaseType.Sqlite => nameof(SLAddDMApiValidationMode),
+					_ => BadDatabaseType(),
+				};
+
 			if (targetVersion < new Version(6, 7, 0))
 				targetMigration = currentDatabaseType switch
 				{

--- a/src/Tgstation.Server.Host/Database/Migrations/20241103161845_MSAddAutoStartAndStop.Designer.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20241103161845_MSAddAutoStartAndStop.Designer.cs
@@ -3,20 +3,23 @@ using System;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Tgstation.Server.Host.Database
 {
-	[DbContext(typeof(PostgresSqlDatabaseContext))]
-	partial class PostgresSqlDatabaseContextModelSnapshot : ModelSnapshot
+	[DbContext(typeof(SqlServerDatabaseContext))]
+	[Migration("20241103161845_MSAddAutoStartAndStop")]
+	partial class MSAddAutoStartAndStop
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		/// <inheritdoc />
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder
 				.HasAnnotation("ProductVersion", "8.0.10")
-				.HasAnnotation("Relational:MaxIdentifierLength", 63);
+				.HasAnnotation("Relational:MaxIdentifierLength", 128);
 
-			NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
+			SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.ChatBot", b =>
 			{
@@ -24,18 +27,18 @@ namespace Tgstation.Server.Host.Database
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<int>("ChannelLimit")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<string>("ConnectionString")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<bool?>("Enabled")
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
@@ -43,10 +46,10 @@ namespace Tgstation.Server.Host.Database
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("nvarchar(100)");
 
 				b.Property<int>("Provider")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<long>("ReconnectionInterval")
 					.HasColumnType("bigint");
@@ -65,45 +68,47 @@ namespace Tgstation.Server.Host.Database
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<long>("ChatSettingsId")
 					.HasColumnType("bigint");
 
 				b.Property<decimal?>("DiscordChannelId")
-					.HasColumnType("numeric(20,0)");
+					.HasColumnType("decimal(20,0)");
 
 				b.Property<string>("IrcChannel")
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("nvarchar(100)");
 
 				b.Property<bool?>("IsAdminChannel")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<bool?>("IsSystemChannel")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<bool?>("IsUpdatesChannel")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<bool?>("IsWatchdogChannel")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<string>("Tag")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("nvarchar(max)");
 
 				b.HasKey("Id");
 
 				b.HasIndex("ChatSettingsId", "DiscordChannelId")
-					.IsUnique();
+					.IsUnique()
+					.HasFilter("[DiscordChannelId] IS NOT NULL");
 
 				b.HasIndex("ChatSettingsId", "IrcChannel")
-					.IsUnique();
+					.IsUnique()
+					.HasFilter("[IrcChannel] IS NOT NULL");
 
 				b.ToTable("ChatChannels");
 			});
@@ -114,28 +119,28 @@ namespace Tgstation.Server.Host.Database
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<int?>("DMApiMajorVersion")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int?>("DMApiMinorVersion")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int?>("DMApiPatchVersion")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<Guid?>("DirectoryName")
 					.IsRequired()
-					.HasColumnType("uuid");
+					.HasColumnType("uniqueidentifier");
 
 				b.Property<string>("DmeName")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<string>("EngineVersion")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<long?>("GitHubDeploymentId")
 					.HasColumnType("bigint");
@@ -147,14 +152,14 @@ namespace Tgstation.Server.Host.Database
 					.HasColumnType("bigint");
 
 				b.Property<int?>("MinimumSecurityLevel")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<string>("Output")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<string>("RepositoryOrigin")
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<long>("RevisionInformationId")
 					.HasColumnType("bigint");
@@ -177,24 +182,24 @@ namespace Tgstation.Server.Host.Database
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<string>("AdditionalParameters")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<bool?>("AllowWebClient")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<bool?>("AutoStart")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<bool?>("DumpOnHealthCheckRestart")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<long>("HealthCheckSeconds")
 					.HasColumnType("bigint");
@@ -204,27 +209,27 @@ namespace Tgstation.Server.Host.Database
 
 				b.Property<bool?>("LogOutput")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<long>("MapThreads")
 					.HasColumnType("bigint");
 
 				b.Property<bool?>("Minidumps")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<int>("OpenDreamTopicPort")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int>("Port")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int>("SecurityLevel")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<bool?>("StartProfiler")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<long>("StartupTimeout")
 					.HasColumnType("bigint");
@@ -233,7 +238,7 @@ namespace Tgstation.Server.Host.Database
 					.HasColumnType("bigint");
 
 				b.Property<int>("Visibility")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.HasKey("Id");
 
@@ -249,31 +254,31 @@ namespace Tgstation.Server.Host.Database
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<int>("ApiValidationPort")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int>("ApiValidationSecurityLevel")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<string>("CompilerAdditionalArguments")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<int>("DMApiValidationMode")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
 				b.Property<string>("ProjectName")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<TimeSpan?>("Timeout")
 					.IsRequired()
-					.HasColumnType("interval");
+					.HasColumnType("time");
 
 				b.HasKey("Id");
 
@@ -289,52 +294,53 @@ namespace Tgstation.Server.Host.Database
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<string>("AutoStartCron")
 					.IsRequired()
 					.HasMaxLength(1000)
-					.HasColumnType("character varying(1000)");
+					.HasColumnType("nvarchar(1000)");
 
 				b.Property<string>("AutoStopCron")
 					.IsRequired()
 					.HasMaxLength(1000)
-					.HasColumnType("character varying(1000)");
+					.HasColumnType("nvarchar(1000)");
 
 				b.Property<string>("AutoUpdateCron")
 					.IsRequired()
 					.HasMaxLength(1000)
-					.HasColumnType("character varying(1000)");
+					.HasColumnType("nvarchar(1000)");
 
 				b.Property<long>("AutoUpdateInterval")
 					.HasColumnType("bigint");
 
 				b.Property<int>("ChatBotLimit")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int>("ConfigurationType")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("nvarchar(100)");
 
 				b.Property<bool?>("Online")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<string>("Path")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(450)");
 
 				b.Property<string>("SwarmIdentifer")
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(450)");
 
 				b.HasKey("Id");
 
 				b.HasIndex("Path", "SwarmIdentifer")
-					.IsUnique();
+					.IsUnique()
+					.HasFilter("[SwarmIdentifer] IS NOT NULL");
 
 				b.ToTable("Instances");
 			});
@@ -345,34 +351,34 @@ namespace Tgstation.Server.Host.Database
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<decimal>("ChatBotRights")
-					.HasColumnType("numeric(20,0)");
+					.HasColumnType("decimal(20,0)");
 
 				b.Property<decimal>("ConfigurationRights")
-					.HasColumnType("numeric(20,0)");
+					.HasColumnType("decimal(20,0)");
 
 				b.Property<decimal>("DreamDaemonRights")
-					.HasColumnType("numeric(20,0)");
+					.HasColumnType("decimal(20,0)");
 
 				b.Property<decimal>("DreamMakerRights")
-					.HasColumnType("numeric(20,0)");
+					.HasColumnType("decimal(20,0)");
 
 				b.Property<decimal>("EngineRights")
-					.HasColumnType("numeric(20,0)");
+					.HasColumnType("decimal(20,0)");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
 				b.Property<decimal>("InstancePermissionSetRights")
-					.HasColumnType("numeric(20,0)");
+					.HasColumnType("decimal(20,0)");
 
 				b.Property<long>("PermissionSetId")
 					.HasColumnType("bigint");
 
 				b.Property<decimal>("RepositoryRights")
-					.HasColumnType("numeric(20,0)");
+					.HasColumnType("decimal(20,0)");
 
 				b.HasKey("Id");
 
@@ -390,46 +396,46 @@ namespace Tgstation.Server.Host.Database
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<decimal?>("CancelRight")
-					.HasColumnType("numeric(20,0)");
+					.HasColumnType("decimal(20,0)");
 
 				b.Property<decimal?>("CancelRightsType")
-					.HasColumnType("numeric(20,0)");
+					.HasColumnType("decimal(20,0)");
 
 				b.Property<bool?>("Cancelled")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<long?>("CancelledById")
 					.HasColumnType("bigint");
 
 				b.Property<string>("Description")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<long?>("ErrorCode")
 					.HasColumnType("bigint");
 
 				b.Property<string>("ExceptionDetails")
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
 				b.Property<byte>("JobCode")
-					.HasColumnType("smallint");
+					.HasColumnType("tinyint");
 
 				b.Property<DateTimeOffset?>("StartedAt")
 					.IsRequired()
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("datetimeoffset");
 
 				b.Property<long>("StartedById")
 					.HasColumnType("bigint");
 
 				b.Property<DateTimeOffset?>("StoppedAt")
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("datetimeoffset");
 
 				b.HasKey("Id");
 
@@ -448,15 +454,15 @@ namespace Tgstation.Server.Host.Database
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<string>("ExternalUserId")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("nvarchar(100)");
 
 				b.Property<int>("Provider")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<long>("UserId")
 					.HasColumnType("bigint");
@@ -477,16 +483,16 @@ namespace Tgstation.Server.Host.Database
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<decimal>("AdministrationRights")
-					.HasColumnType("numeric(20,0)");
+					.HasColumnType("decimal(20,0)");
 
 				b.Property<long?>("GroupId")
 					.HasColumnType("bigint");
 
 				b.Property<decimal>("InstanceManagerRights")
-					.HasColumnType("numeric(20,0)");
+					.HasColumnType("decimal(20,0)");
 
 				b.Property<long?>("UserId")
 					.HasColumnType("bigint");
@@ -494,10 +500,12 @@ namespace Tgstation.Server.Host.Database
 				b.HasKey("Id");
 
 				b.HasIndex("GroupId")
-					.IsUnique();
+					.IsUnique()
+					.HasFilter("[GroupId] IS NOT NULL");
 
 				b.HasIndex("UserId")
-					.IsUnique();
+					.IsUnique()
+					.HasFilter("[UserId] IS NOT NULL");
 
 				b.ToTable("PermissionSets");
 			});
@@ -508,11 +516,11 @@ namespace Tgstation.Server.Host.Database
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<string>("AccessIdentifier")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<long>("CompileJobId")
 					.HasColumnType("bigint");
@@ -521,22 +529,22 @@ namespace Tgstation.Server.Host.Database
 					.HasColumnType("bigint");
 
 				b.Property<int>("LaunchSecurityLevel")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int>("LaunchVisibility")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int>("Port")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int>("ProcessId")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int>("RebootState")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int?>("TopicPort")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.HasKey("Id");
 
@@ -553,56 +561,56 @@ namespace Tgstation.Server.Host.Database
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<string>("AccessToken")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<string>("AccessUser")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<bool?>("AutoUpdatesKeepTestMerges")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<bool?>("AutoUpdatesSynchronize")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<string>("CommitterEmail")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<string>("CommitterName")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<bool?>("CreateGitHubDeployments")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
 				b.Property<bool?>("PostTestMergeComment")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<bool?>("PushTestMergeCommits")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<bool?>("ShowTestMergeCommitters")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<bool?>("UpdateSubmodules")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.HasKey("Id");
 
@@ -618,7 +626,7 @@ namespace Tgstation.Server.Host.Database
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<long>("RevisionInformationId")
 					.HasColumnType("bigint");
@@ -641,12 +649,12 @@ namespace Tgstation.Server.Host.Database
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<string>("CommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("character varying(40)");
+					.HasColumnType("nvarchar(40)");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
@@ -654,10 +662,10 @@ namespace Tgstation.Server.Host.Database
 				b.Property<string>("OriginCommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("character varying(40)");
+					.HasColumnType("nvarchar(40)");
 
 				b.Property<DateTimeOffset>("Timestamp")
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("datetimeoffset");
 
 				b.HasKey("Id");
 
@@ -673,28 +681,28 @@ namespace Tgstation.Server.Host.Database
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<string>("Author")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<string>("BodyAtMerge")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<string>("Comment")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<DateTimeOffset>("MergedAt")
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("datetimeoffset");
 
 				b.Property<long>("MergedById")
 					.HasColumnType("bigint");
 
 				b.Property<int>("Number")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<long?>("PrimaryRevisionInformationId")
 					.IsRequired()
@@ -703,15 +711,15 @@ namespace Tgstation.Server.Host.Database
 				b.Property<string>("TargetCommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("character varying(40)");
+					.HasColumnType("nvarchar(40)");
 
 				b.Property<string>("TitleAtMerge")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<string>("Url")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(max)");
 
 				b.HasKey("Id");
 
@@ -729,41 +737,41 @@ namespace Tgstation.Server.Host.Database
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<string>("CanonicalName")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("nvarchar(100)");
 
 				b.Property<DateTimeOffset?>("CreatedAt")
 					.IsRequired()
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("datetimeoffset");
 
 				b.Property<long?>("CreatedById")
 					.HasColumnType("bigint");
 
 				b.Property<bool?>("Enabled")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("bit");
 
 				b.Property<long?>("GroupId")
 					.HasColumnType("bigint");
 
 				b.Property<DateTimeOffset?>("LastPasswordUpdate")
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("datetimeoffset");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("nvarchar(100)");
 
 				b.Property<string>("PasswordHash")
-					.HasColumnType("text");
+					.HasColumnType("nvarchar(max)");
 
 				b.Property<string>("SystemIdentifier")
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("nvarchar(100)");
 
 				b.HasKey("Id");
 
@@ -775,7 +783,8 @@ namespace Tgstation.Server.Host.Database
 				b.HasIndex("GroupId");
 
 				b.HasIndex("SystemIdentifier")
-					.IsUnique();
+					.IsUnique()
+					.HasFilter("[SystemIdentifier] IS NOT NULL");
 
 				b.ToTable("Users");
 			});
@@ -786,12 +795,12 @@ namespace Tgstation.Server.Host.Database
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("nvarchar(100)");
 
 				b.HasKey("Id");
 
@@ -834,7 +843,7 @@ namespace Tgstation.Server.Host.Database
 				b.HasOne("Tgstation.Server.Host.Models.RevisionInformation", "RevisionInformation")
 					.WithMany("CompileJobs")
 					.HasForeignKey("RevisionInformationId")
-					.OnDelete(DeleteBehavior.Cascade)
+					.OnDelete(DeleteBehavior.ClientNoAction)
 					.IsRequired();
 
 				b.Navigation("Job");

--- a/src/Tgstation.Server.Host/Database/Migrations/20241103161845_MSAddAutoStartAndStop.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20241103161845_MSAddAutoStartAndStop.cs
@@ -1,0 +1,84 @@
+﻿using System;
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Tgstation.Server.Host.Database
+{
+	/// <inheritdoc />
+	public partial class MSAddAutoStartAndStop : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+			migrationBuilder.AlterColumn<long>(
+				name: "UserId",
+				table: "OAuthConnections",
+				type: "bigint",
+				nullable: false,
+				defaultValue: 0L,
+				oldClrType: typeof(long),
+				oldType: "bigint",
+				oldNullable: true);
+
+			migrationBuilder.AlterColumn<string>(
+				name: "AutoUpdateCron",
+				table: "Instances",
+				type: "nvarchar(1000)",
+				maxLength: 1000,
+				nullable: false,
+				oldClrType: typeof(string),
+				oldType: "nvarchar(max)",
+				oldMaxLength: 10000);
+
+			migrationBuilder.AddColumn<string>(
+				name: "AutoStartCron",
+				table: "Instances",
+				type: "nvarchar(1000)",
+				maxLength: 1000,
+				nullable: false,
+				defaultValue: String.Empty);
+
+			migrationBuilder.AddColumn<string>(
+				name: "AutoStopCron",
+				table: "Instances",
+				type: "nvarchar(1000)",
+				maxLength: 1000,
+				nullable: false,
+				defaultValue: String.Empty);
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+			migrationBuilder.DropColumn(
+				name: "AutoStartCron",
+				table: "Instances");
+
+			migrationBuilder.DropColumn(
+				name: "AutoStopCron",
+				table: "Instances");
+
+			migrationBuilder.AlterColumn<long>(
+				name: "UserId",
+				table: "OAuthConnections",
+				type: "bigint",
+				nullable: true,
+				oldClrType: typeof(long),
+				oldType: "bigint");
+
+			migrationBuilder.AlterColumn<string>(
+				name: "AutoUpdateCron",
+				table: "Instances",
+				type: "nvarchar(max)",
+				maxLength: 10000,
+				nullable: false,
+				oldClrType: typeof(string),
+				oldType: "nvarchar(1000)",
+				oldMaxLength: 1000);
+		}
+	}
+}

--- a/src/Tgstation.Server.Host/Database/Migrations/20241103161856_MYAddAutoStartAndStop.Designer.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20241103161856_MYAddAutoStartAndStop.Designer.cs
@@ -3,20 +3,23 @@ using System;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Tgstation.Server.Host.Database
 {
-	[DbContext(typeof(PostgresSqlDatabaseContext))]
-	partial class PostgresSqlDatabaseContextModelSnapshot : ModelSnapshot
+	[DbContext(typeof(MySqlDatabaseContext))]
+	[Migration("20241103161856_MYAddAutoStartAndStop")]
+	partial class MYAddAutoStartAndStop
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		/// <inheritdoc />
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder
 				.HasAnnotation("ProductVersion", "8.0.10")
-				.HasAnnotation("Relational:MaxIdentifierLength", 63);
+				.HasAnnotation("Relational:MaxIdentifierLength", 64);
 
-			NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
+			MySqlModelBuilderExtensions.AutoIncrementColumns(modelBuilder);
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.ChatBot", b =>
 			{
@@ -24,18 +27,21 @@ namespace Tgstation.Server.Host.Database
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long?>("Id"));
 
-				b.Property<int>("ChannelLimit")
-					.HasColumnType("integer");
+				b.Property<ushort?>("ChannelLimit")
+					.IsRequired()
+					.HasColumnType("smallint unsigned");
 
 				b.Property<string>("ConnectionString")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("ConnectionString"), "utf8mb4");
 
 				b.Property<bool?>("Enabled")
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
@@ -43,13 +49,14 @@ namespace Tgstation.Server.Host.Database
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("varchar(100)");
 
 				b.Property<int>("Provider")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
-				b.Property<long>("ReconnectionInterval")
-					.HasColumnType("bigint");
+				b.Property<uint?>("ReconnectionInterval")
+					.IsRequired()
+					.HasColumnType("int unsigned");
 
 				b.HasKey("Id");
 
@@ -65,37 +72,41 @@ namespace Tgstation.Server.Host.Database
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<long>("ChatSettingsId")
 					.HasColumnType("bigint");
 
-				b.Property<decimal?>("DiscordChannelId")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong?>("DiscordChannelId")
+					.HasColumnType("bigint unsigned");
 
 				b.Property<string>("IrcChannel")
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("varchar(100)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("IrcChannel"), "utf8mb4");
 
 				b.Property<bool?>("IsAdminChannel")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("IsSystemChannel")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("IsUpdatesChannel")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("IsWatchdogChannel")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<string>("Tag")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Tag"), "utf8mb4");
 
 				b.HasKey("Id");
 
@@ -114,28 +125,32 @@ namespace Tgstation.Server.Host.Database
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<int?>("DMApiMajorVersion")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int?>("DMApiMinorVersion")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int?>("DMApiPatchVersion")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<Guid?>("DirectoryName")
 					.IsRequired()
-					.HasColumnType("uuid");
+					.HasColumnType("char(36)");
 
 				b.Property<string>("DmeName")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("DmeName"), "utf8mb4");
 
 				b.Property<string>("EngineVersion")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("EngineVersion"), "utf8mb4");
 
 				b.Property<long?>("GitHubDeploymentId")
 					.HasColumnType("bigint");
@@ -147,14 +162,18 @@ namespace Tgstation.Server.Host.Database
 					.HasColumnType("bigint");
 
 				b.Property<int?>("MinimumSecurityLevel")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<string>("Output")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Output"), "utf8mb4");
 
 				b.Property<string>("RepositoryOrigin")
-					.HasColumnType("text");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("RepositoryOrigin"), "utf8mb4");
 
 				b.Property<long>("RevisionInformationId")
 					.HasColumnType("bigint");
@@ -177,63 +196,71 @@ namespace Tgstation.Server.Host.Database
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<string>("AdditionalParameters")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("AdditionalParameters"), "utf8mb4");
 
 				b.Property<bool?>("AllowWebClient")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("AutoStart")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("DumpOnHealthCheckRestart")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
-				b.Property<long>("HealthCheckSeconds")
-					.HasColumnType("bigint");
+				b.Property<uint?>("HealthCheckSeconds")
+					.IsRequired()
+					.HasColumnType("int unsigned");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
 				b.Property<bool?>("LogOutput")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
-				b.Property<long>("MapThreads")
-					.HasColumnType("bigint");
+				b.Property<uint?>("MapThreads")
+					.IsRequired()
+					.HasColumnType("int unsigned");
 
 				b.Property<bool?>("Minidumps")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
-				b.Property<int>("OpenDreamTopicPort")
-					.HasColumnType("integer");
+				b.Property<ushort?>("OpenDreamTopicPort")
+					.IsRequired()
+					.HasColumnType("smallint unsigned");
 
-				b.Property<int>("Port")
-					.HasColumnType("integer");
+				b.Property<ushort?>("Port")
+					.IsRequired()
+					.HasColumnType("smallint unsigned");
 
 				b.Property<int>("SecurityLevel")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<bool?>("StartProfiler")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
-				b.Property<long>("StartupTimeout")
-					.HasColumnType("bigint");
+				b.Property<uint?>("StartupTimeout")
+					.IsRequired()
+					.HasColumnType("int unsigned");
 
-				b.Property<long>("TopicRequestTimeout")
-					.HasColumnType("bigint");
+				b.Property<uint?>("TopicRequestTimeout")
+					.IsRequired()
+					.HasColumnType("int unsigned");
 
 				b.Property<int>("Visibility")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.HasKey("Id");
 
@@ -249,31 +276,34 @@ namespace Tgstation.Server.Host.Database
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long>("Id"));
 
-				b.Property<int>("ApiValidationPort")
-					.HasColumnType("integer");
+				b.Property<ushort?>("ApiValidationPort")
+					.IsRequired()
+					.HasColumnType("smallint unsigned");
 
 				b.Property<int>("ApiValidationSecurityLevel")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<string>("CompilerAdditionalArguments")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("varchar(10000)");
 
 				b.Property<int>("DMApiValidationMode")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
 				b.Property<string>("ProjectName")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("ProjectName"), "utf8mb4");
 
 				b.Property<TimeSpan?>("Timeout")
 					.IsRequired()
-					.HasColumnType("interval");
+					.HasColumnType("time(6)");
 
 				b.HasKey("Id");
 
@@ -289,47 +319,55 @@ namespace Tgstation.Server.Host.Database
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<string>("AutoStartCron")
 					.IsRequired()
 					.HasMaxLength(1000)
-					.HasColumnType("character varying(1000)");
+					.HasColumnType("varchar(1000)");
 
 				b.Property<string>("AutoStopCron")
 					.IsRequired()
 					.HasMaxLength(1000)
-					.HasColumnType("character varying(1000)");
+					.HasColumnType("varchar(1000)");
 
 				b.Property<string>("AutoUpdateCron")
 					.IsRequired()
 					.HasMaxLength(1000)
-					.HasColumnType("character varying(1000)");
+					.HasColumnType("varchar(1000)");
 
-				b.Property<long>("AutoUpdateInterval")
-					.HasColumnType("bigint");
+				b.Property<uint?>("AutoUpdateInterval")
+					.IsRequired()
+					.HasColumnType("int unsigned");
 
-				b.Property<int>("ChatBotLimit")
-					.HasColumnType("integer");
+				b.Property<ushort?>("ChatBotLimit")
+					.IsRequired()
+					.HasColumnType("smallint unsigned");
 
 				b.Property<int>("ConfigurationType")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("varchar(100)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Name"), "utf8mb4");
 
 				b.Property<bool?>("Online")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<string>("Path")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("varchar(255)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Path"), "utf8mb4");
 
 				b.Property<string>("SwarmIdentifer")
-					.HasColumnType("text");
+					.HasColumnType("varchar(255)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("SwarmIdentifer"), "utf8mb4");
 
 				b.HasKey("Id");
 
@@ -345,34 +383,34 @@ namespace Tgstation.Server.Host.Database
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long>("Id"));
 
-				b.Property<decimal>("ChatBotRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("ChatBotRights")
+					.HasColumnType("bigint unsigned");
 
-				b.Property<decimal>("ConfigurationRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("ConfigurationRights")
+					.HasColumnType("bigint unsigned");
 
-				b.Property<decimal>("DreamDaemonRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("DreamDaemonRights")
+					.HasColumnType("bigint unsigned");
 
-				b.Property<decimal>("DreamMakerRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("DreamMakerRights")
+					.HasColumnType("bigint unsigned");
 
-				b.Property<decimal>("EngineRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("EngineRights")
+					.HasColumnType("bigint unsigned");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
-				b.Property<decimal>("InstancePermissionSetRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("InstancePermissionSetRights")
+					.HasColumnType("bigint unsigned");
 
 				b.Property<long>("PermissionSetId")
 					.HasColumnType("bigint");
 
-				b.Property<decimal>("RepositoryRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("RepositoryRights")
+					.HasColumnType("bigint unsigned");
 
 				b.HasKey("Id");
 
@@ -390,46 +428,50 @@ namespace Tgstation.Server.Host.Database
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long?>("Id"));
 
-				b.Property<decimal?>("CancelRight")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong?>("CancelRight")
+					.HasColumnType("bigint unsigned");
 
-				b.Property<decimal?>("CancelRightsType")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong?>("CancelRightsType")
+					.HasColumnType("bigint unsigned");
 
 				b.Property<bool?>("Cancelled")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<long?>("CancelledById")
 					.HasColumnType("bigint");
 
 				b.Property<string>("Description")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("longtext");
 
-				b.Property<long?>("ErrorCode")
-					.HasColumnType("bigint");
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Description"), "utf8mb4");
+
+				b.Property<uint?>("ErrorCode")
+					.HasColumnType("int unsigned");
 
 				b.Property<string>("ExceptionDetails")
-					.HasColumnType("text");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("ExceptionDetails"), "utf8mb4");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
 				b.Property<byte>("JobCode")
-					.HasColumnType("smallint");
+					.HasColumnType("tinyint unsigned");
 
 				b.Property<DateTimeOffset?>("StartedAt")
 					.IsRequired()
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("datetime(6)");
 
 				b.Property<long>("StartedById")
 					.HasColumnType("bigint");
 
 				b.Property<DateTimeOffset?>("StoppedAt")
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("datetime(6)");
 
 				b.HasKey("Id");
 
@@ -448,15 +490,17 @@ namespace Tgstation.Server.Host.Database
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<string>("ExternalUserId")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("varchar(100)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("ExternalUserId"), "utf8mb4");
 
 				b.Property<int>("Provider")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<long>("UserId")
 					.HasColumnType("bigint");
@@ -477,16 +521,16 @@ namespace Tgstation.Server.Host.Database
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long?>("Id"));
 
-				b.Property<decimal>("AdministrationRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("AdministrationRights")
+					.HasColumnType("bigint unsigned");
 
 				b.Property<long?>("GroupId")
 					.HasColumnType("bigint");
 
-				b.Property<decimal>("InstanceManagerRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("InstanceManagerRights")
+					.HasColumnType("bigint unsigned");
 
 				b.Property<long?>("UserId")
 					.HasColumnType("bigint");
@@ -508,11 +552,13 @@ namespace Tgstation.Server.Host.Database
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<string>("AccessIdentifier")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("AccessIdentifier"), "utf8mb4");
 
 				b.Property<long>("CompileJobId")
 					.HasColumnType("bigint");
@@ -521,22 +567,22 @@ namespace Tgstation.Server.Host.Database
 					.HasColumnType("bigint");
 
 				b.Property<int>("LaunchSecurityLevel")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int>("LaunchVisibility")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
-				b.Property<int>("Port")
-					.HasColumnType("integer");
+				b.Property<ushort>("Port")
+					.HasColumnType("smallint unsigned");
 
 				b.Property<int>("ProcessId")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<int>("RebootState")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
-				b.Property<int?>("TopicPort")
-					.HasColumnType("integer");
+				b.Property<ushort?>("TopicPort")
+					.HasColumnType("smallint unsigned");
 
 				b.HasKey("Id");
 
@@ -553,56 +599,64 @@ namespace Tgstation.Server.Host.Database
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<string>("AccessToken")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("AccessToken"), "utf8mb4");
 
 				b.Property<string>("AccessUser")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("AccessUser"), "utf8mb4");
 
 				b.Property<bool?>("AutoUpdatesKeepTestMerges")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("AutoUpdatesSynchronize")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<string>("CommitterEmail")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("CommitterEmail"), "utf8mb4");
 
 				b.Property<string>("CommitterName")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("CommitterName"), "utf8mb4");
 
 				b.Property<bool?>("CreateGitHubDeployments")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
 
 				b.Property<bool?>("PostTestMergeComment")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("PushTestMergeCommits")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("ShowTestMergeCommitters")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<bool?>("UpdateSubmodules")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.HasKey("Id");
 
@@ -618,7 +672,7 @@ namespace Tgstation.Server.Host.Database
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<long>("RevisionInformationId")
 					.HasColumnType("bigint");
@@ -641,12 +695,14 @@ namespace Tgstation.Server.Host.Database
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<string>("CommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("character varying(40)");
+					.HasColumnType("varchar(40)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("CommitSha"), "utf8mb4");
 
 				b.Property<long>("InstanceId")
 					.HasColumnType("bigint");
@@ -654,10 +710,12 @@ namespace Tgstation.Server.Host.Database
 				b.Property<string>("OriginCommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("character varying(40)");
+					.HasColumnType("varchar(40)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("OriginCommitSha"), "utf8mb4");
 
 				b.Property<DateTimeOffset>("Timestamp")
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("datetime(6)");
 
 				b.HasKey("Id");
 
@@ -673,28 +731,34 @@ namespace Tgstation.Server.Host.Database
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long>("Id"));
 
 				b.Property<string>("Author")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Author"), "utf8mb4");
 
 				b.Property<string>("BodyAtMerge")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("BodyAtMerge"), "utf8mb4");
 
 				b.Property<string>("Comment")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Comment"), "utf8mb4");
 
 				b.Property<DateTimeOffset>("MergedAt")
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("datetime(6)");
 
 				b.Property<long>("MergedById")
 					.HasColumnType("bigint");
 
 				b.Property<int>("Number")
-					.HasColumnType("integer");
+					.HasColumnType("int");
 
 				b.Property<long?>("PrimaryRevisionInformationId")
 					.IsRequired()
@@ -703,15 +767,21 @@ namespace Tgstation.Server.Host.Database
 				b.Property<string>("TargetCommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("character varying(40)");
+					.HasColumnType("varchar(40)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("TargetCommitSha"), "utf8mb4");
 
 				b.Property<string>("TitleAtMerge")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("TitleAtMerge"), "utf8mb4");
 
 				b.Property<string>("Url")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Url"), "utf8mb4");
 
 				b.HasKey("Id");
 
@@ -729,41 +799,49 @@ namespace Tgstation.Server.Host.Database
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<string>("CanonicalName")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("varchar(100)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("CanonicalName"), "utf8mb4");
 
 				b.Property<DateTimeOffset?>("CreatedAt")
 					.IsRequired()
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("datetime(6)");
 
 				b.Property<long?>("CreatedById")
 					.HasColumnType("bigint");
 
 				b.Property<bool?>("Enabled")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("tinyint(1)");
 
 				b.Property<long?>("GroupId")
 					.HasColumnType("bigint");
 
 				b.Property<DateTimeOffset?>("LastPasswordUpdate")
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("datetime(6)");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("varchar(100)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Name"), "utf8mb4");
 
 				b.Property<string>("PasswordHash")
-					.HasColumnType("text");
+					.HasColumnType("longtext");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("PasswordHash"), "utf8mb4");
 
 				b.Property<string>("SystemIdentifier")
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("varchar(100)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("SystemIdentifier"), "utf8mb4");
 
 				b.HasKey("Id");
 
@@ -786,12 +864,14 @@ namespace Tgstation.Server.Host.Database
 					.ValueGeneratedOnAdd()
 					.HasColumnType("bigint");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long?>("Id"));
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("varchar(100)");
+
+				MySqlPropertyBuilderExtensions.HasCharSet(b.Property<string>("Name"), "utf8mb4");
 
 				b.HasKey("Id");
 

--- a/src/Tgstation.Server.Host/Database/Migrations/20241103161856_MYAddAutoStartAndStop.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20241103161856_MYAddAutoStartAndStop.cs
@@ -1,0 +1,90 @@
+﻿using System;
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Tgstation.Server.Host.Database
+{
+	/// <inheritdoc />
+	public partial class MYAddAutoStartAndStop : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+			migrationBuilder.AlterColumn<long>(
+				name: "UserId",
+				table: "OAuthConnections",
+				type: "bigint",
+				nullable: false,
+				defaultValue: 0L,
+				oldClrType: typeof(long),
+				oldType: "bigint",
+				oldNullable: true);
+
+			migrationBuilder.AlterColumn<string>(
+				name: "AutoUpdateCron",
+				table: "Instances",
+				type: "varchar(1000)",
+				maxLength: 1000,
+				nullable: false,
+				oldClrType: typeof(string),
+				oldType: "varchar(10000)",
+				oldMaxLength: 10000)
+				.Annotation("MySql:CharSet", "utf8mb4")
+				.OldAnnotation("MySql:CharSet", "utf8mb4");
+
+			migrationBuilder.AddColumn<string>(
+				name: "AutoStartCron",
+				table: "Instances",
+				type: "varchar(1000)",
+				maxLength: 1000,
+				nullable: false,
+				defaultValue: String.Empty)
+				.Annotation("MySql:CharSet", "utf8mb4");
+
+			migrationBuilder.AddColumn<string>(
+				name: "AutoStopCron",
+				table: "Instances",
+				type: "varchar(1000)",
+				maxLength: 1000,
+				nullable: false,
+				defaultValue: String.Empty)
+				.Annotation("MySql:CharSet", "utf8mb4");
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+			migrationBuilder.DropColumn(
+				name: "AutoStartCron",
+				table: "Instances");
+
+			migrationBuilder.DropColumn(
+				name: "AutoStopCron",
+				table: "Instances");
+
+			migrationBuilder.AlterColumn<long>(
+				name: "UserId",
+				table: "OAuthConnections",
+				type: "bigint",
+				nullable: true,
+				oldClrType: typeof(long),
+				oldType: "bigint");
+
+			migrationBuilder.AlterColumn<string>(
+				name: "AutoUpdateCron",
+				table: "Instances",
+				type: "varchar(10000)",
+				maxLength: 10000,
+				nullable: false,
+				oldClrType: typeof(string),
+				oldType: "varchar(1000)",
+				oldMaxLength: 1000)
+				.Annotation("MySql:CharSet", "utf8mb4")
+				.OldAnnotation("MySql:CharSet", "utf8mb4");
+		}
+	}
+}

--- a/src/Tgstation.Server.Host/Database/Migrations/20241103161906_PGAddAutoStartAndStop.Designer.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20241103161906_PGAddAutoStartAndStop.Designer.cs
@@ -3,13 +3,16 @@ using System;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Tgstation.Server.Host.Database
 {
 	[DbContext(typeof(PostgresSqlDatabaseContext))]
-	partial class PostgresSqlDatabaseContextModelSnapshot : ModelSnapshot
+	[Migration("20241103161906_PGAddAutoStartAndStop")]
+	partial class PGAddAutoStartAndStop
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		/// <inheritdoc />
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder

--- a/src/Tgstation.Server.Host/Database/Migrations/20241103161906_PGAddAutoStartAndStop.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20241103161906_PGAddAutoStartAndStop.cs
@@ -1,0 +1,84 @@
+﻿using System;
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Tgstation.Server.Host.Database
+{
+	/// <inheritdoc />
+	public partial class PGAddAutoStartAndStop : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+			migrationBuilder.AlterColumn<long>(
+				name: "UserId",
+				table: "OAuthConnections",
+				type: "bigint",
+				nullable: false,
+				defaultValue: 0L,
+				oldClrType: typeof(long),
+				oldType: "bigint",
+				oldNullable: true);
+
+			migrationBuilder.AlterColumn<string>(
+				name: "AutoUpdateCron",
+				table: "Instances",
+				type: "character varying(1000)",
+				maxLength: 1000,
+				nullable: false,
+				oldClrType: typeof(string),
+				oldType: "character varying(10000)",
+				oldMaxLength: 10000);
+
+			migrationBuilder.AddColumn<string>(
+				name: "AutoStartCron",
+				table: "Instances",
+				type: "character varying(1000)",
+				maxLength: 1000,
+				nullable: false,
+				defaultValue: String.Empty);
+
+			migrationBuilder.AddColumn<string>(
+				name: "AutoStopCron",
+				table: "Instances",
+				type: "character varying(1000)",
+				maxLength: 1000,
+				nullable: false,
+				defaultValue: String.Empty);
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+			migrationBuilder.DropColumn(
+				name: "AutoStartCron",
+				table: "Instances");
+
+			migrationBuilder.DropColumn(
+				name: "AutoStopCron",
+				table: "Instances");
+
+			migrationBuilder.AlterColumn<long>(
+				name: "UserId",
+				table: "OAuthConnections",
+				type: "bigint",
+				nullable: true,
+				oldClrType: typeof(long),
+				oldType: "bigint");
+
+			migrationBuilder.AlterColumn<string>(
+				name: "AutoUpdateCron",
+				table: "Instances",
+				type: "character varying(10000)",
+				maxLength: 10000,
+				nullable: false,
+				oldClrType: typeof(string),
+				oldType: "character varying(1000)",
+				oldMaxLength: 1000);
+		}
+	}
+}

--- a/src/Tgstation.Server.Host/Database/Migrations/20241103161915_SLAddAutoStartAndStop.Designer.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20241103161915_SLAddAutoStartAndStop.Designer.cs
@@ -3,53 +3,52 @@ using System;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Tgstation.Server.Host.Database
 {
-	[DbContext(typeof(PostgresSqlDatabaseContext))]
-	partial class PostgresSqlDatabaseContextModelSnapshot : ModelSnapshot
+	[DbContext(typeof(SqliteDatabaseContext))]
+	[Migration("20241103161915_SLAddAutoStartAndStop")]
+	partial class SLAddAutoStartAndStop
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		/// <inheritdoc />
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
-			modelBuilder
-				.HasAnnotation("ProductVersion", "8.0.10")
-				.HasAnnotation("Relational:MaxIdentifierLength", 63);
-
-			NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
+			modelBuilder.HasAnnotation("ProductVersion", "8.0.10");
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.ChatBot", b =>
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
-
-				b.Property<int>("ChannelLimit")
-					.HasColumnType("integer");
+				b.Property<ushort?>("ChannelLimit")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("ConnectionString")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("TEXT");
 
 				b.Property<bool?>("Enabled")
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("TEXT");
 
 				b.Property<int>("Provider")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
-				b.Property<long>("ReconnectionInterval")
-					.HasColumnType("bigint");
+				b.Property<uint?>("ReconnectionInterval")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
 				b.HasKey("Id");
 
@@ -63,39 +62,37 @@ namespace Tgstation.Server.Host.Database
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("ChatSettingsId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
-				b.Property<decimal?>("DiscordChannelId")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong?>("DiscordChannelId")
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("IrcChannel")
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("TEXT");
 
 				b.Property<bool?>("IsAdminChannel")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("IsSystemChannel")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("IsUpdatesChannel")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("IsWatchdogChannel")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("Tag")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("TEXT");
 
 				b.HasKey("Id");
 
@@ -112,52 +109,50 @@ namespace Tgstation.Server.Host.Database
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<int?>("DMApiMajorVersion")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
 				b.Property<int?>("DMApiMinorVersion")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
 				b.Property<int?>("DMApiPatchVersion")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
 				b.Property<Guid?>("DirectoryName")
 					.IsRequired()
-					.HasColumnType("uuid");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("DmeName")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("EngineVersion")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
 				b.Property<long?>("GitHubDeploymentId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<long?>("GitHubRepoId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("JobId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<int?>("MinimumSecurityLevel")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("Output")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("RepositoryOrigin")
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
 				b.Property<long>("RevisionInformationId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.HasKey("Id");
 
@@ -175,65 +170,69 @@ namespace Tgstation.Server.Host.Database
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("AdditionalParameters")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("TEXT");
 
 				b.Property<bool?>("AllowWebClient")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("AutoStart")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("DumpOnHealthCheckRestart")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
-				b.Property<long>("HealthCheckSeconds")
-					.HasColumnType("bigint");
+				b.Property<uint?>("HealthCheckSeconds")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("LogOutput")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
-				b.Property<long>("MapThreads")
-					.HasColumnType("bigint");
+				b.Property<uint?>("MapThreads")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("Minidumps")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
-				b.Property<int>("OpenDreamTopicPort")
-					.HasColumnType("integer");
+				b.Property<ushort?>("OpenDreamTopicPort")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
-				b.Property<int>("Port")
-					.HasColumnType("integer");
+				b.Property<ushort?>("Port")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
 				b.Property<int>("SecurityLevel")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("StartProfiler")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
-				b.Property<long>("StartupTimeout")
-					.HasColumnType("bigint");
+				b.Property<uint?>("StartupTimeout")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
-				b.Property<long>("TopicRequestTimeout")
-					.HasColumnType("bigint");
+				b.Property<uint?>("TopicRequestTimeout")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
 				b.Property<int>("Visibility")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
 				b.HasKey("Id");
 
@@ -247,33 +246,32 @@ namespace Tgstation.Server.Host.Database
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
-
-				b.Property<int>("ApiValidationPort")
-					.HasColumnType("integer");
+				b.Property<ushort?>("ApiValidationPort")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
 				b.Property<int>("ApiValidationSecurityLevel")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("CompilerAdditionalArguments")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("TEXT");
 
 				b.Property<int>("DMApiValidationMode")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("ProjectName")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("TEXT");
 
 				b.Property<TimeSpan?>("Timeout")
 					.IsRequired()
-					.HasColumnType("interval");
+					.HasColumnType("TEXT");
 
 				b.HasKey("Id");
 
@@ -287,49 +285,49 @@ namespace Tgstation.Server.Host.Database
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("AutoStartCron")
 					.IsRequired()
 					.HasMaxLength(1000)
-					.HasColumnType("character varying(1000)");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("AutoStopCron")
 					.IsRequired()
 					.HasMaxLength(1000)
-					.HasColumnType("character varying(1000)");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("AutoUpdateCron")
 					.IsRequired()
 					.HasMaxLength(1000)
-					.HasColumnType("character varying(1000)");
+					.HasColumnType("TEXT");
 
-				b.Property<long>("AutoUpdateInterval")
-					.HasColumnType("bigint");
+				b.Property<uint?>("AutoUpdateInterval")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
-				b.Property<int>("ChatBotLimit")
-					.HasColumnType("integer");
+				b.Property<ushort?>("ChatBotLimit")
+					.IsRequired()
+					.HasColumnType("INTEGER");
 
 				b.Property<int>("ConfigurationType")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("TEXT");
 
 				b.Property<bool?>("Online")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("Path")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("SwarmIdentifer")
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
 				b.HasKey("Id");
 
@@ -343,36 +341,34 @@ namespace Tgstation.Server.Host.Database
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+				b.Property<ulong>("ChatBotRights")
+					.HasColumnType("INTEGER");
 
-				b.Property<decimal>("ChatBotRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("ConfigurationRights")
+					.HasColumnType("INTEGER");
 
-				b.Property<decimal>("ConfigurationRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("DreamDaemonRights")
+					.HasColumnType("INTEGER");
 
-				b.Property<decimal>("DreamDaemonRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("DreamMakerRights")
+					.HasColumnType("INTEGER");
 
-				b.Property<decimal>("DreamMakerRights")
-					.HasColumnType("numeric(20,0)");
-
-				b.Property<decimal>("EngineRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("EngineRights")
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
-				b.Property<decimal>("InstancePermissionSetRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("InstancePermissionSetRights")
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("PermissionSetId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
-				b.Property<decimal>("RepositoryRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("RepositoryRights")
+					.HasColumnType("INTEGER");
 
 				b.HasKey("Id");
 
@@ -388,48 +384,46 @@ namespace Tgstation.Server.Host.Database
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+				b.Property<ulong?>("CancelRight")
+					.HasColumnType("INTEGER");
 
-				b.Property<decimal?>("CancelRight")
-					.HasColumnType("numeric(20,0)");
-
-				b.Property<decimal?>("CancelRightsType")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong?>("CancelRightsType")
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("Cancelled")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<long?>("CancelledById")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("Description")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
-				b.Property<long?>("ErrorCode")
-					.HasColumnType("bigint");
+				b.Property<uint?>("ErrorCode")
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("ExceptionDetails")
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<byte>("JobCode")
-					.HasColumnType("smallint");
+					.HasColumnType("INTEGER");
 
 				b.Property<DateTimeOffset?>("StartedAt")
 					.IsRequired()
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("TEXT");
 
 				b.Property<long>("StartedById")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<DateTimeOffset?>("StoppedAt")
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("TEXT");
 
 				b.HasKey("Id");
 
@@ -446,20 +440,18 @@ namespace Tgstation.Server.Host.Database
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("ExternalUserId")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("TEXT");
 
 				b.Property<int>("Provider")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("UserId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.HasKey("Id");
 
@@ -475,21 +467,19 @@ namespace Tgstation.Server.Host.Database
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
-
-				b.Property<decimal>("AdministrationRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("AdministrationRights")
+					.HasColumnType("INTEGER");
 
 				b.Property<long?>("GroupId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
-				b.Property<decimal>("InstanceManagerRights")
-					.HasColumnType("numeric(20,0)");
+				b.Property<ulong>("InstanceManagerRights")
+					.HasColumnType("INTEGER");
 
 				b.Property<long?>("UserId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.HasKey("Id");
 
@@ -506,37 +496,35 @@ namespace Tgstation.Server.Host.Database
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("AccessIdentifier")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
 				b.Property<long>("CompileJobId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<long?>("InitialCompileJobId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<int>("LaunchSecurityLevel")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
 				b.Property<int>("LaunchVisibility")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
-				b.Property<int>("Port")
-					.HasColumnType("integer");
+				b.Property<ushort>("Port")
+					.HasColumnType("INTEGER");
 
 				b.Property<int>("ProcessId")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
 				b.Property<int>("RebootState")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
-				b.Property<int?>("TopicPort")
-					.HasColumnType("integer");
+				b.Property<ushort?>("TopicPort")
+					.HasColumnType("INTEGER");
 
 				b.HasKey("Id");
 
@@ -551,58 +539,56 @@ namespace Tgstation.Server.Host.Database
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("AccessToken")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("AccessUser")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("TEXT");
 
 				b.Property<bool?>("AutoUpdatesKeepTestMerges")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("AutoUpdatesSynchronize")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("CommitterEmail")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("CommitterName")
 					.IsRequired()
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("TEXT");
 
 				b.Property<bool?>("CreateGitHubDeployments")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("PostTestMergeComment")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("PushTestMergeCommits")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("ShowTestMergeCommitters")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("UpdateSubmodules")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.HasKey("Id");
 
@@ -616,15 +602,13 @@ namespace Tgstation.Server.Host.Database
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("RevisionInformationId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<long>("TestMergeId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.HasKey("Id");
 
@@ -639,25 +623,23 @@ namespace Tgstation.Server.Host.Database
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("CommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("character varying(40)");
+					.HasColumnType("TEXT");
 
 				b.Property<long>("InstanceId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("OriginCommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("character varying(40)");
+					.HasColumnType("TEXT");
 
 				b.Property<DateTimeOffset>("Timestamp")
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("TEXT");
 
 				b.HasKey("Id");
 
@@ -671,47 +653,45 @@ namespace Tgstation.Server.Host.Database
 			{
 				b.Property<long>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("Author")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("BodyAtMerge")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("Comment")
 					.HasMaxLength(10000)
-					.HasColumnType("character varying(10000)");
+					.HasColumnType("TEXT");
 
 				b.Property<DateTimeOffset>("MergedAt")
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("TEXT");
 
 				b.Property<long>("MergedById")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<int>("Number")
-					.HasColumnType("integer");
+					.HasColumnType("INTEGER");
 
 				b.Property<long?>("PrimaryRevisionInformationId")
 					.IsRequired()
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("TargetCommitSha")
 					.IsRequired()
 					.HasMaxLength(40)
-					.HasColumnType("character varying(40)");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("TitleAtMerge")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("Url")
 					.IsRequired()
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
 				b.HasKey("Id");
 
@@ -727,43 +707,41 @@ namespace Tgstation.Server.Host.Database
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("CanonicalName")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("TEXT");
 
 				b.Property<DateTimeOffset?>("CreatedAt")
 					.IsRequired()
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("TEXT");
 
 				b.Property<long?>("CreatedById")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<bool?>("Enabled")
 					.IsRequired()
-					.HasColumnType("boolean");
+					.HasColumnType("INTEGER");
 
 				b.Property<long?>("GroupId")
-					.HasColumnType("bigint");
+					.HasColumnType("INTEGER");
 
 				b.Property<DateTimeOffset?>("LastPasswordUpdate")
-					.HasColumnType("timestamp with time zone");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("PasswordHash")
-					.HasColumnType("text");
+					.HasColumnType("TEXT");
 
 				b.Property<string>("SystemIdentifier")
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("TEXT");
 
 				b.HasKey("Id");
 
@@ -784,14 +762,12 @@ namespace Tgstation.Server.Host.Database
 			{
 				b.Property<long?>("Id")
 					.ValueGeneratedOnAdd()
-					.HasColumnType("bigint");
-
-				NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long?>("Id"));
+					.HasColumnType("INTEGER");
 
 				b.Property<string>("Name")
 					.IsRequired()
 					.HasMaxLength(100)
-					.HasColumnType("character varying(100)");
+					.HasColumnType("TEXT");
 
 				b.HasKey("Id");
 
@@ -834,7 +810,7 @@ namespace Tgstation.Server.Host.Database
 				b.HasOne("Tgstation.Server.Host.Models.RevisionInformation", "RevisionInformation")
 					.WithMany("CompileJobs")
 					.HasForeignKey("RevisionInformationId")
-					.OnDelete(DeleteBehavior.Cascade)
+					.OnDelete(DeleteBehavior.ClientNoAction)
 					.IsRequired();
 
 				b.Navigation("Job");

--- a/src/Tgstation.Server.Host/Database/Migrations/20241103161915_SLAddAutoStartAndStop.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/20241103161915_SLAddAutoStartAndStop.cs
@@ -1,0 +1,64 @@
+﻿using System;
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Tgstation.Server.Host.Database
+{
+	/// <inheritdoc />
+	public partial class SLAddAutoStartAndStop : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+			migrationBuilder.AlterColumn<long>(
+				name: "UserId",
+				table: "OAuthConnections",
+				type: "INTEGER",
+				nullable: false,
+				defaultValue: 0L,
+				oldClrType: typeof(long),
+				oldType: "INTEGER",
+				oldNullable: true);
+
+			migrationBuilder.AddColumn<string>(
+				name: "AutoStartCron",
+				table: "Instances",
+				type: "TEXT",
+				maxLength: 1000,
+				nullable: false,
+				defaultValue: String.Empty);
+
+			migrationBuilder.AddColumn<string>(
+				name: "AutoStopCron",
+				table: "Instances",
+				type: "TEXT",
+				maxLength: 1000,
+				nullable: false,
+				defaultValue: String.Empty);
+		}
+
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+			migrationBuilder.DropColumn(
+				name: "AutoStartCron",
+				table: "Instances");
+
+			migrationBuilder.DropColumn(
+				name: "AutoStopCron",
+				table: "Instances");
+
+			migrationBuilder.AlterColumn<long>(
+				name: "UserId",
+				table: "OAuthConnections",
+				type: "INTEGER",
+				nullable: true,
+				oldClrType: typeof(long),
+				oldType: "INTEGER");
+		}
+	}
+}

--- a/src/Tgstation.Server.Host/Database/Migrations/MySqlDatabaseContextModelSnapshot.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/MySqlDatabaseContextModelSnapshot.cs
@@ -4,7 +4,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
-namespace Tgstation.Server.Host.Database.Migrations
+namespace Tgstation.Server.Host.Database
 {
 	[DbContext(typeof(MySqlDatabaseContext))]
 	partial class MySqlDatabaseContextModelSnapshot : ModelSnapshot
@@ -13,7 +13,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 		{
 #pragma warning disable 612, 618
 			modelBuilder
-				.HasAnnotation("ProductVersion", "8.0.8")
+				.HasAnnotation("ProductVersion", "8.0.10")
 				.HasAnnotation("Relational:MaxIdentifierLength", 64);
 
 			MySqlModelBuilderExtensions.AutoIncrementColumns(modelBuilder);
@@ -318,10 +318,20 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long?>("Id"));
 
+				b.Property<string>("AutoStartCron")
+					.IsRequired()
+					.HasMaxLength(1000)
+					.HasColumnType("varchar(1000)");
+
+				b.Property<string>("AutoStopCron")
+					.IsRequired()
+					.HasMaxLength(1000)
+					.HasColumnType("varchar(1000)");
+
 				b.Property<string>("AutoUpdateCron")
 					.IsRequired()
-					.HasMaxLength(10000)
-					.HasColumnType("varchar(10000)");
+					.HasMaxLength(1000)
+					.HasColumnType("varchar(1000)");
 
 				b.Property<uint?>("AutoUpdateInterval")
 					.IsRequired()
@@ -489,7 +499,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.Property<int>("Provider")
 					.HasColumnType("int");
 
-				b.Property<long?>("UserId")
+				b.Property<long>("UserId")
 					.HasColumnType("bigint");
 
 				b.HasKey("Id");
@@ -980,7 +990,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.HasOne("Tgstation.Server.Host.Models.User", "User")
 					.WithMany("OAuthConnections")
 					.HasForeignKey("UserId")
-					.OnDelete(DeleteBehavior.Cascade);
+					.OnDelete(DeleteBehavior.Cascade)
+					.IsRequired();
 
 				b.Navigation("User");
 			});

--- a/src/Tgstation.Server.Host/Database/Migrations/SqlServerDatabaseContextModelSnapshot.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/SqlServerDatabaseContextModelSnapshot.cs
@@ -4,7 +4,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
-namespace Tgstation.Server.Host.Database.Migrations
+namespace Tgstation.Server.Host.Database
 {
 	[DbContext(typeof(SqlServerDatabaseContext))]
 	partial class SqlServerDatabaseContextModelSnapshot : ModelSnapshot
@@ -13,7 +13,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 		{
 #pragma warning disable 612, 618
 			modelBuilder
-				.HasAnnotation("ProductVersion", "8.0.8")
+				.HasAnnotation("ProductVersion", "8.0.10")
 				.HasAnnotation("Relational:MaxIdentifierLength", 128);
 
 			SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
@@ -293,10 +293,20 @@ namespace Tgstation.Server.Host.Database.Migrations
 
 				SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long?>("Id"));
 
+				b.Property<string>("AutoStartCron")
+					.IsRequired()
+					.HasMaxLength(1000)
+					.HasColumnType("nvarchar(1000)");
+
+				b.Property<string>("AutoStopCron")
+					.IsRequired()
+					.HasMaxLength(1000)
+					.HasColumnType("nvarchar(1000)");
+
 				b.Property<string>("AutoUpdateCron")
 					.IsRequired()
-					.HasMaxLength(10000)
-					.HasColumnType("nvarchar(max)");
+					.HasMaxLength(1000)
+					.HasColumnType("nvarchar(1000)");
 
 				b.Property<long>("AutoUpdateInterval")
 					.HasColumnType("bigint");
@@ -451,7 +461,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.Property<int>("Provider")
 					.HasColumnType("int");
 
-				b.Property<long?>("UserId")
+				b.Property<long>("UserId")
 					.HasColumnType("bigint");
 
 				b.HasKey("Id");
@@ -909,7 +919,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.HasOne("Tgstation.Server.Host.Models.User", "User")
 					.WithMany("OAuthConnections")
 					.HasForeignKey("UserId")
-					.OnDelete(DeleteBehavior.Cascade);
+					.OnDelete(DeleteBehavior.Cascade)
+					.IsRequired();
 
 				b.Navigation("User");
 			});

--- a/src/Tgstation.Server.Host/Database/Migrations/SqliteDatabaseContextModelSnapshot.cs
+++ b/src/Tgstation.Server.Host/Database/Migrations/SqliteDatabaseContextModelSnapshot.cs
@@ -4,7 +4,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
-namespace Tgstation.Server.Host.Database.Migrations
+namespace Tgstation.Server.Host.Database
 {
 	[DbContext(typeof(SqliteDatabaseContext))]
 	partial class SqliteDatabaseContextModelSnapshot : ModelSnapshot
@@ -12,7 +12,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 		protected override void BuildModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
-			modelBuilder.HasAnnotation("ProductVersion", "8.0.8");
+			modelBuilder.HasAnnotation("ProductVersion", "8.0.10");
 
 			modelBuilder.Entity("Tgstation.Server.Host.Models.ChatBot", b =>
 			{
@@ -284,9 +284,19 @@ namespace Tgstation.Server.Host.Database.Migrations
 					.ValueGeneratedOnAdd()
 					.HasColumnType("INTEGER");
 
+				b.Property<string>("AutoStartCron")
+					.IsRequired()
+					.HasMaxLength(1000)
+					.HasColumnType("TEXT");
+
+				b.Property<string>("AutoStopCron")
+					.IsRequired()
+					.HasMaxLength(1000)
+					.HasColumnType("TEXT");
+
 				b.Property<string>("AutoUpdateCron")
 					.IsRequired()
-					.HasMaxLength(10000)
+					.HasMaxLength(1000)
 					.HasColumnType("TEXT");
 
 				b.Property<uint?>("AutoUpdateInterval")
@@ -437,7 +447,7 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.Property<int>("Provider")
 					.HasColumnType("INTEGER");
 
-				b.Property<long?>("UserId")
+				b.Property<long>("UserId")
 					.HasColumnType("INTEGER");
 
 				b.HasKey("Id");
@@ -876,7 +886,8 @@ namespace Tgstation.Server.Host.Database.Migrations
 				b.HasOne("Tgstation.Server.Host.Models.User", "User")
 					.WithMany("OAuthConnections")
 					.HasForeignKey("UserId")
-					.OnDelete(DeleteBehavior.Cascade);
+					.OnDelete(DeleteBehavior.Cascade)
+					.IsRequired();
 
 				b.Navigation("User");
 			});

--- a/src/Tgstation.Server.Host/Models/Instance.cs
+++ b/src/Tgstation.Server.Host/Models/Instance.cs
@@ -76,6 +76,8 @@ namespace Tgstation.Server.Host.Models
 			Path = Path,
 			Online = Online,
 			ChatBotLimit = ChatBotLimit,
+			AutoStartCron = AutoStartCron,
+			AutoStopCron = AutoStopCron,
 		};
 	}
 }

--- a/src/Tgstation.Server.Host/Models/OAuthConnection.cs
+++ b/src/Tgstation.Server.Host/Models/OAuthConnection.cs
@@ -1,4 +1,6 @@
-﻿namespace Tgstation.Server.Host.Models
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Tgstation.Server.Host.Models
 {
 	/// <inheritdoc cref="Api.Models.OAuthConnection" />
 	public sealed class OAuthConnection : Api.Models.OAuthConnection, ILegacyApiTransformable<Api.Models.OAuthConnection>
@@ -16,6 +18,7 @@
 		/// <summary>
 		/// The owning <see cref="Models.User"/>.
 		/// </summary>
+		[Required]
 		public User? User { get; set; }
 
 		/// <inheritdoc />

--- a/src/Tgstation.Server.Host/Security/SessionInvalidationTracker.cs
+++ b/src/Tgstation.Server.Host/Security/SessionInvalidationTracker.cs
@@ -86,7 +86,7 @@ namespace Tgstation.Server.Host.Security
 								var timeTillSessionExpiry = authenticationContext.SessionExpiry - DateTimeOffset.UtcNow;
 								if (timeTillSessionExpiry > TimeSpan.Zero)
 								{
-									var delayTask = asyncDelayer.Delay(timeTillSessionExpiry, applicationLifetime.ApplicationStopping);
+									var delayTask = asyncDelayer.Delay(timeTillSessionExpiry, applicationLifetime.ApplicationStopping).AsTask();
 
 									await Task.WhenAny(delayTask, otherCancellationReason);
 

--- a/src/Tgstation.Server.Host/Security/SessionInvalidationTracker.cs
+++ b/src/Tgstation.Server.Host/Security/SessionInvalidationTracker.cs
@@ -40,7 +40,7 @@ namespace Tgstation.Server.Host.Security
 		readonly ILogger<SessionInvalidationTracker> logger;
 
 		/// <summary>
-		/// <see cref="ConcurrentDictionary{TKey, TValue}"/> of tracked <see cref="IAuthenticationContext.SessionId"/>s and <see cref="Models.User"/> <see cref="Api.Models.EntityId.Id"/>s to the <see cref="TaskCompletionSource{TResult}"/> for their <see cref="SessionInvalidationReason"/>s.
+		/// <see cref="ConcurrentDictionary{TKey, TValue}"/> of tracked <see cref="IAuthenticationContext.SessionId"/>s and <see cref="User"/> <see cref="Api.Models.EntityId.Id"/>s to the <see cref="TaskCompletionSource{TResult}"/> for their <see cref="SessionInvalidationReason"/>s.
 		/// </summary>
 		readonly ConcurrentDictionary<(string SessionId, long UserId), TaskCompletionSource<SessionInvalidationReason>> trackedSessions;
 
@@ -122,7 +122,7 @@ namespace Tgstation.Server.Host.Security
 		}
 
 		/// <inheritdoc />
-		public void UserModifiedInvalidateSessions(Models.User user)
+		public void UserModifiedInvalidateSessions(User user)
 		{
 			ArgumentNullException.ThrowIfNull(user);
 

--- a/src/Tgstation.Server.Host/Swarm/SwarmService.cs
+++ b/src/Tgstation.Server.Host/Swarm/SwarmService.cs
@@ -298,7 +298,7 @@ namespace Tgstation.Server.Host.Swarm
 			var timeoutTask = swarmController
 				? asyncDelayer.Delay(
 					TimeSpan.FromMinutes(SwarmConstants.UpdateCommitTimeoutMinutes),
-					cancellationToken)
+					cancellationToken).AsTask()
 				: Extensions.TaskExtensions.InfiniteTask.WaitAsync(cancellationToken);
 
 			var commitTask = Task.WhenAny(localUpdateOperation.CommitGate, timeoutTask);
@@ -1512,7 +1512,8 @@ namespace Tgstation.Server.Host.Swarm
 
 					var delayTask = asyncDelayer.Delay(
 						delay,
-						cancellationToken);
+						cancellationToken)
+						.AsTask();
 
 					var awakeningTask = Task.WhenAny(
 						delayTask,

--- a/src/Tgstation.Server.Host/Utils/AsyncDelayer.cs
+++ b/src/Tgstation.Server.Host/Utils/AsyncDelayer.cs
@@ -1,13 +1,57 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging;
 
 namespace Tgstation.Server.Host.Utils
 {
 	/// <inheritdoc />
 	sealed class AsyncDelayer : IAsyncDelayer
 	{
+		/// <summary>
+		/// The <see cref="ILogger"/> for the <see cref="AsyncDelayer"/>.
+		/// </summary>
+		readonly ILogger<AsyncDelayer> logger;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="AsyncDelayer"/> class.
+		/// </summary>
+		/// <param name="logger">The value of <see cref="logger"/>.</param>
+		public AsyncDelayer(ILogger<AsyncDelayer> logger)
+		{
+			this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+		}
+
 		/// <inheritdoc />
-		public Task Delay(TimeSpan timeSpan, CancellationToken cancellationToken) => Task.Delay(timeSpan, cancellationToken);
+		public async ValueTask Delay(TimeSpan timeSpan, CancellationToken cancellationToken)
+		{
+			// https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task.delay?view=net-8.0#system-threading-tasks-task-delay(system-timespan)
+			const uint DelayMinutesLimit = UInt32.MaxValue - 1;
+			Debug.Assert(DelayMinutesLimit == 4294967294, "Delay limit assertion failure!");
+
+			var maxDelayIterations = 0UL;
+			if (timeSpan.TotalMilliseconds >= UInt32.MaxValue)
+			{
+				maxDelayIterations = (ulong)Math.Floor(timeSpan.TotalMilliseconds / DelayMinutesLimit);
+				logger.LogDebug("Breaking interval into {iterationCount} iterations", maxDelayIterations + 1);
+				timeSpan = TimeSpan.FromMilliseconds(timeSpan.TotalMilliseconds - (maxDelayIterations * DelayMinutesLimit));
+			}
+
+			if (maxDelayIterations > 0)
+			{
+				var longDelayTimeSpan = TimeSpan.FromMilliseconds(DelayMinutesLimit);
+				for (var i = 0UL; i < maxDelayIterations; ++i)
+				{
+					logger.LogTrace("Long delay #{iteration}...", i + 1);
+					await Task.Delay(longDelayTimeSpan, cancellationToken);
+				}
+
+				logger.LogTrace("Final delay iteration #{iteration}...", maxDelayIterations + 1);
+			}
+
+			await Task.Delay(timeSpan, cancellationToken);
+		}
 	}
 }

--- a/src/Tgstation.Server.Host/Utils/IAsyncDelayer.cs
+++ b/src/Tgstation.Server.Host/Utils/IAsyncDelayer.cs
@@ -14,7 +14,7 @@ namespace Tgstation.Server.Host.Utils
 		/// </summary>
 		/// <param name="timeSpan">The <see cref="TimeSpan"/> that must elapse.</param>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
-		/// <returns>A <see cref="Task"/> representing the running operation.</returns>
-		Task Delay(TimeSpan timeSpan, CancellationToken cancellationToken);
+		/// <returns>A <see cref="ValueTask"/> representing the running operation.</returns>
+		ValueTask Delay(TimeSpan timeSpan, CancellationToken cancellationToken);
 	}
 }

--- a/tests/Tgstation.Server.Host.Tests.Signals/Program.cs
+++ b/tests/Tgstation.Server.Host.Tests.Signals/Program.cs
@@ -25,7 +25,7 @@ namespace Tgstation.Server.Host.Tests.Signals
 				.Returns(ValueTask.CompletedTask);
 
 			var mockAsyncDelayer = new Mock<IAsyncDelayer>();
-			mockAsyncDelayer.Setup(x => x.Delay(It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+			mockAsyncDelayer.Setup(x => x.Delay(It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>())).Returns(ValueTask.CompletedTask);
 			using var signalHandler = new PosixSignalHandler(mockServerControl.Object, mockAsyncDelayer.Object, Mock.Of<ILogger<PosixSignalHandler>>());
 
 			Assert.IsFalse(tcs.Task.IsCompleted);

--- a/tests/Tgstation.Server.Host.Tests/Components/Chat/Providers/TestIrcProvider.cs
+++ b/tests/Tgstation.Server.Host.Tests/Components/Chat/Providers/TestIrcProvider.cs
@@ -89,7 +89,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers.Tests
 				Instance = new Models.Instance(),
 			};
 
-			await using var provider = new IrcProvider(mockJobManager, new AsyncDelayer(), loggerFactory.CreateLogger<IrcProvider>(), Mock.Of<IAssemblyInformationProvider>(), chatBot, new FileLoggingConfiguration());
+			await using var provider = new IrcProvider(mockJobManager, new AsyncDelayer(loggerFactory.CreateLogger<AsyncDelayer>()), loggerFactory.CreateLogger<IrcProvider>(), Mock.Of<IAssemblyInformationProvider>(), chatBot, new FileLoggingConfiguration());
 			Assert.IsFalse(provider.Connected);
 			await InvokeConnect(provider);
 			Assert.IsTrue(provider.Connected);

--- a/tests/Tgstation.Server.Host.Tests/Setup/TestSetupWizard.cs
+++ b/tests/Tgstation.Server.Host.Tests/Setup/TestSetupWizard.cs
@@ -91,7 +91,7 @@ namespace Tgstation.Server.Host.Setup.Tests
 				mockInternalConfigurationOptions.Object);
 
 			mockPlatformIdentifier.SetupGet(x => x.IsWindows).Returns(true).Verifiable();
-			mockAsyncDelayer.Setup(x => x.Delay(It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask).Verifiable();
+			mockAsyncDelayer.Setup(x => x.Delay(It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>())).Returns(ValueTask.CompletedTask).Verifiable();
 
 			await RunWizard();
 

--- a/tests/Tgstation.Server.Host.Tests/Swarm/TestableSwarmNode.cs
+++ b/tests/Tgstation.Server.Host.Tests/Swarm/TestableSwarmNode.cs
@@ -129,7 +129,7 @@ namespace Tgstation.Server.Host.Swarm.Tests
 			mockAsyncDelayer.Setup(
 				x => x.Delay(It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
 				.Returns<TimeSpan, CancellationToken>(
-					(delay, ct) => Task.Delay(TimeSpan.FromMilliseconds(100), ct));
+					async (delay, ct) => await Task.Delay(TimeSpan.FromMilliseconds(100), ct));
 
 			var mockServerUpdater = new Mock<IServerUpdater>();
 
@@ -152,7 +152,7 @@ namespace Tgstation.Server.Host.Swarm.Tests
 				new CryptographySuite(
 					Mock.Of<IPasswordHasher<Models.User>>()),
 				Mock.Of<IIOManager>(),
-				new AsyncDelayer(), // use a real one here because otherwise tickets expire too fast
+				new AsyncDelayer(Mock.Of<ILogger<AsyncDelayer>>()), // use a real one here because otherwise tickets expire too fast
 				CreateLoggerFactoryForLogger(loggerFactory.CreateLogger($"FileTransferService-{swarmConfiguration.Identifier}"), out var mockLoggerFactory).CreateLogger<FileTransferService>());
 
 			RpcMapper = new SwarmRpcMapper(

--- a/tests/Tgstation.Server.Host.Tests/Utils/TestAsyncDelayer.cs
+++ b/tests/Tgstation.Server.Host.Tests/Utils/TestAsyncDelayer.cs
@@ -2,7 +2,10 @@
 using System.Threading;
 using System.Threading.Tasks;
 
+using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Moq;
 
 namespace Tgstation.Server.Host.Utils.Tests
 {
@@ -12,7 +15,7 @@ namespace Tgstation.Server.Host.Utils.Tests
 		[TestMethod]
 		public async Task TestDelay()
 		{
-			var delayer = new AsyncDelayer();
+			var delayer = new AsyncDelayer(Mock.Of<ILogger<AsyncDelayer>>());
 			var startDelay = delayer.Delay(TimeSpan.FromSeconds(1), CancellationToken.None);
 			var checkDelay = Task.Delay(TimeSpan.FromSeconds(1) - TimeSpan.FromMilliseconds(100), CancellationToken.None);
 			await startDelay;
@@ -22,10 +25,10 @@ namespace Tgstation.Server.Host.Utils.Tests
 		[TestMethod]
 		public async Task TestCancel()
 		{
-			var delayer = new AsyncDelayer();
+			var delayer = new AsyncDelayer(Mock.Of<ILogger<AsyncDelayer>>());
 			using var cts = new CancellationTokenSource();
 			cts.Cancel();
-			await Assert.ThrowsExceptionAsync<TaskCanceledException>(() => delayer.Delay(TimeSpan.FromSeconds(1), cts.Token));
+			await Assert.ThrowsExceptionAsync<TaskCanceledException>(() => delayer.Delay(TimeSpan.FromSeconds(1), cts.Token).AsTask());
 		}
 	}
 }

--- a/tests/Tgstation.Server.Tests/Live/DummyChatProvider.cs
+++ b/tests/Tgstation.Server.Tests/Live/DummyChatProvider.cs
@@ -51,7 +51,7 @@ namespace Tgstation.Server.Tests.Live
 			// at time of writing, this is used exclusively for the reconnection interval which works in minutes
 			// shorten it to 3s
 			var mock = new Mock<IAsyncDelayer>();
-			mock.Setup(x => x.Delay(It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>())).Returns<TimeSpan, CancellationToken>((delay, cancellationToken) => Task.Delay(TimeSpan.FromSeconds(3), cancellationToken));
+			mock.Setup(x => x.Delay(It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>())).Returns<TimeSpan, CancellationToken>(async (delay, cancellationToken) => await Task.Delay(TimeSpan.FromSeconds(3), cancellationToken));
 			return mock.Object;
 		}
 

--- a/tests/Tgstation.Server.Tests/Live/Instance/WatchdogTest.cs
+++ b/tests/Tgstation.Server.Tests/Live/Instance/WatchdogTest.cs
@@ -309,7 +309,7 @@ namespace Tgstation.Server.Tests.Live.Instance
 					? await session.TopicSendSemaphore.Lock(cancellationToken)
 					: null)
 					return await topicClient.SendWithOptionalPriority(
-						new AsyncDelayer(),
+						new AsyncDelayer(loggerFactory.CreateLogger<AsyncDelayer>()),
 						loggerFactory.CreateLogger<WatchdogTest>(),
 						queryString,
 						topicPort,

--- a/tests/Tgstation.Server.Tests/TestDatabase.cs
+++ b/tests/Tgstation.Server.Tests/TestDatabase.cs
@@ -109,6 +109,8 @@ namespace Tgstation.Server.Tests
 				ChatBotLimit = 1,
 				ChatSettings = new List<Host.Models.ChatBot>(),
 				ConfigurationType = ConfigurationType.HostWrite,
+				AutoStartCron = String.Empty,
+				AutoStopCron = String.Empty,
 				DreamDaemonSettings = new Host.Models.DreamDaemonSettings
 				{
 					AllowWebClient = false,


### PR DESCRIPTION
Fixes #1985 
Closes #1969 

🆑
Fixed version telemetry not being reported. This was due to a misconfiguration in the deployment process and isn't reflected in code.
Fixed `GET /Administration` returning bad data if a prior request to it was aborted.
Fixed downgrading to versions between <6.70 and >=6.6.0 migrating MySQL/MariaDB databases incorrectly.
UserId in OAuthConnections schema is now properly non-nullable.
**(POTENTIAL INCOMPATIBILITY) Limited database cron string lengths to 1000 characters instead of 10000.**
Fixed cases where very long timers could throw exceptions.
Added start/stop cron schedules for instance game servers.
/🆑

🆑 HTTP API
Added `autoStartCron` and `autoStopCron` to Instance model. Functions identically to `autoUpdateCron` but will instead launch and gracefully shutdown the server respectively. Added instance rights 2048 and 4096 to adjust these respectively.
/🆑

🆑 Nuget: API
Updated to API v10.12.0.
Added `Limits.CronStringLength`.
Adjusted `StringLength` attribute on `Instance.AutoUpdateCron`.
Added `Instance.AutoStartCron` and `Instance.AutoStopCron`.
Added `InstanceManagerRights.SetAutoStart` and `InstanceManagerRights.SetAutoStop`.
/🆑

:cl: Nuget: Client
Update API Library to v16.3.0
/:cl:

Merging with `[RESTDeploy][NugetDeploy]`