### PR TITLE
v6.13.0 (fr this time): Version Bump + Custom Event completion event failure fix

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="WebpanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>6.12.3</TgsCoreVersion>
+    <TgsCoreVersion>6.13.0</TgsCoreVersion>
     <TgsConfigVersion>5.4.0</TgsConfigVersion>
     <TgsRestVersion>10.12.1</TgsRestVersion>
     <TgsGraphQLVersion>0.5.0</TgsGraphQLVersion>

--- a/src/Tgstation.Server.Host/Components/Interop/Bridge/BridgeParameters.cs
+++ b/src/Tgstation.Server.Host/Components/Interop/Bridge/BridgeParameters.cs
@@ -52,7 +52,7 @@ namespace Tgstation.Server.Host.Components.Interop.Bridge
 		public ushort? TopicPort { get; set; }
 
 		/// <summary>
-		/// The <see cref="Bridge.CustomEventInvocation"/> being triggered.
+		/// The <see cref="CustomEventInvocation"/> being triggered.
 		/// </summary>
 		public CustomEventInvocation? EventInvocation { get; set; }
 

--- a/src/Tgstation.Server.Host/Components/Session/SessionController.cs
+++ b/src/Tgstation.Server.Host/Components/Session/SessionController.cs
@@ -1171,14 +1171,26 @@ namespace Tgstation.Server.Host.Components.Session
 			{
 				try
 				{
-					await eventTask.Value;
+					Exception? exception;
+					try
+					{
+						await eventTask.Value;
+						exception = null;
+					}
+					catch (Exception ex)
+					{
+						exception = ex;
+					}
 
 					if (notifyCompletion.Value)
 						await SendCommand(
 							new TopicParameters(eventId),
 							cancellationToken);
-					else
+					else if (exception == null)
 						Logger.LogTrace("Finished custom event {eventId}, not sending notification.", eventId);
+
+					if (exception != null)
+						throw exception;
 				}
 				catch (OperationCanceledException ex)
 				{


### PR DESCRIPTION
🆑
If a DM triggered TGS event script errors, the completion notification will now still be sent, unblocking the DMAPI call.
/🆑