### PR TITLE
v6.14.1: Fix Docker health checks and app token expiry

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -2322,9 +2322,9 @@ jobs:
 
   update-nix:
     name: Update Nix SHA
-    needs: deploy-tgs
+    needs: changelog-regen
     runs-on: ubuntu-latest
-    if: (!(cancelled() || failure())) && needs.deploy-tgs.result == 'success'
+    if: (!(cancelled() || failure())) && needs.changelog-regen.result == 'success'
     steps:
       - name: Install Native Packages # Name checked in rerunFlakyTests.js
         run: |

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -79,6 +79,6 @@ COPY --from=build /repo/build/tgs.docker.sh tgs.sh
 
 VOLUME ["/config_data", "/tgs_logs", "/app/lib"]
 
-HEALTHCHECK --start-interval=60s CMD --curl --fail http://localhost:5000/health || exit
+HEALTHCHECK --start-interval=60s CMD curl --fail http://localhost:5000/health || exit
 
 ENTRYPOINT ["./tgs.sh"]

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -79,6 +79,6 @@ COPY --from=build /repo/build/tgs.docker.sh tgs.sh
 
 VOLUME ["/config_data", "/tgs_logs", "/app/lib"]
 
-HEALTHCHECK CMD --curl --fail http://localhost:5000/health || exit
+HEALTHCHECK --start-interval=60s CMD --curl --fail http://localhost:5000/health || exit
 
 ENTRYPOINT ["./tgs.sh"]

--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="WebpanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>6.14.0</TgsCoreVersion>
+    <TgsCoreVersion>6.14.1</TgsCoreVersion>
     <TgsConfigVersion>5.5.0</TgsConfigVersion>
     <TgsRestVersion>10.12.1</TgsRestVersion>
     <TgsGraphQLVersion>0.5.0</TgsGraphQLVersion>


### PR DESCRIPTION
🆑
Docker: Fixed bad health check command.
Fixed an issue where GitHub app tokens would be cached beyond their expiry period.
/🆑