### PR TITLE
Chatbots now mention the changes to TMs in deployment messages

### DIFF
--- a/src/Tgstation.Server.Host/Components/Chat/ChatManager.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/ChatManager.cs
@@ -377,6 +377,7 @@ namespace Tgstation.Server.Host.Components.Chat
 		/// <inheritdoc />
 		public Func<string?, string, Action<bool>> QueueDeploymentMessage(
 			Models.RevisionInformation revisionInformation,
+			Models.RevisionInformation? previousRevisionInformation,
 			EngineVersion engineVersion,
 			DateTimeOffset? estimatedCompletionTime,
 			string? gitHubOwner,
@@ -407,6 +408,7 @@ namespace Tgstation.Server.Host.Components.Chat
 						{
 							var callback = await provider.SendUpdateMessage(
 								revisionInformation,
+								previousRevisionInformation,
 								engineVersion,
 								estimatedCompletionTime,
 								gitHubOwner,

--- a/src/Tgstation.Server.Host/Components/Chat/IChatManager.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/IChatManager.cs
@@ -61,6 +61,7 @@ namespace Tgstation.Server.Host.Components.Chat
 		/// Send the message for a deployment to configured deployment channels.
 		/// </summary>
 		/// <param name="revisionInformation">The <see cref="RevisionInformation"/> of the deployment.</param>
+		/// <param name="previousRevisionInformation">The optional <see cref="RevisionInformation"/> of the previous deployment.</param>
 		/// <param name="engineVersion">The <see cref="Api.Models.EngineVersion"/> of the deployment.</param>
 		/// <param name="estimatedCompletionTime">The optional <see cref="DateTimeOffset"/> the deployment is expected to be completed at.</param>
 		/// <param name="gitHubOwner">The repository GitHub owner, if any.</param>
@@ -69,6 +70,7 @@ namespace Tgstation.Server.Host.Components.Chat
 		/// <returns>A <see cref="Func{T1, T2, TResult}"/> to call to update the message at the deployment's conclusion. Parameters: Error message if any, DreamMaker output if any. Returns an <see cref="Action"/> to call to mark the deployment as active/inactive. Parameter: If the deployment is being activated or inactivated.</returns>
 		Func<string?, string, Action<bool>> QueueDeploymentMessage(
 			Models.RevisionInformation revisionInformation,
+			Models.RevisionInformation? previousRevisionInformation,
 			Api.Models.EngineVersion engineVersion,
 			DateTimeOffset? estimatedCompletionTime,
 			string? gitHubOwner,

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordProvider.cs
@@ -303,6 +303,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		/// <inheritdoc />
 		public override async ValueTask<Func<string?, string, ValueTask<Func<bool, ValueTask>>>> SendUpdateMessage(
 			Models.RevisionInformation revisionInformation,
+			Models.RevisionInformation? previousRevisionInformation,
 			EngineVersion engineVersion,
 			DateTimeOffset? estimatedCompletionTime,
 			string? gitHubOwner,
@@ -316,7 +317,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 
 			localCommitPushed |= revisionInformation.CommitSha == revisionInformation.OriginCommitSha;
 
-			var fields = BuildUpdateEmbedFields(revisionInformation, engineVersion, gitHubOwner, gitHubRepo, localCommitPushed);
+			var fields = BuildUpdateEmbedFields(revisionInformation, previousRevisionInformation, engineVersion, gitHubOwner, gitHubRepo, localCommitPushed);
 			Optional<IEmbedAuthor> author = new EmbedAuthor(assemblyInformationProvider.VersionPrefix)
 			{
 				Url = "https://github.com/tgstation/tgstation-server",
@@ -900,6 +901,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		/// Create a <see cref="List{T}"/> of <see cref="IEmbedField"/>s for a discord update embed.
 		/// </summary>
 		/// <param name="revisionInformation">The <see cref="RevisionInformation"/> of the deployment.</param>
+		/// <param name="previousRevisionInformation">The optional <see cref="RevisionInformation"/> of the previous deployment.</param>
 		/// <param name="engineVersion">The <see cref="EngineVersion"/> of the deployment.</param>
 		/// <param name="gitHubOwner">The repository GitHub owner, if any.</param>
 		/// <param name="gitHubRepo">The repository GitHub name, if any.</param>
@@ -907,6 +909,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		/// <returns>A new <see cref="List{T}"/> of <see cref="IEmbedField"/>s to use.</returns>
 		List<IEmbedField> BuildUpdateEmbedFields(
 			Models.RevisionInformation revisionInformation,
+			Models.RevisionInformation? previousRevisionInformation,
 			EngineVersion engineVersion,
 			string? gitHubOwner,
 			string? gitHubRepo,
@@ -936,6 +939,40 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 			if (gitHubOwner == null || gitHubRepo == null)
 				return fields;
 
+			previousRevisionInformation ??= new Models.RevisionInformation();
+			previousRevisionInformation.ActiveTestMerges ??= new List<RevInfoTestMerge>();
+
+			revisionInformation.ActiveTestMerges ??= new List<RevInfoTestMerge>();
+
+			var addedTestMerges = revisionInformation
+				.ActiveTestMerges
+				.Select(x => x.TestMerge)
+				.Where(x => !previousRevisionInformation
+					.ActiveTestMerges
+					.Any(y => y.TestMerge.Number == x.Number))
+				.ToList();
+			var removedTestMerges = previousRevisionInformation
+				.ActiveTestMerges
+				.Select(x => x.TestMerge)
+				.Where(x => !revisionInformation
+					.ActiveTestMerges
+					.Any(y => y.TestMerge.Number == x.Number))
+				.ToList();
+			var updatedTestMerges = revisionInformation
+				.ActiveTestMerges
+				.Select(x => x.TestMerge)
+				.Where(x => previousRevisionInformation
+					.ActiveTestMerges
+					.Any(y => y.TestMerge.Number == x.Number && y.TestMerge.TargetCommitSha != x.TargetCommitSha))
+				.ToList();
+			var unchangedTestMerges = revisionInformation
+				.ActiveTestMerges
+				.Select(x => x.TestMerge)
+				.Where(x => previousRevisionInformation
+					.ActiveTestMerges
+					.Any(y => y.TestMerge.Number == x.Number && y.TestMerge.TargetCommitSha == x.TargetCommitSha))
+				.ToList();
+
 			fields.Add(
 				new EmbedField(
 					"Local Commit",
@@ -952,12 +989,34 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 						: revisionOriginSha[..7],
 					true));
 
-			fields.AddRange((revisionInformation.ActiveTestMerges ?? Enumerable.Empty<RevInfoTestMerge>())
-				.Select(x => x.TestMerge)
+			fields.AddRange(addedTestMerges
+				.Select(x => new EmbedField(
+					$"#{x.Number} (Added)",
+					$"[{x.TitleAtMerge}]({x.Url}) by _[@{x.Author}](https://github.com/{x.Author})_{Environment.NewLine}Commit: [{x.TargetCommitSha![..7]}](https://github.com/{gitHubOwner}/{gitHubRepo}/commit/{x.TargetCommitSha}){(String.IsNullOrWhiteSpace(x.Comment) ? String.Empty : $"{Environment.NewLine}_**{x.Comment}**_")}",
+					false)));
+
+			fields.AddRange(updatedTestMerges
+				.Select(x => new EmbedField(
+					$"#{x.Number} (Updated)",
+					$"[{x.TitleAtMerge}]({x.Url}) by _[@{x.Author}](https://github.com/{x.Author})_{Environment.NewLine}Commit: [{x.TargetCommitSha![..7]}](https://github.com/{gitHubOwner}/{gitHubRepo}/commit/{x.TargetCommitSha}){(String.IsNullOrWhiteSpace(x.Comment) ? String.Empty : $"{Environment.NewLine}_**{x.Comment}**_")}",
+					false)));
+
+			fields.AddRange(unchangedTestMerges
 				.Select(x => new EmbedField(
 					$"#{x.Number}",
 					$"[{x.TitleAtMerge}]({x.Url}) by _[@{x.Author}](https://github.com/{x.Author})_{Environment.NewLine}Commit: [{x.TargetCommitSha![..7]}](https://github.com/{gitHubOwner}/{gitHubRepo}/commit/{x.TargetCommitSha}){(String.IsNullOrWhiteSpace(x.Comment) ? String.Empty : $"{Environment.NewLine}_**{x.Comment}**_")}",
 					false)));
+
+			if (removedTestMerges.Count != 0)
+			{
+				fields.Add(
+				new EmbedField(
+					"Removed:",
+					String.Join(
+						Environment.NewLine,
+						removedTestMerges
+							.Select(x => $"- #{x.Number} [{x.TitleAtMerge}]({x.Url}) by _[@{x.Author}](https://github.com/{x.Author})_"))));
+			}
 
 			return fields;
 		}

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordProvider.cs
@@ -939,37 +939,28 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 			if (gitHubOwner == null || gitHubRepo == null)
 				return fields;
 
-			previousRevisionInformation ??= new Models.RevisionInformation();
-			previousRevisionInformation.ActiveTestMerges ??= new List<RevInfoTestMerge>();
+			var previousTestMerges = (IEnumerable<RevInfoTestMerge>?)previousRevisionInformation?.ActiveTestMerges ?? Enumerable.Empty<RevInfoTestMerge>();
+			var currentTestMerges = (IEnumerable<RevInfoTestMerge>?)revisionInformation.ActiveTestMerges ?? Enumerable.Empty<RevInfoTestMerge>();
 
-			revisionInformation.ActiveTestMerges ??= new List<RevInfoTestMerge>();
-
-			var addedTestMerges = revisionInformation
-				.ActiveTestMerges
+			// determine what TMs were changed and how
+			var addedTestMerges = currentTestMerges
 				.Select(x => x.TestMerge)
-				.Where(x => !previousRevisionInformation
-					.ActiveTestMerges
+				.Where(x => !previousTestMerges
 					.Any(y => y.TestMerge.Number == x.Number))
 				.ToList();
-			var removedTestMerges = previousRevisionInformation
-				.ActiveTestMerges
+			var removedTestMerges = previousTestMerges
 				.Select(x => x.TestMerge)
-				.Where(x => !revisionInformation
-					.ActiveTestMerges
+				.Where(x => !currentTestMerges
 					.Any(y => y.TestMerge.Number == x.Number))
 				.ToList();
-			var updatedTestMerges = revisionInformation
-				.ActiveTestMerges
+			var updatedTestMerges = currentTestMerges
 				.Select(x => x.TestMerge)
-				.Where(x => previousRevisionInformation
-					.ActiveTestMerges
+				.Where(x => previousTestMerges
 					.Any(y => y.TestMerge.Number == x.Number && y.TestMerge.TargetCommitSha != x.TargetCommitSha))
 				.ToList();
-			var unchangedTestMerges = revisionInformation
-				.ActiveTestMerges
+			var unchangedTestMerges = currentTestMerges
 				.Select(x => x.TestMerge)
-				.Where(x => previousRevisionInformation
-					.ActiveTestMerges
+				.Where(x => previousTestMerges
 					.Any(y => y.TestMerge.Number == x.Number && y.TestMerge.TargetCommitSha == x.TargetCommitSha))
 				.ToList();
 
@@ -1008,7 +999,6 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 					false)));
 
 			if (removedTestMerges.Count != 0)
-			{
 				fields.Add(
 				new EmbedField(
 					"Removed:",
@@ -1016,7 +1006,6 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 						Environment.NewLine,
 						removedTestMerges
 							.Select(x => $"- #{x.Number} [{x.TitleAtMerge}]({x.Url}) by _[@{x.Author}](https://github.com/{x.Author})_"))));
-			}
 
 			return fields;
 		}

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/IProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/IProvider.cs
@@ -84,7 +84,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		/// Send the message for a deployment.
 		/// </summary>
 		/// <param name="revisionInformation">The <see cref="RevisionInformation"/> of the deployment.</param>
-		/// <param name="previousRevisionInformation">The optional <see cref="RevisionInformation"/> of the previous deployment.</param>
+		/// <param name="previousRevisionInformation">The <see cref="RevisionInformation"/> of the previous deployment if any.</param>
 		/// <param name="engineVersion">The <see cref="Api.Models.EngineVersion"/> of the deployment.</param>
 		/// <param name="estimatedCompletionTime">The optional <see cref="DateTimeOffset"/> the deployment is expected to be completed at.</param>
 		/// <param name="gitHubOwner">The repository GitHub owner, if any.</param>

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/IProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/IProvider.cs
@@ -84,6 +84,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		/// Send the message for a deployment.
 		/// </summary>
 		/// <param name="revisionInformation">The <see cref="RevisionInformation"/> of the deployment.</param>
+		/// <param name="previousRevisionInformation">The optional <see cref="RevisionInformation"/> of the previous deployment.</param>
 		/// <param name="engineVersion">The <see cref="Api.Models.EngineVersion"/> of the deployment.</param>
 		/// <param name="estimatedCompletionTime">The optional <see cref="DateTimeOffset"/> the deployment is expected to be completed at.</param>
 		/// <param name="gitHubOwner">The repository GitHub owner, if any.</param>
@@ -94,6 +95,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		/// <returns>A <see cref="ValueTask{TResult}"/> resulting in a <see cref="Func{T1, T2, TResult}"/> to call to update the message at the deployment's conclusion. Parameters: Error message if any, DreamMaker output if any. Returns another callback which should be called to mark the deployment as active.</returns>
 		ValueTask<Func<string?, string, ValueTask<Func<bool, ValueTask>>>> SendUpdateMessage(
 			Models.RevisionInformation revisionInformation,
+			Models.RevisionInformation? previousRevisionInformation,
 			Api.Models.EngineVersion engineVersion,
 			DateTimeOffset? estimatedCompletionTime,
 			string? gitHubOwner,

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/IrcProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/IrcProvider.cs
@@ -268,9 +268,17 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 								}
 
 								var result = String.Format(CultureInfo.InvariantCulture, "#{0} at {1}", x.Number, x.TargetCommitSha![..7]);
+
 								if (x.Comment != null)
 								{
-									result += String.Format(CultureInfo.InvariantCulture, " ({1} - {0})", x.Comment, status);
+									if (!string.IsNullOrEmpty(status))
+									{
+										result += String.Format(CultureInfo.InvariantCulture, " ({1} - {0})", x.Comment, status);
+									}
+									else
+									{
+										result += String.Format(CultureInfo.InvariantCulture, " ({0})", x.Comment);
+									}
 								}
 								else if (!string.IsNullOrEmpty(status))
 								{

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/Provider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/Provider.cs
@@ -199,6 +199,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		/// <inheritdoc />
 		public abstract ValueTask<Func<string?, string, ValueTask<Func<bool, ValueTask>>>> SendUpdateMessage(
 			RevisionInformation revisionInformation,
+			RevisionInformation? previousRevisionInformation,
 			Api.Models.EngineVersion engineVersion,
 			DateTimeOffset? estimatedCompletionTime,
 			string? gitHubOwner,

--- a/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
@@ -326,7 +326,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 						likelyPushedTestMergeCommit,
 						cancellationToken);
 
-				var activeCompileJob = await compileJobConsumer.LatestCompileJob();
+				var oldCompileJob = await compileJobConsumer.LatestCompileJob();
 				try
 				{
 					await databaseContextFactory.UseContext(
@@ -374,7 +374,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 
 				var commentsTask = remoteDeploymentManager!.PostDeploymentComments(
 					compileJob,
-					activeCompileJob?.RevisionInformation,
+					oldCompileJob?.RevisionInformation,
 					repositorySettings,
 					repoOwner,
 					repoName,
@@ -478,8 +478,10 @@ namespace Tgstation.Server.Host.Components.Deployment
 			try
 			{
 				using var engineLock = await engineManager.UseExecutables(null, null, cancellationToken);
+				var oldCompileJob = await compileJobConsumer.LatestCompileJob();
 				currentChatCallback = chatManager.QueueDeploymentMessage(
 					revisionInformation,
+					oldCompileJob?.RevisionInformation,
 					engineLock.Version,
 					DateTimeOffset.UtcNow + estimatedDuration,
 					repository.RemoteRepositoryOwner,

--- a/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/DreamMaker.cs
@@ -336,12 +336,14 @@ namespace Tgstation.Server.Host.Components.Deployment
 						}
 					});
 
-				var likelyPushedTestMergeCommit =
-					repositorySettings!.PushTestMergeCommits!.Value
-					&& repositorySettings.AccessToken != null
-					&& repositorySettings.AccessUser != null;
-				var oldCompileJob = await compileJobConsumer.LatestCompileJob();
+				Models.CompileJob? oldCompileJob;
 				using (repo)
+				{
+					var likelyPushedTestMergeCommit =
+						repositorySettings!.PushTestMergeCommits!.Value
+						&& repositorySettings.AccessToken != null
+						&& repositorySettings.AccessUser != null;
+					oldCompileJob = await compileJobConsumer.LatestCompileJob();
 					compileJob = await Compile(
 						job,
 						oldCompileJob,
@@ -354,6 +356,7 @@ namespace Tgstation.Server.Host.Components.Deployment
 						averageSpan,
 						likelyPushedTestMergeCommit,
 						cancellationToken);
+				}
 
 				try
 				{

--- a/src/Tgstation.Server.Host/Components/Deployment/Remote/BaseRemoteDeploymentManager.cs
+++ b/src/Tgstation.Server.Host/Components/Deployment/Remote/BaseRemoteDeploymentManager.cs
@@ -66,36 +66,28 @@ namespace Tgstation.Server.Host.Components.Deployment.Remote
 			if (repositorySettings.AccessToken == null)
 				return;
 
-			var deployedRevisionInformation = compileJob.RevisionInformation;
-			if ((previousRevisionInformation != null && previousRevisionInformation.CommitSha == deployedRevisionInformation.CommitSha)
+			var revisionInformation = compileJob.RevisionInformation;
+			if ((previousRevisionInformation != null && previousRevisionInformation.CommitSha == revisionInformation.CommitSha)
 				|| !repositorySettings.PostTestMergeComment!.Value)
 				return;
 
-			previousRevisionInformation ??= new RevisionInformation();
-			previousRevisionInformation.ActiveTestMerges ??= new List<RevInfoTestMerge>();
+			var previousTestMerges = (IEnumerable<RevInfoTestMerge>?)previousRevisionInformation?.ActiveTestMerges ?? Enumerable.Empty<RevInfoTestMerge>();
+			var currentTestMerges = (IEnumerable<RevInfoTestMerge>?)revisionInformation.ActiveTestMerges ?? Enumerable.Empty<RevInfoTestMerge>();
 
-			deployedRevisionInformation.ActiveTestMerges ??= new List<RevInfoTestMerge>();
-
-			// added prs
-			var addedTestMerges = deployedRevisionInformation
-				.ActiveTestMerges
+			// determine what TMs were changed and how
+			var addedTestMerges = currentTestMerges
 				.Select(x => x.TestMerge)
-				.Where(x => !previousRevisionInformation
-					.ActiveTestMerges
+				.Where(x => !previousTestMerges
 					.Any(y => y.TestMerge.Number == x.Number))
 				.ToList();
-			var removedTestMerges = previousRevisionInformation
-				.ActiveTestMerges
+			var removedTestMerges = previousTestMerges
 				.Select(x => x.TestMerge)
-				.Where(x => !deployedRevisionInformation
-					.ActiveTestMerges
+				.Where(x => !currentTestMerges
 					.Any(y => y.TestMerge.Number == x.Number))
 				.ToList();
-			var updatedTestMerges = deployedRevisionInformation
-				.ActiveTestMerges
+			var updatedTestMerges = currentTestMerges
 				.Select(x => x.TestMerge)
-				.Where(x => previousRevisionInformation
-					.ActiveTestMerges
+				.Where(x => previousTestMerges
 					.Any(y => y.TestMerge.Number == x.Number))
 				.ToList();
 

--- a/tests/Tgstation.Server.Tests/Live/DummyChatProvider.cs
+++ b/tests/Tgstation.Server.Tests/Live/DummyChatProvider.cs
@@ -105,6 +105,7 @@ namespace Tgstation.Server.Tests.Live
 
 		public override ValueTask<Func<string, string, ValueTask<Func<bool, ValueTask>>>> SendUpdateMessage(
 			RevisionInformation revisionInformation,
+			RevisionInformation previousRevisionInformation,
 			Api.Models.EngineVersion engineVersion,
 			DateTimeOffset? estimatedCompletionTime,
 			string gitHubOwner,


### PR DESCRIPTION
[Base Branch]: # (Please set the base branch of your pull request appropriately. If you only made a patch, code improvement, non-server code change, or comment/documentation update please target the `master` branch. Otherwise, target the `dev` branch.)

[Release Notes]: # (Your PR should contain a detailed list of notable changes, titled appropriately. This includes any observable changes to the server or DMAPI. See examples below.)

🆑
Discord and IRC chatbot now will indicate either Added or Updated next to TM entries (this also changes sorting) in deployment messages
Discord chatbot now will list removed TMs in deployment messages
/🆑

[Why]: # (If this does not close or work on an existing GitHub issue, please add a short description [two lines down] of why you think these changes would benefit the server. If you can't justify it in words, it might not be worth adding.)

Its ultimately just more information for maintainers and server managers to know what changed with a new deployment, rather than just simply what the current TMs are. (I also want to do this to the deployment tab in the webpanel, but currently am struggling to sort this out so am PRing what I have already working).

Discord bot examples (I had to fix "Removed:" always getting listed if nothing was removed): 
![image](https://github.com/user-attachments/assets/f9a3de2b-8215-4119-a05a-6b520dd439d9)
![image](https://github.com/user-attachments/assets/833433f6-1b63-4139-ad64-3df9a7b3ee56)