### PR TITLE
Fix IRC throwing errors for non-GitHub update messages

### DIFF
--- a/src/Tgstation.Server.Host/Components/Chat/Providers/IrcProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/IrcProvider.cs
@@ -227,8 +227,6 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		{
 			ArgumentNullException.ThrowIfNull(revisionInformation);
 			ArgumentNullException.ThrowIfNull(engineVersion);
-			ArgumentNullException.ThrowIfNull(gitHubOwner);
-			ArgumentNullException.ThrowIfNull(gitHubRepo);
 
 			var commitInsert = revisionInformation.CommitSha![..7];
 			string remoteCommitInsert;

--- a/tests/Tgstation.Server.Tests/Live/DummyChatProvider.cs
+++ b/tests/Tgstation.Server.Tests/Live/DummyChatProvider.cs
@@ -115,8 +115,6 @@ namespace Tgstation.Server.Tests.Live
 		{
 			ArgumentNullException.ThrowIfNull(revisionInformation);
 			ArgumentNullException.ThrowIfNull(engineVersion);
-			ArgumentNullException.ThrowIfNull(gitHubOwner);
-			ArgumentNullException.ThrowIfNull(gitHubRepo);
 
 			Assert.IsTrue(knownChannels.ContainsKey(channelId));
 


### PR DESCRIPTION
🆑
Fixed IRC provider not being able to send update messages for non-GitHub repositories.
/🆑