### PR TITLE
Compatibility with SpacemanDMM's redefined_proc lint

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -10,7 +10,7 @@
     <TgsCommonLibraryVersion>7.0.0</TgsCommonLibraryVersion>
     <TgsApiLibraryVersion>17.0.0</TgsApiLibraryVersion>
     <TgsClientVersion>20.0.0</TgsClientVersion>
-    <TgsDmapiVersion>7.3.0</TgsDmapiVersion>
+    <TgsDmapiVersion>7.3.1</TgsDmapiVersion>
     <TgsInteropVersion>5.10.0</TgsInteropVersion>
     <TgsHostWatchdogVersion>1.6.0</TgsHostWatchdogVersion>
     <TgsSwarmProtocolVersion>8.0.0</TgsSwarmProtocolVersion>

--- a/src/DMAPI/tgs.dm
+++ b/src/DMAPI/tgs.dm
@@ -1,7 +1,7 @@
 // tgstation-server DMAPI
 // The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in IETF RFC 2119.
 
-#define TGS_DMAPI_VERSION "7.3.0"
+#define TGS_DMAPI_VERSION "7.3.1"
 
 // All functions and datums outside this document are subject to change with any version and should not be relied on.
 
@@ -56,6 +56,11 @@
 #error Your codebase is re-defining the BYOND proc file2text. The DMAPI requires the native version to read the result of world.Export(). You SHOULD fix this by adding "#define TGS_FILE2TEXT_NATIVE file2text" before your override of file2text to allow the DMAPI to use the native version. This will only be used for world.Export(), not regular file accesses
 #endif
 #define TGS_FILE2TEXT_NATIVE file2text
+#endif
+
+// SpacemanDMM compatibility
+#ifndef CAN_BE_REDEFINED
+#define CAN_BE_REDEFINED(X)
 #endif
 
 // EVENT CODES
@@ -160,6 +165,7 @@
  * * http_handler - Optional user defined [/datum/tgs_http_handler].
  */
 /world/proc/TgsNew(datum/tgs_event_handler/event_handler, minimum_required_security_level = TGS_SECURITY_ULTRASAFE, datum/tgs_http_handler/http_handler)
+	CAN_BE_REDEFINED(TRUE)
 	return
 
 /**
@@ -170,6 +176,7 @@
  * This function should not be called before ..() in [/world/proc/New].
  */
 /world/proc/TgsInitializationComplete()
+	CAN_BE_REDEFINED(TRUE)
 	return
 
 /// Consumers MUST run this macro at the start of [/world/proc/Topic].
@@ -177,6 +184,7 @@
 
 /// Consumers MUST call this as late as possible in [world/proc/Reboot] (BEFORE ..()).
 /world/proc/TgsReboot()
+	CAN_BE_REDEFINED(TRUE)
 	return
 
 // DATUM DEFINITIONS
@@ -214,6 +222,7 @@
  * Returns [TRUE]/[FALSE] based on if the [/datum/tgs_version] contains wildcards.
  */
 /datum/tgs_version/proc/Wildcard()
+	CAN_BE_REDEFINED(TRUE)
 	return
 
 /**
@@ -222,6 +231,7 @@
  * other_version - The [/datum/tgs_version] to compare against.
  */
 /datum/tgs_version/proc/Equals(datum/tgs_version/other_version)
+	CAN_BE_REDEFINED(TRUE)
 	return
 
 /// Represents a merge of a GitHub pull request.
@@ -459,16 +469,19 @@
 
 /// Returns the maximum supported [/datum/tgs_version] of the DMAPI.
 /world/proc/TgsMaximumApiVersion()
+	CAN_BE_REDEFINED(TRUE)
 	return
 
 /// Returns the minimum supported [/datum/tgs_version] of the DMAPI.
 /world/proc/TgsMinimumApiVersion()
+	CAN_BE_REDEFINED(TRUE)
 	return
 
 /**
  * Returns [TRUE] if DreamDaemon was launched under TGS, the API matches, and was properly initialized. [FALSE] will be returned otherwise.
  */
 /world/proc/TgsAvailable()
+	CAN_BE_REDEFINED(TRUE)
 	return
 
 // No function below this succeeds if it TgsAvailable() returns FALSE or if TgsNew() has yet to be called.
@@ -480,6 +493,7 @@
  * If TGS has not requested a [TGS_REBOOT_MODE_SHUTDOWN] DreamDaemon will be launched again.
  */
 /world/proc/TgsEndProcess()
+	CAN_BE_REDEFINED(TRUE)
 	return
 
 /**
@@ -490,6 +504,7 @@
  * admin_only: If [TRUE], message will be sent to admin connected chats. Vice-versa applies.
  */
 /world/proc/TgsTargetedChatBroadcast(datum/tgs_message_content/message, admin_only = FALSE)
+	CAN_BE_REDEFINED(TRUE)
 	return
 
 /**
@@ -500,6 +515,7 @@
  * user: The [/datum/tgs_chat_user] to PM.
  */
 /world/proc/TgsChatPrivateMessage(datum/tgs_message_content/message, datum/tgs_chat_user/user)
+	CAN_BE_REDEFINED(TRUE)
 	return
 
 /**
@@ -510,42 +526,52 @@
  * channels - Optional list of [/datum/tgs_chat_channel]s to restrict the message to.
  */
 /world/proc/TgsChatBroadcast(datum/tgs_message_content/message, list/channels = null)
+	CAN_BE_REDEFINED(TRUE)
 	return
 
 /// Returns the current [/datum/tgs_version] of TGS if it is running the server, null otherwise. This function may sleep if the call to [/world/proc/TgsNew] is sleeping!
 /world/proc/TgsVersion()
+	CAN_BE_REDEFINED(TRUE)
 	return
 
 /// Returns the running engine type
 /world/proc/TgsEngine()
+	CAN_BE_REDEFINED(TRUE)
 	return
 
 /// Returns the current [/datum/tgs_version] of the DMAPI being used if it was activated, null otherwise. This function may sleep if the call to [/world/proc/TgsNew] is sleeping!
 /world/proc/TgsApiVersion()
+	CAN_BE_REDEFINED(TRUE)
 	return
 
 /// Returns the name of the TGS instance running the game if TGS is present, null otherwise. This function may sleep if the call to [/world/proc/TgsNew] is sleeping!
 /world/proc/TgsInstanceName()
+	CAN_BE_REDEFINED(TRUE)
 	return
 
 /// Return the current [/datum/tgs_revision_information] of the running server if TGS is present, null otherwise. This function may sleep if the call to [/world/proc/TgsNew] is sleeping!
 /world/proc/TgsRevision()
+	CAN_BE_REDEFINED(TRUE)
 	return
 
 /// Returns the current BYOND security level as a TGS_SECURITY_ define if TGS is present, null otherwise. This function may sleep if the call to [/world/proc/TgsNew] is sleeping!
 /world/proc/TgsSecurityLevel()
+	CAN_BE_REDEFINED(TRUE)
 	return
 
 /// Returns the current BYOND visibility level as a TGS_VISIBILITY_ define if TGS is present, null otherwise. Requires TGS to be using interop API version 5 or higher otherwise the string "___unimplemented" wil be returned. This function may sleep if the call to [/world/proc/TgsNew] is sleeping!
 /world/proc/TgsVisibility()
+	CAN_BE_REDEFINED(TRUE)
 	return
 
 /// Returns a list of active [/datum/tgs_revision_information/test_merge]s if TGS is present, null otherwise. This function may sleep if the call to [/world/proc/TgsNew] is sleeping!
 /world/proc/TgsTestMerges()
+	CAN_BE_REDEFINED(TRUE)
 	return
 
 /// Returns a list of connected [/datum/tgs_chat_channel]s if TGS is present, null otherwise. This function may sleep if the call to [/world/proc/TgsNew] is sleeping!
 /world/proc/TgsChatChannelInfo()
+	CAN_BE_REDEFINED(TRUE)
 	return
 
 /**
@@ -556,6 +582,7 @@
  * wait_for_completion - If set, this function will not return until the event has run to completion.
  */
 /world/proc/TgsTriggerEvent(event_name, list/parameters, wait_for_completion = FALSE)
+	CAN_BE_REDEFINED(TRUE)
 	return
 
 /*


### PR DESCRIPTION
Closes #2056

:cl: DreamMaker API
Added compatibility with SpacemanDMM's `redefined_proc` lint.
/:cl:

Merging with `[DMDeploy]`