### PR TITLE
TM commits no longer reference PRs

### DIFF
--- a/src/Tgstation.Server.Host/Components/Repository/Repository.cs
+++ b/src/Tgstation.Server.Host/Components/Repository/Repository.cs
@@ -199,7 +199,7 @@ namespace Tgstation.Server.Host.Components.Repository
 
 			var commitMessage = String.Format(
 				CultureInfo.InvariantCulture,
-				"TGS Test Merge (#{0}){1}{2}",
+				"TGS Test Merge ({0}){1}{2}",
 				testMergeParameters.Number,
 				testMergeParameters.Comment != null
 					? Environment.NewLine

--- a/src/Tgstation.Server.Host/Components/Repository/Repository.cs
+++ b/src/Tgstation.Server.Host/Components/Repository/Repository.cs
@@ -199,7 +199,7 @@ namespace Tgstation.Server.Host.Components.Repository
 
 			var commitMessage = String.Format(
 				CultureInfo.InvariantCulture,
-				"TGS Test Merge ({0}){1}{2}",
+				"TGS Test Merge (PR {0}){1}{2}",
 				testMergeParameters.Number,
 				testMergeParameters.Comment != null
 					? Environment.NewLine


### PR DESCRIPTION
[Base Branch]: # (Please set the base branch of your pull request appropriately. If you only made a patch, code improvement, non-server code change, or comment/documentation update please target the `master` branch. Otherwise, target the `dev` branch.)

[Release Notes]: # (Your PR should contain a detailed list of notable changes, titled appropriately. This includes any observable changes to the server or DMAPI. See examples below.)

🆑
Commits pushed now do not include # so the commit is not autolinked with the PR.
/🆑

[Why]: # (If this does not close or work on an existing GitHub issue, please add a short description [two lines down] of why you think these changes would benefit the server. If you can't justify it in words, it might not be worth adding.)

This change was originally intended for #2131 but it was requested to be separate. The reasoning is that I don't find these messages useful when the consolidated commit messages (in that PR) convey more information better.

Instead of:
![image](https://github.com/user-attachments/assets/e57571b9-54ae-4e2d-b59b-341109d64f41)
Now the commits aren't autolinked with the PR and they appear like this (But prefixed with "PR " per RC): 
![image](https://github.com/user-attachments/assets/580cba88-11ca-41a3-b2fe-b69419a1ab25)