### PR TITLE
Nix Support

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -1444,6 +1444,7 @@ jobs:
   build-msi:
     name: Build Windows Installer .exe
     runs-on: windows-latest
+    needs: start-gate
     env:
       TGS_TELEMETRY_KEY_FILE: C:/tgs_telemetry_key.txt
     steps:

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -47,8 +47,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  start-gate:
+    name: CI Start Gate
+    runs-on: ubuntu-latest
+    if: (!contains(github.event.head_commit.message, '[TGSRelease]'))
+    steps:
+      - name: GitHub Requires at Least One Step for a Job
+        run: exit 0
+
   build-releasenotes:
     name: Build ReleaseNotes for Other Jobs
+    needs: start-gate
     runs-on: ubuntu-latest
     steps:
       - name: Install Native Dependencies
@@ -83,6 +92,7 @@ jobs:
 
   code-scanning:
     name: Run CodeQL
+    needs: start-gate
     runs-on: ubuntu-latest
     permissions:
       security-events: write
@@ -134,6 +144,7 @@ jobs:
 
   dmapi-build:
     name: Build DMAPI
+    needs: start-gate
     strategy:
       fail-fast: false
       matrix:
@@ -222,6 +233,7 @@ jobs:
 
   opendream-build:
     name: Build DMAPI (OpenDream)
+    needs: start-gate
     strategy:
       fail-fast: false
       matrix:
@@ -278,6 +290,7 @@ jobs:
   efcore-version-match:
     name: Check Nuget Versions Match Tools
     runs-on: ubuntu-latest
+    needs: start-gate
     steps:
       - name: Checkout (Branch)
         uses: actions/checkout@v4
@@ -412,6 +425,7 @@ jobs:
   docker-build:
     name: Build Docker Image
     runs-on: ubuntu-latest
+    needs: start-gate
     env:
       TGS_TELEMETRY_KEY_FILE: tgs_telemetry_key.txt
     steps:
@@ -438,6 +452,7 @@ jobs:
 
   linux-unit-tests:
     name: Linux Tests
+    needs: start-gate
     strategy:
       fail-fast: false
       matrix:
@@ -510,6 +525,7 @@ jobs:
 
   windows-unit-tests:
     name: Windows Tests
+    needs: start-gate
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -2172,7 +2172,13 @@ jobs:
           subject-path: ./ServerConsole.zip
           github-token: ${{ steps.app-token-generation.outputs.token }}
 
-      - name: Upload Server Console Artifact
+      - name: Upload Server Console Zip Artifact to Action
+        uses: actions/upload-artifact@v4
+        with:
+          name: server-console-release
+          path: ./ServerConsole.zip
+
+      - name: Upload Server Console Artifact to Release
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ steps.app-token-generation.outputs.token }}
@@ -2309,6 +2315,58 @@ jobs:
           asset_path: ./build/package/winget/tgstation-server-installer.exe
           asset_name: tgstation-server-installer.exe
           asset_content_type: application/octet-stream
+
+  update-nix:
+    name: Update Nix SHA
+    needs: deploy-tgs
+    runs-on: ubuntu-latest
+    if: (!(cancelled() || failure())) && needs.deploy-tgs.result == 'success'
+    steps:
+      - name: Install Native Packages # Name checked in rerunFlakyTests.js
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xmlstarlet
+
+      - name: Setup Nix
+        uses: cachix/install-nix-action@v27
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Parse TGS version
+        run: echo "TGS_VERSION=$(xmlstarlet sel -N X="http://schemas.microsoft.com/developer/msbuild/2003" --template --value-of /X:Project/X:PropertyGroup/X:TgsCoreVersion build/Version.props)" >> $GITHUB_ENV
+
+      - name: Retrieve ServerConsole.zip Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: server-console-release
+          path: server-console-release
+
+      - name: Regenerate Nix Hash
+        run: |
+          nix hash path ./server-console-release > build/package/nix/ServerConsole.sha256
+          cat build/package/nix/ServerConsole.sha256
+
+      - name: Commit
+        run: |
+          git config --global push.default simple
+          git config user.name "tgstation-server-ci[bot]"
+          git config user.email "161980869+tgstation-server-ci[bot]@users.noreply.github.com"
+          git add build/package/nix/ServerConsole.sha256
+          git commit -m "Update nix SHA256 for [TGSRelease] v${{ env.TGS_VERSION }}"
+
+      - name: Re-tag
+        run: |
+          git tag -d tgstation-server-v${{ env.TGS_VERSION }}
+          git tag tgstation-server-v${{ env.TGS_VERSION }}
+
+      - name: Push Commit
+        run: git push
+
+      - name: Force Push Tags
+        run: git push -f --tags
 
   changelog-regen:
     name: Regenerate Changelog

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -1731,6 +1731,12 @@ jobs:
           body_path: release_notes.md
           commitish: ${{ github.event.head_commit.id }}
 
+      - name: Generate Artifact Attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: ./swagger/tgs_api.json
+          github-token: ${{ steps.app-token-generation.outputs.token }}
+
       - name: Upload OpenApi Spec
         uses: actions/upload-release-asset@v1
         env:
@@ -1811,6 +1817,12 @@ jobs:
           commitish: ${{ github.event.head_commit.id }}
           prerelease: ${{ env.TGS_GRAPHQL_PRERELEASE }}
 
+      - name: Generate Artifact Attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: ./schema/tgs_api.graphql
+          github-token: ${{ steps.app-token-generation.outputs.token }}
+
       - name: Upload GraphQL Schema
         uses: actions/upload-release-asset@v1
         env:
@@ -1882,6 +1894,12 @@ jobs:
           release_name: tgstation-server DMAPI v${{ env.TGS_DM_VERSION }}
           body_path: release_notes.md
           commitish: ${{ github.event.head_commit.id }}
+
+      - name: Generate Artifact Attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: ./DMAPI.zip
+          github-token: ${{ steps.app-token-generation.outputs.token }}
 
       - name: Upload DMAPI Artifact
         uses: actions/upload-release-asset@v1
@@ -2148,6 +2166,12 @@ jobs:
           body_path: release_notes.md
           commitish: ${{ github.event.head_commit.id }}
 
+      - name: Generate Server Console Artifact Attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: ./ServerConsole.zip
+          github-token: ${{ steps.app-token-generation.outputs.token }}
+
       - name: Upload Server Console Artifact
         uses: actions/upload-release-asset@v1
         env:
@@ -2157,6 +2181,12 @@ jobs:
           asset_path: ./ServerConsole.zip
           asset_name: ServerConsole.zip
           asset_content_type: application/zip
+
+      - name: Generate Server Service Artifact Attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: ./ServerService.zip
+          github-token: ${{ steps.app-token-generation.outputs.token }}
 
       - name: Upload Server Service Artifact
         uses: actions/upload-release-asset@v1
@@ -2168,6 +2198,12 @@ jobs:
           asset_name: ServerService.zip
           asset_content_type: application/zip
 
+      - name: Generate DMAPI Artifact Attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: ./DMAPI.zip
+          github-token: ${{ steps.app-token-generation.outputs.token }}
+
       - name: Upload DMAPI Artifact
         uses: actions/upload-release-asset@v1
         env:
@@ -2177,6 +2213,12 @@ jobs:
           asset_path: ./DMAPI.zip
           asset_name: DMAPI.zip
           asset_content_type: application/zip
+
+      - name: Generate REST API Artifact Attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: ./swagger/tgs_api.json
+          github-token: ${{ steps.app-token-generation.outputs.token }}
 
       - name: Upload REST API Artifact
         uses: actions/upload-release-asset@v1
@@ -2188,6 +2230,12 @@ jobs:
           asset_name: swagger.json
           asset_content_type: application/json
 
+      - name: Generate GraphQL API Artifact Attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: ./schema/tgs-api.graphql
+          github-token: ${{ steps.app-token-generation.outputs.token }}
+
       - name: Upload GraphQL API Artifact
         uses: actions/upload-release-asset@v1
         env:
@@ -2197,6 +2245,12 @@ jobs:
           asset_path: ./schema/tgs-api.graphql
           asset_name: tgs-api.graphql
           asset_content_type: text/plain
+
+      - name: Generate Server Update Package Artifact Attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: ./ServerUpdatePackage.zip
+          github-token: ${{ steps.app-token-generation.outputs.token }}
 
       - name: Upload Server Update Package Artifact
         uses: actions/upload-release-asset@v1
@@ -2208,7 +2262,13 @@ jobs:
           asset_name: ServerUpdatePackage.zip
           asset_content_type: application/zip
 
-      - name: Upload Debian Pacakaging Artifact
+      - name: Generate Debian Packaging Artifact Attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: ./packaging-debian/tgstation-server-v${{ env.TGS_VERSION }}.debian.packaging.tar.xz
+          github-token: ${{ steps.app-token-generation.outputs.token }}
+
+      - name: Upload Debian Packaging Artifact
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ steps.app-token-generation.outputs.token }}
@@ -2217,6 +2277,12 @@ jobs:
           asset_path: ./packaging-debian/tgstation-server-v${{ env.TGS_VERSION }}.debian.packaging.tar.xz
           asset_name: tgstation-server-v${{ env.TGS_VERSION }}.debian.packaging.tar.xz
           asset_content_type: application/x-tar
+
+      - name: Generate MariaDB .msi Attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: ./build/package/winget/Tgstation.Server.Host.Service.Wix.Bundle/bin/Release/mariadb.msi
+          github-token: ${{ steps.app-token-generation.outputs.token }}
 
       - name: Upload MariaDB .msi
         uses: actions/upload-release-asset@v1
@@ -2227,6 +2293,12 @@ jobs:
           asset_path: ./build/package/winget/Tgstation.Server.Host.Service.Wix.Bundle/bin/Release/mariadb.msi
           asset_name: mariadb-${{ env.MARIADB_VERSION }}-winx64.msi
           asset_content_type: application/octet-stream
+
+      - name: Generate Installer .exe Attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: ./build/package/winget/tgstation-server-installer.exe
+          github-token: ${{ steps.app-token-generation.outputs.token }}
 
       - name: Upload Installer .exe
         uses: actions/upload-release-asset@v1

--- a/README.md
+++ b/README.md
@@ -137,6 +137,31 @@ sudo dpkg --add-architecture i386 \
 
 The service will execute as the newly created user: `tgstation-server`. You should, ideally, store your instances somewhere under `/home/tgstation-server`.
 
