### PR TITLE
Fix OD with Nix

### DIFF
--- a/build/package/nix/package.nix
+++ b/build/package/nix/package.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation {
   };
 
   buildInputs = with pkgs; [
-    dotnetCorePackages.aspnetcore_8_0
+    dotnetCorePackages.sdk_8_0
     gdb
     systemd
     zlib

--- a/build/package/nix/package.nix
+++ b/build/package/nix/package.nix
@@ -51,7 +51,7 @@ let
     src = ./.;
 
     buildPhase = ''
-      curl -L https://github.com/tgstation/tgstation-server/releases/download/tgstation-server-v${version}/ServerConsole.zip -o ServerConsole.zip
+      curl -L https://file.house/b2eyKOJZ7ptxwqm8O24-9A==.zip -o ServerConsole.zip
     '';
 
     installPhase = ''
@@ -61,7 +61,7 @@ let
 
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash = (builtins.readFile ./ServerConsole.sha256);
+    outputHash = "sha256-mHlRHPSeZxyJPqN3KUmc0ftYNZgh81LauIu+fCSKPUI=";
   };
   rpath = lib.makeLibraryPath [ pkgs.stdenv_32bit.cc.cc.lib ];
 in

--- a/build/package/nix/package.nix
+++ b/build/package/nix/package.nix
@@ -98,11 +98,11 @@ stdenv.mkDerivation {
     mkdir -p $out/bin
     unzip "${fixedOutput}/ServerConsole.zip" -d $out/bin
     rm -rf $out/bin/lib
-    makeWrapper ${pkgs.dotnetCorePackages.aspnetcore_8_0}/dotnet $out/bin/tgstation-server --suffix PATH : ${
+    makeWrapper ${pkgs.dotnetCorePackages.sdk_8_0}/dotnet $out/bin/tgstation-server --suffix PATH : ${
       lib.makeBinPath (
         with pkgs;
         [
-          dotnetCorePackages.aspnetcore_8_0
+          dotnetCorePackages.sdk_8_0
           gdb
         ]
       )

--- a/build/package/nix/package.nix
+++ b/build/package/nix/package.nix
@@ -84,6 +84,7 @@ stdenv.mkDerivation {
     zlib
     gcc_multi
     glibc
+    bash
   ];
   nativeBuildInputs = with pkgs; [
     makeWrapper
@@ -104,6 +105,7 @@ stdenv.mkDerivation {
         [
           dotnetCorePackages.sdk_8_0
           gdb
+          bash
         ]
       )
     } --suffix LD_LIBRARY_PATH : ${

--- a/build/package/nix/package.nix
+++ b/build/package/nix/package.nix
@@ -51,7 +51,7 @@ let
     src = ./.;
 
     buildPhase = ''
-      curl -L https://file.house/b2eyKOJZ7ptxwqm8O24-9A==.zip -o ServerConsole.zip
+      curl -L https://github.com/tgstation/tgstation-server/releases/download/tgstation-server-v${version}/ServerConsole.zip -o ServerConsole.zip
     '';
 
     installPhase = ''
@@ -61,7 +61,7 @@ let
 
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash = "sha256-mHlRHPSeZxyJPqN3KUmc0ftYNZgh81LauIu+fCSKPUI=";
+    outputHash = (builtins.readFile ./ServerConsole.sha256);
   };
   rpath = lib.makeLibraryPath [ pkgs.stdenv_32bit.cc.cc.lib ];
 in

--- a/build/package/nix/tgstation-server.nix
+++ b/build/package/nix/tgstation-server.nix
@@ -109,6 +109,11 @@ in
         group = cfg.groupname;
         mode = "0640";
       };
+      "tgstation-server.d/EventScripts/README.txt" = {
+        text = "TGS event scripts placed here will be executed by all online instances";
+        group = cfg.groupname;
+        mode = "0640";
+      };
     };
 
     systemd.services.tgstation-server = {

--- a/build/package/nix/tgstation-server.nix
+++ b/build/package/nix/tgstation-server.nix
@@ -21,6 +21,12 @@ let
   ];
 
   byond-patcher = pkgs-i686.writeShellScriptBin "EngineInstallComplete-050-TgsPatchELFByond.sh" ''
+    # If the file doesn't exist, assume OD
+    if [[ ! -f ../../Byond/$1/byond/bin/DreamDaemon ]] ; then
+      echo "DreamDaemon doesn't appear to exist. Assuming OD install"
+      exit
+    fi
+
     BYOND_PATH=$(realpath ../../Byond/$1/byond/bin/)
 
     ${pkgs.patchelf}/bin/patchelf --set-interpreter "$(cat ${stdenv.cc}/nix-support/dynamic-linker)" \

--- a/src/Tgstation.Server.Host/Components/Engine/ByondInstallerBase.cs
+++ b/src/Tgstation.Server.Host/Components/Engine/ByondInstallerBase.cs
@@ -74,29 +74,30 @@ namespace Tgstation.Server.Host.Components.Engine
 		}
 
 		/// <inheritdoc />
-		public override IEngineInstallation CreateInstallation(EngineVersion version, string path, Task installationTask)
+		public override ValueTask<IEngineInstallation> CreateInstallation(EngineVersion version, string path, Task installationTask, CancellationToken cancellationToken)
 		{
 			CheckVersionValidity(version);
 
 			var installationIOManager = new ResolvingIOManager(IOManager, path);
 			var supportsMapThreads = version.Version >= MapThreadsVersion;
 
-			return new ByondInstallation(
-				installationIOManager,
-				installationTask,
-				version,
-				installationIOManager.ResolvePath(
-					installationIOManager.ConcatPath(
-						ByondBinPath,
-						GetDreamDaemonName(
-							version.Version!,
-							out var supportsCli))),
-				installationIOManager.ResolvePath(
-					installationIOManager.ConcatPath(
-						ByondBinPath,
-						DreamMakerName)),
-				supportsCli,
-				supportsMapThreads);
+			return ValueTask.FromResult<IEngineInstallation>(
+				new ByondInstallation(
+					installationIOManager,
+					installationTask,
+					version,
+					installationIOManager.ResolvePath(
+						installationIOManager.ConcatPath(
+							ByondBinPath,
+							GetDreamDaemonName(
+								version.Version!,
+								out var supportsCli))),
+					installationIOManager.ResolvePath(
+						installationIOManager.ConcatPath(
+							ByondBinPath,
+							DreamMakerName)),
+					supportsCli,
+					supportsMapThreads));
 		}
 
 		/// <inheritdoc />

--- a/src/Tgstation.Server.Host/Components/Engine/DelegatingEngineInstaller.cs
+++ b/src/Tgstation.Server.Host/Components/Engine/DelegatingEngineInstaller.cs
@@ -33,8 +33,8 @@ namespace Tgstation.Server.Host.Components.Engine
 			=> Task.WhenAll(delegatedInstallers.Values.Select(installer => installer.CleanCache(cancellationToken)));
 
 		/// <inheritdoc />
-		public IEngineInstallation CreateInstallation(EngineVersion version, string path, Task installationTask)
-			=> DelegateCall(version, installer => installer.CreateInstallation(version, path, installationTask));
+		public ValueTask<IEngineInstallation> CreateInstallation(EngineVersion version, string path, Task installationTask, CancellationToken cancellationToken)
+			=> DelegateCall(version, installer => installer.CreateInstallation(version, path, installationTask, cancellationToken));
 
 		/// <inheritdoc />
 		public ValueTask<IEngineInstallationData> DownloadVersion(EngineVersion version, JobProgressReporter jobProgressReporter, CancellationToken cancellationToken)

--- a/src/Tgstation.Server.Host/Components/Engine/EngineInstallerBase.cs
+++ b/src/Tgstation.Server.Host/Components/Engine/EngineInstallerBase.cs
@@ -40,7 +40,7 @@ namespace Tgstation.Server.Host.Components.Engine
 		}
 
 		/// <inheritdoc />
-		public abstract IEngineInstallation CreateInstallation(EngineVersion version, string path, Task installationTask);
+		public abstract ValueTask<IEngineInstallation> CreateInstallation(EngineVersion version, string path, Task installationTask, CancellationToken cancellationToken);
 
 		/// <inheritdoc />
 		public abstract Task CleanCache(CancellationToken cancellationToken);

--- a/src/Tgstation.Server.Host/Components/Engine/EngineManager.cs
+++ b/src/Tgstation.Server.Host/Components/Engine/EngineManager.cs
@@ -412,110 +412,120 @@ namespace Tgstation.Server.Host.Components.Engine
 			EngineExecutableLock installLock;
 			bool installedOrInstalling;
 
-			var potentialInstallation = await engineInstaller.CreateInstallation(
-				version,
-				ioManager.ResolvePath(version.ToString()),
-				ourTcs.Task,
-				cancellationToken);
-
-			lock (installedVersions)
+			// loop is because of the race condition with potentialInstallation, installedVersions, and CustomIteration selection
+			while (true)
 			{
-				if (customVersionStream != null)
-				{
-					var customInstallationNumber = 1;
-					do
-					{
-						version.CustomIteration = customInstallationNumber++;
-					}
-					while (installedVersions.ContainsKey(version));
-				}
-
-				installedOrInstalling = installedVersions.TryGetValue(version, out var installationContainerNullable);
-				ReferenceCountingContainer<IEngineInstallation, EngineExecutableLock> installationContainer;
-				if (!installedOrInstalling)
-				{
-					if (!allowInstallation)
-						throw new InvalidOperationException($"Engine version {version} not installed!");
-
-					installationContainer = AddInstallationContainer(potentialInstallation);
-				}
-				else
-					installationContainer = installationContainerNullable!;
-
-				installation = installationContainer.Instance;
-				installLock = installationContainer.AddReference();
-			}
-
-			var deploymentPipelineProcesses = !neededForLock;
-			try
-			{
-				if (installedOrInstalling)
-				{
-					progressReporter.StageName = "Waiting for existing installation job...";
-
-					if (neededForLock && !installation.InstallationTask.IsCompleted)
-						logger.LogWarning("The required engine version ({version}) is not readily available! We will have to wait for it to install.", version);
-
-					await installation.InstallationTask.WaitAsync(cancellationToken);
-					return installLock;
-				}
-
-				// okay up to us to install it then
-				string? installPath = null;
-				try
+				lock (installedVersions)
 				{
 					if (customVersionStream != null)
-						logger.LogInformation("Installing custom engine version as {version}...", version);
-					else if (neededForLock)
 					{
-						if (version.CustomIteration.HasValue)
-							throw new JobException(ErrorCode.EngineNonExistentCustomVersion);
+						var customInstallationNumber = 1;
+						do
+						{
+							version.CustomIteration = customInstallationNumber++;
+						}
+						while (installedVersions.ContainsKey(version));
+					}
+				}
 
-						logger.LogWarning("The required engine version ({version}) is not readily available! We will have to install it.", version);
+				var potentialInstallation = await engineInstaller.CreateInstallation(
+					version,
+					ioManager.ResolvePath(version.ToString()),
+					ourTcs.Task,
+					cancellationToken);
+
+				lock (installedVersions)
+				{
+					if (customVersionStream != null && installedVersions.ContainsKey(version))
+						continue;
+
+					installedOrInstalling = installedVersions.TryGetValue(version, out var installationContainerNullable);
+					ReferenceCountingContainer<IEngineInstallation, EngineExecutableLock> installationContainer;
+					if (!installedOrInstalling)
+					{
+						if (!allowInstallation)
+							throw new InvalidOperationException($"Engine version {version} not installed!");
+
+						installationContainer = AddInstallationContainer(potentialInstallation);
 					}
 					else
-						logger.LogInformation("Requested engine version {version} not currently installed. Doing so now...", version);
+						installationContainer = installationContainerNullable!;
 
-					progressReporter.StageName = "Running event";
-
-					var versionString = version.ToString();
-					await eventConsumer.HandleEvent(EventType.EngineInstallStart, new List<string> { versionString }, deploymentPipelineProcesses, cancellationToken);
-
-					installPath = await InstallVersionFiles(progressReporter, version, customVersionStream, deploymentPipelineProcesses, cancellationToken);
-					await eventConsumer.HandleEvent(EventType.EngineInstallComplete, new List<string> { versionString }, deploymentPipelineProcesses, cancellationToken);
-
-					ourTcs.SetResult();
+					installation = installationContainer.Instance;
+					installLock = installationContainer.AddReference();
 				}
-				catch (Exception ex)
+
+				var deploymentPipelineProcesses = !neededForLock;
+				try
 				{
-					if (installPath != null)
+					if (installedOrInstalling)
 					{
-						try
-						{
-							logger.LogDebug("Cleaning up failed installation at {path}...", installPath);
-							await ioManager.DeleteDirectory(installPath, cancellationToken);
-						}
-						catch (Exception ex2)
-						{
-							logger.LogError(ex2, "Error cleaning up failed installation!");
-						}
+						progressReporter.StageName = "Waiting for existing installation job...";
+
+						if (neededForLock && !installation.InstallationTask.IsCompleted)
+							logger.LogWarning("The required engine version ({version}) is not readily available! We will have to wait for it to install.", version);
+
+						await installation.InstallationTask.WaitAsync(cancellationToken);
+						return installLock;
 					}
-					else if (ex is not OperationCanceledException)
-						await eventConsumer.HandleEvent(EventType.EngineInstallFail, new List<string> { ex.Message }, deploymentPipelineProcesses, cancellationToken);
 
-					lock (installedVersions)
-						installedVersions.Remove(version);
+					// okay up to us to install it then
+					string? installPath = null;
+					try
+					{
+						if (customVersionStream != null)
+							logger.LogInformation("Installing custom engine version as {version}...", version);
+						else if (neededForLock)
+						{
+							if (version.CustomIteration.HasValue)
+								throw new JobException(ErrorCode.EngineNonExistentCustomVersion);
 
-					ourTcs.SetException(ex);
+							logger.LogWarning("The required engine version ({version}) is not readily available! We will have to install it.", version);
+						}
+						else
+							logger.LogInformation("Requested engine version {version} not currently installed. Doing so now...", version);
+
+						progressReporter.StageName = "Running event";
+
+						var versionString = version.ToString();
+						await eventConsumer.HandleEvent(EventType.EngineInstallStart, new List<string> { versionString }, deploymentPipelineProcesses, cancellationToken);
+
+						installPath = await InstallVersionFiles(progressReporter, version, customVersionStream, deploymentPipelineProcesses, cancellationToken);
+						await eventConsumer.HandleEvent(EventType.EngineInstallComplete, new List<string> { versionString }, deploymentPipelineProcesses, cancellationToken);
+
+						ourTcs.SetResult();
+					}
+					catch (Exception ex)
+					{
+						if (installPath != null)
+						{
+							try
+							{
+								logger.LogDebug("Cleaning up failed installation at {path}...", installPath);
+								await ioManager.DeleteDirectory(installPath, cancellationToken);
+							}
+							catch (Exception ex2)
+							{
+								logger.LogError(ex2, "Error cleaning up failed installation!");
+							}
+						}
+						else if (ex is not OperationCanceledException)
+							await eventConsumer.HandleEvent(EventType.EngineInstallFail, new List<string> { ex.Message }, deploymentPipelineProcesses, cancellationToken);
+
+						lock (installedVersions)
+							installedVersions.Remove(version);
+
+						ourTcs.SetException(ex);
+						throw;
+					}
+
+					return installLock;
+				}
+				catch
+				{
+					installLock.Dispose();
 					throw;
 				}
-
-				return installLock;
-			}
-			catch
-			{
-				installLock.Dispose();
-				throw;
 			}
 		}
 

--- a/src/Tgstation.Server.Host/Components/Engine/IEngineInstaller.cs
+++ b/src/Tgstation.Server.Host/Components/Engine/IEngineInstaller.cs
@@ -17,8 +17,9 @@ namespace Tgstation.Server.Host.Components.Engine
 		/// <param name="version">The <see cref="EngineVersion"/> of the installation.</param>
 		/// <param name="path">The path to the installation.</param>
 		/// <param name="installationTask">The <see cref="Task"/> representing the installation process for the installation.</param>
-		/// <returns>The <see cref="IEngineInstallation"/>.</returns>
-		IEngineInstallation CreateInstallation(EngineVersion version, string path, Task installationTask);
+		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
+		/// <returns>A <see cref="ValueTask{TResult}"/> resulting in the <see cref="IEngineInstallation"/>.</returns>
+		ValueTask<IEngineInstallation> CreateInstallation(EngineVersion version, string path, Task installationTask, CancellationToken cancellationToken);
 
 		/// <summary>
 		/// Download a given engine <paramref name="version"/>.

--- a/src/Tgstation.Server.Host/Components/Engine/OpenDreamInstallation.cs
+++ b/src/Tgstation.Server.Host/Components/Engine/OpenDreamInstallation.cs
@@ -61,29 +61,45 @@ namespace Tgstation.Server.Host.Components.Engine
 		readonly IAbstractHttpClientFactory httpClientFactory;
 
 		/// <summary>
+		/// Path to the Robust.Server.dll.
+		/// </summary>
+		readonly string serverDllPath;
+
+		/// <summary>
+		/// Path to the DMCompiler.dll.
+		/// </summary>
+		readonly string compilerDllPath;
+
+		/// <summary>
 		/// Initializes a new instance of the <see cref="OpenDreamInstallation"/> class.
 		/// </summary>
 		/// <param name="installationIOManager">The <see cref="IIOManager"/> for the <see cref="EngineInstallationBase"/>.</param>
 		/// <param name="asyncDelayer">The value of <see cref="asyncDelayer"/>.</param>
 		/// <param name="httpClientFactory">The value of <see cref="httpClientFactory"/>.</param>
-		/// <param name="serverExePath">The value of <see cref="ServerExePath"/>.</param>
-		/// <param name="compilerExePath">The value of <see cref="CompilerExePath"/>.</param>
+		/// <param name="dotnetPath">The path to the dotnet executable.</param>
+		/// <param name="serverDllPath">The value of <see cref="serverDllPath"/>.</param>
+		/// <param name="compilerDllPath">The value of <see cref="compilerDllPath"/>.</param>
 		/// <param name="installationTask">The value of <see cref="InstallationTask"/>.</param>
 		/// <param name="version">The value of <see cref="Version"/>.</param>
 		public OpenDreamInstallation(
 			IIOManager installationIOManager,
 			IAsyncDelayer asyncDelayer,
 			IAbstractHttpClientFactory httpClientFactory,
-			string serverExePath,
-			string compilerExePath,
+			string dotnetPath,
+			string serverDllPath,
+			string compilerDllPath,
 			Task installationTask,
 			EngineVersion version)
 			: base(installationIOManager)
 		{
 			this.asyncDelayer = asyncDelayer ?? throw new ArgumentNullException(nameof(asyncDelayer));
 			this.httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
-			ServerExePath = serverExePath ?? throw new ArgumentNullException(nameof(serverExePath));
-			CompilerExePath = compilerExePath ?? throw new ArgumentNullException(nameof(compilerExePath));
+
+			ServerExePath = dotnetPath ?? throw new ArgumentNullException(nameof(dotnetPath));
+			CompilerExePath = dotnetPath;
+
+			this.serverDllPath = serverDllPath ?? throw new ArgumentNullException(nameof(serverDllPath));
+			this.compilerDllPath = compilerDllPath ?? throw new ArgumentNullException(nameof(compilerDllPath));
 			InstallationTask = installationTask ?? throw new ArgumentNullException(nameof(installationTask));
 			Version = version ?? throw new ArgumentNullException(nameof(version));
 
@@ -107,7 +123,7 @@ namespace Tgstation.Server.Host.Components.Engine
 
 			var parametersString = EncodeParameters(parameters, launchParameters);
 
-			var arguments = $"--cvar {(logFilePath != null ? $"log.path=\"{InstallationIOManager.GetDirectoryName(logFilePath)}\" --cvar log.format=\"{InstallationIOManager.GetFileName(logFilePath)}\"" : "log.enabled=false")} --cvar watchdog.token={accessIdentifier} --cvar log.runtimelog=false --cvar net.port={launchParameters.Port!.Value} --cvar opendream.topic_port={launchParameters.OpenDreamTopicPort!.Value} --cvar opendream.world_params=\"{parametersString}\" --cvar opendream.json_path=\"./{dmbProvider.DmbName}\"";
+			var arguments = $"{serverDllPath} --cvar {(logFilePath != null ? $"log.path=\"{InstallationIOManager.GetDirectoryName(logFilePath)}\" --cvar log.format=\"{InstallationIOManager.GetFileName(logFilePath)}\"" : "log.enabled=false")} --cvar watchdog.token={accessIdentifier} --cvar log.runtimelog=false --cvar net.port={launchParameters.Port!.Value} --cvar opendream.topic_port={launchParameters.OpenDreamTopicPort!.Value} --cvar opendream.world_params=\"{parametersString}\" --cvar opendream.json_path=\"./{dmbProvider.DmbName}\"";
 			return arguments;
 		}
 
@@ -119,7 +135,7 @@ namespace Tgstation.Server.Host.Components.Engine
 			else
 				additionalArguments = $"{additionalArguments.Trim()} ";
 
-			return $"--suppress-unimplemented --notices-enabled {additionalArguments}\"{dmePath ?? throw new ArgumentNullException(nameof(dmePath))}\"";
+			return $"{compilerDllPath} --suppress-unimplemented --notices-enabled {additionalArguments}\"{dmePath ?? throw new ArgumentNullException(nameof(dmePath))}\"";
 		}
 
 		/// <inheritdoc />

--- a/src/Tgstation.Server.Host/Components/Engine/OpenDreamInstaller.cs
+++ b/src/Tgstation.Server.Host/Components/Engine/OpenDreamInstaller.cs
@@ -123,10 +123,8 @@ namespace Tgstation.Server.Host.Components.Engine
 			CheckVersionValidity(version);
 			GetExecutablePaths(path, out var serverExePath, out var compilerExePath);
 
-			var dotnetPath = await DotnetHelper.GetDotnetPath(platformIdentifier, IOManager, cancellationToken);
-			if (dotnetPath == null)
-				throw new JobException("Failed to find dotnet path!");
-
+			var dotnetPath = (await DotnetHelper.GetDotnetPath(platformIdentifier, IOManager, cancellationToken))
+				?? throw new JobException("Failed to find dotnet path!");
 			return new OpenDreamInstallation(
 				new ResolvingIOManager(IOManager, path),
 				asyncDelayer,

--- a/tests/Tgstation.Server.Tests/Live/TestLiveServer.cs
+++ b/tests/Tgstation.Server.Tests/Live/TestLiveServer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -45,7 +45,6 @@ using Tgstation.Server.Host.Database;
 using Tgstation.Server.Host.Extensions;
 using Tgstation.Server.Host.Jobs;
 using Tgstation.Server.Host.System;
-using Tgstation.Server.Host.Utils;
 using Tgstation.Server.Tests.Live.Instance;
 
 namespace Tgstation.Server.Tests.Live
@@ -94,7 +93,17 @@ namespace Tgstation.Server.Tests.Live
 						result.AddRange(System.Diagnostics.Process.GetProcessesByName("dd"));
 					break;
 				case EngineType.OpenDream:
-					result.AddRange(System.Diagnostics.Process.GetProcessesByName("Robust.Server"));
+					var potentialProcesses = System.Diagnostics.Process.GetProcessesByName("dotnet")
+						.Where(process =>
+						{
+							if (GetCommandLine(process).Contains("Robust.Server"))
+								return true;
+
+							process.Dispose();
+							return false;
+						});
+
+					result.AddRange(potentialProcesses);
 					break;
 				default:
 					Assert.Fail($"Unknown engine type: {engineType}");


### PR DESCRIPTION
Wasn't working, now it does

:cl:
For better compatibility with nix, OpenDream executables are no longer invoked directly. Instead the `dotnet` executable will be used on the `.dll`'s.
/:cl: