### PR TITLE
Fix sha256 of nix serverconsole fixed deviation

### DIFF
--- a/build/package/nix/ServerConsole.sha256
+++ b/build/package/nix/ServerConsole.sha256
@@ -1,1 +1,1 @@
-sha256-omdtQT8XVJ2Lq0QQ2Xy7FHz5AL+lGdiGhY+eanPF2GU=
+sha256-6Wkdb1U2Xmw239zKJTbKcStdAV/G7aMa2oeCsGaSucA=


### PR DESCRIPTION
[Base Branch]: # (Please set the base branch of your pull request appropriately. If you only made a patch, code improvement, non-server code change, or comment/documentation update please target the `master` branch. Otherwise, target the `dev` branch.)

[Release Notes]: # (Your PR should contain a detailed list of notable changes, titled appropriately. This includes any observable changes to the server or DMAPI. See examples below.)

🆑
nix: bump up sha256 of fixed deviation
/:cl:

[Why]: # (If this does not close or work on an existing GitHub issue, please add a short description [two lines down] of why you think these changes would benefit the server. If you can't justify it in words, it might not be worth adding.)

Fixes the nix build, which fails expecting an outdated hash otherwise