+##### Nix Flake
+
+TGS supports being setup on Nix starting with version 6.12.0. Add the [flake](./build/package/nix/flake.nix) to your own system by adding the following code to your flake inputs.
+```nix
+    tgstation-server = {
+      url = "github:tgstation/tgstation-server/tgstation-server-v${version}?dir=build/package/nix";
+    };
+```
+
+Where `version` is the latest major TGS version you wish to use.
+
+Note that changing this version does not change the core version of TGS used after the first launch. Instead, have TGS self-update via its API.
+
+For maximum game server uptime, do NOT modify this version unless you are doing a major TGS version update in which case it is a requirement.
+
+Configure TGS by setting up its service definition:
+```nix
+  services.tgstation-server = {
+    enable = true;
+    production-appsettings = (builtins.readFile ./path/to/your/appsettings.Production.yml);
+  };
+```
+
+Refer to [tgstation-server.nix](./build/package/nix/tgstation-server.nix) for the full list of available configuration options.
+
 ##### Manual Setup
 
 The following dependencies are required.
@@ -242,6 +267,8 @@ Create an `appsettings.Production.yml` file next to `appsettings.yml`. This will
 - `General:GitHubAccessToken`: Specify a classic GitHub personal access token with no scopes here to highly mitigate the possiblity of 429 response codes from GitHub requests
 
 - `General:SkipAddingByondFirewallException`: Set to `true` if you have Windows firewall disabled
+
+- `General:AdditionalEventScriptsDirectories`: An array of directories that are considered to contain EventScripts alongside instance directories. Working directory for executed scripts will remain the instance EventScripts directory.
 
 - `Session:HighPriorityLiveDreamDaemon`: Boolean controlling if live DreamDaemon instances get set to above normal priority processes.
 

--- a/build/Version.props
+++ b/build/Version.props
@@ -12,7 +12,7 @@
     <TgsClientVersion>19.3.0</TgsClientVersion>
     <TgsDmapiVersion>7.3.0</TgsDmapiVersion>
     <TgsInteropVersion>5.10.0</TgsInteropVersion>
-    <TgsHostWatchdogVersion>1.5.0</TgsHostWatchdogVersion>
+    <TgsHostWatchdogVersion>1.6.0</TgsHostWatchdogVersion>
     <TgsSwarmProtocolVersion>8.0.0</TgsSwarmProtocolVersion>
     <TgsContainerScriptVersion>1.2.1</TgsContainerScriptVersion>
     <TgsMigratorVersion>2.0.0</TgsMigratorVersion>

--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="WebpanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>6.11.4</TgsCoreVersion>
+    <TgsCoreVersion>6.12.0</TgsCoreVersion>
     <TgsConfigVersion>5.4.0</TgsConfigVersion>
     <TgsRestVersion>10.12.0</TgsRestVersion>
     <TgsGraphQLVersion>0.5.0</TgsGraphQLVersion>

--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="WebpanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>6.12.0</TgsCoreVersion>
+    <TgsCoreVersion>6.11.4</TgsCoreVersion>
     <TgsConfigVersion>5.4.0</TgsConfigVersion>
     <TgsRestVersion>10.12.0</TgsRestVersion>
     <TgsGraphQLVersion>0.5.0</TgsGraphQLVersion>

--- a/build/package/nix/ServerConsole.sha256
+++ b/build/package/nix/ServerConsole.sha256
@@ -1,0 +1,1 @@
+sha256-mHlRHPSeZxyJPqN3KUmc0ftYNZgh81LauIu+fCSKPUI=

--- a/build/package/nix/flake.nix
+++ b/build/package/nix/flake.nix
@@ -1,0 +1,13 @@
+{
+    description = "tgstation-server";
+
+    inputs = {};
+
+    outputs = { ... }: {
+        nixosModules = {
+            default = { ... }: {
+                imports = [ ./tgstation-server.nix ];
+            };
+        };
+    };
+}

--- a/build/package/nix/package.nix
+++ b/build/package/nix/package.nix
@@ -84,7 +84,6 @@ stdenv.mkDerivation {
     zlib
     gcc_multi
     glibc
-    patchelf
   ];
   nativeBuildInputs = with pkgs; [
     makeWrapper
@@ -103,7 +102,6 @@ stdenv.mkDerivation {
       lib.makeBinPath (
         with pkgs;
         [
-          patchelf
           dotnetCorePackages.aspnetcore_8_0
           gdb
         ]

--- a/build/package/nix/package.nix
+++ b/build/package/nix/package.nix
@@ -51,7 +51,7 @@ let
     src = ./.;
 
     buildPhase = ''
-      curl -L https://file.house/b2eyKOJZ7ptxwqm8O24-9A==.zip -o ServerConsole.zip
+      curl -L https://github.com/tgstation/tgstation-server/releases/download/tgstation-server-v${version}/ServerConsole.zip -o ServerConsole.zip
     '';
 
     installPhase = ''

--- a/build/package/nix/package.nix
+++ b/build/package/nix/package.nix
@@ -1,0 +1,121 @@
+{
+  pkgs,
+  ...
+}:
+
+let
+  inherit (pkgs) stdenv lib;
+
+  versionParse = stdenv.mkDerivation {
+    pname = "tgstation-server-version-parse";
+    version = "1.0.0";
+
+    meta = with pkgs.lib; {
+      description = "Version parser for tgstation-server";
+      homepage = "https://github.com/tgstation/tgstation-server";
+      changelog = "https://github.com/tgstation/tgstation-server/blob/gh-pages/changelog.yml";
+      license = licenses.agpl3Plus;
+      platforms = platforms.x86_64;
+    };
+
+    nativeBuildInputs = with pkgs; [
+      xmlstarlet
+    ];
+
+    src = ./../..;
+
+    installPhase = ''
+      mkdir -p $out
+      xmlstarlet sel -N X="http://schemas.microsoft.com/developer/msbuild/2003" --template --value-of /X:Project/X:PropertyGroup/X:TgsCoreVersion ./Version.props > $out/tgs_version.txt
+    '';
+  };
+
+  fixedOutput = stdenv.mkDerivation {
+    pname = "tgstation-server-release-server-console-zip";
+    version = (builtins.readFile "${versionParse}/tgs_version.txt");
+
+    meta = with pkgs.lib; {
+      description = "Host watchdog binaries for tgstation-server";
+      homepage = "https://github.com/tgstation/tgstation-server";
+      changelog = "https://github.com/tgstation/tgstation-server/releases/tag/tgstation-server-v${version}";
+      license = licenses.agpl3Plus;
+      platforms = platforms.x86_64;
+    };
+
+    nativeBuildInputs = with pkgs; [
+      curl
+      cacert
+      versionParse
+    ];
+
+    src = ./.;
+
+    buildPhase = ''
+      curl -L https://file.house/b2eyKOJZ7ptxwqm8O24-9A==.zip -o ServerConsole.zip
+    '';
+
+    installPhase = ''
+      mkdir -p $out
+      mv ServerConsole.zip $out/ServerConsole.zip
+    '';
+
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    outputHash = (builtins.readFile ./ServerConsole.sha256);
+  };
+  rpath = lib.makeLibraryPath [ pkgs.stdenv_32bit.cc.cc.lib ];
+in
+stdenv.mkDerivation {
+  pname = "tgstation-server";
+  version = (builtins.readFile "${versionParse}/tgs_version.txt");
+
+  meta = with pkgs.lib; {
+    description = "A production scale tool for DreamMaker server management";
+    homepage = "https://github.com/tgstation/tgstation-server";
+    changelog = "https://github.com/tgstation/tgstation-server/releases/tag/tgstation-server-v${version}";
+    license = licenses.agpl3Plus;
+    platforms = platforms.x86_64;
+  };
+
+  buildInputs = with pkgs; [
+    dotnetCorePackages.aspnetcore_8_0
+    gdb
+    systemd
+    zlib
+    gcc_multi
+    glibc
+    patchelf
+  ];
+  nativeBuildInputs = with pkgs; [
+    makeWrapper
+    unzip
+    fixedOutput
+    versionParse
+  ];
+
+  src = ./.;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    unzip "${fixedOutput}/ServerConsole.zip" -d $out/bin
+    rm -rf $out/bin/lib
+    makeWrapper ${pkgs.dotnetCorePackages.aspnetcore_8_0}/dotnet $out/bin/tgstation-server --suffix PATH : ${
+      lib.makeBinPath (
+        with pkgs;
+        [
+          patchelf
+          dotnetCorePackages.aspnetcore_8_0
+          gdb
+        ]
+      )
+    } --suffix LD_LIBRARY_PATH : ${
+      lib.makeLibraryPath (
+        with pkgs;
+        [
+          systemd
+          zlib
+        ]
+      )
+    } --add-flags "$out/bin/Tgstation.Server.Host.Console.dll --bootstrap"
+  '';
+}

--- a/build/package/nix/tgstation-server.nix
+++ b/build/package/nix/tgstation-server.nix
@@ -1,0 +1,124 @@
+inputs@{
+  config,
+  lib,
+  nixpkgs,
+  pkgs,
+  ...
+}:
+
+let
+  pkgs-i686 = nixpkgs.legacyPackages.i686-linux;
+
+  cfg = config.services.tgstation-server;
+
+  package = import ./package.nix inputs;
+
+  stdenv = pkgs-i686.stdenv_32bit;
+
+  rpath = pkgs-i686.lib.makeLibraryPath [
+    stdenv.cc.cc.lib
+  ];
+
+  byond-patcher = pkgs-i686.writeShellScriptBin "byond-patcher" ''
+    BYOND_PATH=$(realpath ../../Byond/$1/byond/bin/)
+
+    patchelf --set-interpreter "$(cat ${stdenv.cc}/nix-support/dynamic-linker)" \
+      --set-rpath "$BYOND_PATH:${rpath}" \
+      $BYOND_PATH/{DreamDaemon,DreamDownload,DreamMaker}
+  '';
+in
+{
+  ##### interface. here we define the options that users of our service can specify
+  options = {
+    # the options for our service will be located under services.foo
+    services.tgstation-server = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Whether to enable tgstation-server.
+        '';
+      };
+
+      username = lib.mkOption {
+        type = lib.types.str;
+        default = "tgstation-server";
+        description = ''
+          The name of the user used to execute tgstation-server.
+        '';
+      };
+
+      groupname = lib.mkOption {
+        type = lib.types.str;
+        default = "tgstation-server";
+        description = ''
+          The name of group the user used to execute tgstation-server will belong to.
+        '';
+      };
+
+      home-directory = lib.mkOption {
+        type = lib.types.str;
+        default = "/home/tgstation-server";
+        description = ''
+          The home directory of TGS. Should be persistent.
+        '';
+      };
+
+      production-appsettings = lib.mkOption {
+        type = lib.types.lines;
+        default = '''';
+        description = ''
+          The contents of appsettings.Production.yml in the /etc/tgstation-server.d directory.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    users.groups."${cfg.groupname}" = { };
+
+    users.users."${cfg.username}" = {
+      isSystemUser = true;
+      createHome = true;
+      group = cfg.groupname;
+      home = cfg.home-directory;
+    };
+
+    environment.etc = {
+      "tgstation-server.d/appsettings.yml" = {
+        text = (builtins.readFile "${package}/bin/appsettings.yml");
+        group = cfg.groupname;
+        mode = "0644";
+      };
+      "tgstation-server.d/appsettings.Production.yml" = {
+        text = cfg.production-appsettings;
+        group = cfg.groupname;
+        mode = "0640";
+      };
+      "tgstation-server.d/EventScripts/EngineInstallComplete-050-PatchELFByond.sh" = {
+        source = "${byond-patcher}/bin/byond-patcher";
+        group = cfg.groupname;
+        mode = "755";
+      };
+    };
+
+    systemd.services.tgstation-server = {
+      description = "tgstation-server";
+      serviceConfig = {
+        User = cfg.username;
+        Type = "notify-reload";
+        NotifyAccess = "all";
+        WorkingDirectory = "${package}/bin";
+        ExecStart = "${package}/bin/tgstation-server --appsettings-base-path=/etc/tgstation-server.d --General:SetupWizardMode=Never --General:AdditionalEventScriptsDirectories:0=/etc/tgstation-server.d/EventScripts";
+        Restart = "always";
+        KillMode = "process";
+        ReloadSignal = "SIGUSR2";
+        AmbientCapabilities = "CAP_SYS_NICE CAP_SYS_PTRACE";
+        WatchdogSec = "60";
+        WatchdogSignal = "SIGTERM";
+        LogsDirectory = "tgstation-server";
+      };
+      wantedBy = [ "multi-user.target" ];
+    };
+  };
+}

--- a/build/package/nix/tgstation-server.nix
+++ b/build/package/nix/tgstation-server.nix
@@ -25,7 +25,9 @@ let
 
     ${pkgs.patchelf}/bin/patchelf --set-interpreter "$(cat ${stdenv.cc}/nix-support/dynamic-linker)" \
       --set-rpath "$BYOND_PATH:${rpath}" \
-      $BYOND_PATH/{DreamDaemon,DreamDownload,DreamMaker,*.so}
+      $BYOND_PATH/{DreamDaemon,DreamDownload,DreamMaker}
+
+    ${pkgs.patchelf}/bin/patchelf --set-rpath "$BYOND_PATH:${rpath}" $BYOND_PATH/*.so
   '';
 
   tgs-wrapper = pkgs.writeShellScriptBin "tgs-path-wrapper" ''

--- a/build/package/nix/tgstation-server.nix
+++ b/build/package/nix/tgstation-server.nix
@@ -23,7 +23,7 @@ let
   byond-patcher = pkgs-i686.writeShellScriptBin "EngineInstallComplete-050-TgsPatchELFByond.sh" ''
     BYOND_PATH=$(realpath ../../Byond/$1/byond/bin/)
 
-    patchelf --set-interpreter "$(cat ${stdenv.cc}/nix-support/dynamic-linker)" \
+    ${pkgs.patchelf}/bin/patchelf --set-interpreter "$(cat ${stdenv.cc}/nix-support/dynamic-linker)" \
       --set-rpath "$BYOND_PATH:${rpath}" \
       $BYOND_PATH/{DreamDaemon,DreamDownload,DreamMaker,*.so}
   '';

--- a/build/package/nix/tgstation-server.nix
+++ b/build/package/nix/tgstation-server.nix
@@ -26,8 +26,6 @@ let
     ${pkgs.patchelf}/bin/patchelf --set-interpreter "$(cat ${stdenv.cc}/nix-support/dynamic-linker)" \
       --set-rpath "$BYOND_PATH:${rpath}" \
       $BYOND_PATH/{DreamDaemon,DreamDownload,DreamMaker}
-
-    ${pkgs.patchelf}/bin/patchelf --set-rpath "$BYOND_PATH:${rpath}" $BYOND_PATH/*.so
   '';
 
   tgs-wrapper = pkgs.writeShellScriptBin "tgs-path-wrapper" ''

--- a/build/package/nix/tgstation-server.nix
+++ b/build/package/nix/tgstation-server.nix
@@ -25,7 +25,7 @@ let
 
     patchelf --set-interpreter "$(cat ${stdenv.cc}/nix-support/dynamic-linker)" \
       --set-rpath "$BYOND_PATH:${rpath}" \
-      $BYOND_PATH/{DreamDaemon,DreamDownload,DreamMaker}
+      $BYOND_PATH/{DreamDaemon,DreamDownload,DreamMaker,*.so}
   '';
 
   tgs-wrapper = pkgs.writeShellScriptBin "tgs-path-wrapper" ''

--- a/build/package/nix/tgstation-server.nix
+++ b/build/package/nix/tgstation-server.nix
@@ -19,7 +19,7 @@ let
     stdenv.cc.cc.lib
   ];
 
-  byond-patcher = pkgs-i686.writeShellScriptBin "byond-patcher" ''
+  byond-patcher = pkgs-i686.writeShellScriptBin "EngineInstallComplete-050-TgsPatchELFByond.sh" ''
     BYOND_PATH=$(realpath ../../Byond/$1/byond/bin/)
 
     patchelf --set-interpreter "$(cat ${stdenv.cc}/nix-support/dynamic-linker)" \
@@ -95,11 +95,6 @@ in
         group = cfg.groupname;
         mode = "0640";
       };
-      "tgstation-server.d/EventScripts/EngineInstallComplete-050-PatchELFByond.sh" = {
-        source = "${byond-patcher}/bin/byond-patcher";
-        group = cfg.groupname;
-        mode = "755";
-      };
     };
 
     systemd.services.tgstation-server = {
@@ -109,7 +104,7 @@ in
         Type = "notify-reload";
         NotifyAccess = "all";
         WorkingDirectory = "${package}/bin";
-        ExecStart = "${package}/bin/tgstation-server --appsettings-base-path=/etc/tgstation-server.d --General:SetupWizardMode=Never --General:AdditionalEventScriptsDirectories:0=/etc/tgstation-server.d/EventScripts";
+        ExecStart = "${package}/bin/tgstation-server --appsettings-base-path=/etc/tgstation-server.d --General:SetupWizardMode=Never --General:AdditionalEventScriptsDirectories:0=/etc/tgstation-server.d/EventScripts --General:AdditionalEventScriptsDirectories:1=${byond-patcher}/bin";
         Restart = "always";
         KillMode = "process";
         ReloadSignal = "SIGUSR2";

--- a/src/Tgstation.Server.Host.Common/DotnetHelper.cs
+++ b/src/Tgstation.Server.Host.Common/DotnetHelper.cs
@@ -14,10 +14,10 @@ namespace Tgstation.Server.Host.Common
 	public static class DotnetHelper
 	{
 		/// <summary>
-		/// Gets the path to the dotnet executable.
+		/// Gets potential paths to the dotnet executable.
 		/// </summary>
 		/// <param name="isWindows">If the current system is a Windows OS.</param>
-		/// <returns>The path to the dotnet executable.</returns>
+		/// <returns>An <see cref="IEnumerable{T}"/> of potential paths to the dotnet executable.</returns>
 		public static IEnumerable<string> GetPotentialDotnetPaths(bool isWindows)
 		{
 			var enviromentPath = Environment.GetEnvironmentVariable("PATH");

--- a/src/Tgstation.Server.Host.Console/Tgstation.Server.Host.Console.csproj
+++ b/src/Tgstation.Server.Host.Console/Tgstation.Server.Host.Console.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(TgsFrameworkVersion)</TargetFramework>
+    <!-- Important that this is core and not host watchdog. Bootstrapping depends on it -->
     <Version>$(TgsCoreVersion)</Version>
     <Nullable>enable</Nullable>
     <UseAppHost>false</UseAppHost>

--- a/src/Tgstation.Server.Host.Service/Tgstation.Server.Host.Service.csproj
+++ b/src/Tgstation.Server.Host.Service/Tgstation.Server.Host.Service.csproj
@@ -7,6 +7,7 @@
     <Nullable>enable</Nullable>
     <!-- DO NOT ADD THE -windows SUFFIX, It makes the service require the desktop runtime instead of the ASP NET Core Hosting Bundle -->
     <TargetFramework>$(TgsFrameworkVersion)</TargetFramework>
+    <!-- Important that this is core and not host watchdog. Bootstrapping depends on it -->
     <Version>$(TgsCoreVersion)</Version>
     <!-- DO NOT ENABLE THIS, It makes the service require the desktop runtime instead of the ASP NET Core Hosting Bundle -->
     <UseWindowsForms>false</UseWindowsForms>

--- a/src/Tgstation.Server.Host.Watchdog/BootstrapSettings.cs
+++ b/src/Tgstation.Server.Host.Watchdog/BootstrapSettings.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Reflection;
+
+using Tgstation.Server.Common.Extensions;
+
+namespace Tgstation.Server.Host.Watchdog
+{
+	/// <summary>
+	/// Settings for the bootstrapper feature.
+	/// </summary>
+	sealed class BootstrapSettings
+	{
+		/// <summary>
+		/// The current supported major version of <see cref="FileVersion"/>.
+		/// </summary>
+		public const int FileMajorVersion = 1;
+
+		/// <summary>
+		/// The token used to substitute <see cref="ServerUpdatePackageUrlFormatter"/>.
+		/// </summary>
+		public const string VersionSubstitutionToken = "${version}";
+
+		/// <summary>
+		/// The version of the boostrapper file.
+		/// </summary>
+		public Version FileVersion { get; set; } = new Version(FileMajorVersion, 0, 0);
+
+		/// <summary>
+		/// The <see cref="Version"/> of TGS last launched in the lib/Default directory.
+		/// </summary>
+		public Version TgsVersion { get; set; } = Assembly.GetEntryAssembly()!.GetName().Version!.Semver();
+
+		/// <summary>
+		/// The URL to format with <see cref="TgsVersion"/> to get the download URL.
+		/// </summary>
+		public string ServerUpdatePackageUrlFormatter { get; set; } = $"https://github.com/tgstation/tgstation-server/releases/download/tgstation-server-v{VersionSubstitutionToken}/ServerUpdatePackage.zip";
+	}
+}

--- a/src/Tgstation.Server.Host.Watchdog/Watchdog.cs
+++ b/src/Tgstation.Server.Host.Watchdog/Watchdog.cs
@@ -92,7 +92,10 @@ namespace Tgstation.Server.Host.Watchdog
 					return false;
 				}
 
-				var assemblyStoragePath = Path.Combine(rootLocation, "lib"); // always always next to watchdog
+				var bootstrappable = args.Contains("--bootstrap", StringComparer.OrdinalIgnoreCase);
+				var homeDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".tgstation-server");
+
+				var assemblyStoragePath = Path.Combine(bootstrappable ? homeDirectory : rootLocation, "lib"); // always always next to watchdog
 
 				var defaultAssemblyPath = Path.GetFullPath(Path.Combine(assemblyStoragePath, "Default"));
 
@@ -122,9 +125,7 @@ namespace Tgstation.Server.Host.Watchdog
 				else
 					Directory.CreateDirectory(assemblyStoragePath);
 
-				var bootstrappable = args.Contains("--bootstrap", StringComparer.OrdinalIgnoreCase);
-				var homeDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-				var bootstrapperSettingsFile = Path.Combine(homeDirectory, ".tgstation-server-bootstrap.json");
+				var bootstrapperSettingsFile = Path.Combine(homeDirectory, "bootstrap.json");
 				BootstrapSettings? bootstrapSettings = null;
 				if (!Directory.Exists(defaultAssemblyPath))
 				{

--- a/src/Tgstation.Server.Host/Components/Engine/EngineManager.cs
+++ b/src/Tgstation.Server.Host/Components/Engine/EngineManager.cs
@@ -477,9 +477,9 @@ namespace Tgstation.Server.Host.Components.Engine
 
 					await InstallVersionFiles(progressReporter, version, customVersionStream, deploymentPipelineProcesses, cancellationToken);
 
-					ourTcs.SetResult();
-
 					await eventConsumer.HandleEvent(EventType.EngineInstallComplete, new List<string> { versionString }, deploymentPipelineProcesses, cancellationToken);
+
+					ourTcs.SetResult();
 				}
 				catch (Exception ex)
 				{

--- a/src/Tgstation.Server.Host/Components/InstanceManager.cs
+++ b/src/Tgstation.Server.Host/Components/InstanceManager.cs
@@ -603,7 +603,7 @@ namespace Tgstation.Server.Host.Components
 				logger.LogInformation("{versionString}", assemblyInformationProvider.VersionString);
 				console.SetTitle(assemblyInformationProvider.VersionString);
 
-				CheckSystemCompatibility();
+				PreflightChecks();
 
 				// To let the web server startup immediately before we do any intense work
 				await Task.Yield();
@@ -673,7 +673,7 @@ namespace Tgstation.Server.Host.Components
 		/// <summary>
 		/// Check we have a valid system and configuration.
 		/// </summary>
-		void CheckSystemCompatibility()
+		void PreflightChecks()
 		{
 			logger.LogDebug("Running as user: {username}", Environment.UserName);
 

--- a/src/Tgstation.Server.Host/Components/StaticFiles/Configuration.cs
+++ b/src/Tgstation.Server.Host/Components/StaticFiles/Configuration.cs
@@ -794,13 +794,20 @@ namespace Tgstation.Server.Host.Components.StaticFiles
 				var tasks = directories.Select<string, ValueTask>(
 					async scriptDirectory =>
 					{
-						var files = await ioManager.GetFilesWithExtension(scriptDirectory, platformIdentifier.ScriptFileExtension, false, cancellationToken);
 						var resolvedScriptsDir = ioManager.ResolvePath(scriptDirectory);
+						logger.LogTrace("Checking for scripts in {directory}...", scriptDirectory);
+						var files = await ioManager.GetFilesWithExtension(scriptDirectory, platformIdentifier.ScriptFileExtension, false, cancellationToken);
 
 						var scriptFiles = files
-							.Select(x => ioManager.ConcatPath(resolvedScriptsDir, ioManager.GetFileName(x)))
+							.Select(ioManager.GetFileName)
 							.Where(x => scriptNames.Any(
-								scriptName => x.StartsWith(scriptName, StringComparison.Ordinal)));
+								scriptName => x.StartsWith(scriptName, StringComparison.Ordinal)))
+							.Select(x =>
+							{
+								var fullScriptPath = ioManager.ConcatPath(resolvedScriptsDir, x);
+								logger.LogTrace("Found matching script: {scriptPath}", fullScriptPath);
+								return fullScriptPath;
+							});
 
 						lock (allScripts)
 							allScripts.AddRange(scriptFiles);

--- a/src/Tgstation.Server.Host/Configuration/GeneralConfiguration.cs
+++ b/src/Tgstation.Server.Host/Configuration/GeneralConfiguration.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -151,6 +154,11 @@ namespace Tgstation.Server.Host.Configuration
 		public bool OpenDreamSuppressInstallOutput { get; set; }
 
 		/// <summary>
+		/// List of directories that have their contents merged with instance EventScripts directories when executing scripts.
+		/// </summary>
+		public List<string>? AdditionalEventScriptsDirectories { get; set; }
+
+		/// <summary>
 		/// Initializes a new instance of the <see cref="GeneralConfiguration"/> class.
 		/// </summary>
 		public GeneralConfiguration()
@@ -190,6 +198,9 @@ namespace Tgstation.Server.Host.Configuration
 
 			if (ByondTopicTimeout <= 1000)
 				logger.LogWarning("The timeout for sending BYOND topics is very low ({ms}ms). Topic calls may fail to complete at all!", ByondTopicTimeout);
+
+			if (AdditionalEventScriptsDirectories?.Any(path => !Path.IsPathRooted(path)) == true)
+				logger.LogWarning($"Config option \"{nameof(AdditionalEventScriptsDirectories)}\" contains non-rooted paths. These will be evaluated relative to each instances \"Configuration\" directory!");
 		}
 	}
 }

--- a/src/Tgstation.Server.Host/Server.cs
+++ b/src/Tgstation.Server.Host/Server.cs
@@ -208,7 +208,23 @@ namespace Tgstation.Server.Host
 
 			async Task RunUpdate()
 			{
-				if (await updateExecutor.ExecuteUpdate(updatePath, criticalCancellationToken, criticalCancellationToken))
+				var updateExecutedSuccessfully = false;
+				try
+				{
+					updateExecutedSuccessfully = await updateExecutor.ExecuteUpdate(updatePath, criticalCancellationToken, criticalCancellationToken);
+				}
+				catch (OperationCanceledException ex)
+				{
+					logger.LogDebug(ex, "Update cancelled!");
+					UpdateInProgress = false;
+				}
+				catch (Exception ex)
+				{
+					logger.LogError(ex, "Update errored!");
+					UpdateInProgress = false;
+				}
+
+				if (updateExecutedSuccessfully)
 				{
 					logger.LogTrace("Update complete!");
 					await RestartImpl(newVersion, null, true, true);

--- a/src/Tgstation.Server.Host/appsettings.yml
+++ b/src/Tgstation.Server.Host/appsettings.yml
@@ -19,6 +19,7 @@ General:
   OpenDreamGitUrl: https://github.com/OpenDreamProject/OpenDream # The repository to retrieve OpenDream from
   OpenDreamGitTagPrefix: v # The prefix to the OpenDream semver as tags appear in the git repository
   OpenDreamSuppressInstallOutput: false # Suppress the dotnet output of creating an OpenDream installation. Known to cause hangs in CI.
+  AdditionalEventScriptsDirectories: # An array of directories that are considered to contain EventScripts alongside instance directories. Working directory will remain the instance EventScripts directory.
 Session:
   HighPriorityLiveDreamDaemon: false # If DreamDaemon instances should run as higher priority processes
   LowPriorityDeploymentProcesses: true # If TGS Deployments should run as lower priority processes

--- a/src/Tgstation.Server.Host/appsettings.yml
+++ b/src/Tgstation.Server.Host/appsettings.yml
@@ -19,7 +19,7 @@ General:
   OpenDreamGitUrl: https://github.com/OpenDreamProject/OpenDream # The repository to retrieve OpenDream from
   OpenDreamGitTagPrefix: v # The prefix to the OpenDream semver as tags appear in the git repository
   OpenDreamSuppressInstallOutput: false # Suppress the dotnet output of creating an OpenDream installation. Known to cause hangs in CI.
-  AdditionalEventScriptsDirectories: # An array of directories that are considered to contain EventScripts alongside instance directories. Working directory will remain the instance EventScripts directory.
+  AdditionalEventScriptsDirectories: # An array of directories that are considered to contain EventScripts alongside instance directories. Working directory for exectued scripts will remain the instance EventScripts directory.
 Session:
   HighPriorityLiveDreamDaemon: false # If DreamDaemon instances should run as higher priority processes
   LowPriorityDeploymentProcesses: true # If TGS Deployments should run as lower priority processes


### PR DESCRIPTION
🆑
Added Nix support.
Added the `--bootstrap` parameter to the host watchdog, which will cause it to look for TGS binaries in `~/.tgstation-server/lib` instead of its local directory. This also causes it to read and save which TGS version should be used/was in use in `~/.tgstation-server/bootstrap.json`
Fixed issues with engine installation jobs if the `EngineInstallComplete` script errored.
Fixed incomplete engine installations lingering if the `EngineInstallComplete` script errored.
The `EngineInstallFail` event will no longer run if the `EngineInstallComplete` script errored.
Fixed an issue where aborting a zip file upload for a TGS update would prevent the server from updating without a restart.
Added support for global `EventScripts` directories.
/🆑

:cl: **Configuration**
Added `General:AdditionalEventScriptsDirectories` array which can be used to specify EventScript directories that are used by all instances.
/:cl:
