### PR TITLE
v6.17.0: Instance root export

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -10,7 +10,7 @@
     <TgsCommonLibraryVersion>7.0.0</TgsCommonLibraryVersion>
     <TgsApiLibraryVersion>18.0.0</TgsApiLibraryVersion>
     <TgsClientVersion>21.0.0</TgsClientVersion>
-    <TgsDmapiVersion>7.3.2</TgsDmapiVersion>
+    <TgsDmapiVersion>7.3.3</TgsDmapiVersion>
     <TgsInteropVersion>5.10.1</TgsInteropVersion>
     <TgsHostWatchdogVersion>1.6.0</TgsHostWatchdogVersion>
     <TgsSwarmProtocolVersion>9.0.0</TgsSwarmProtocolVersion>

--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="WebpanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>6.16.1</TgsCoreVersion>
+    <TgsCoreVersion>6.17.0</TgsCoreVersion>
     <TgsConfigVersion>5.7.0</TgsConfigVersion>
     <TgsRestVersion>10.13.0</TgsRestVersion>
     <TgsGraphQLVersion>0.6.0</TgsGraphQLVersion>

--- a/src/DMAPI/tgs.dm
+++ b/src/DMAPI/tgs.dm
@@ -1,7 +1,7 @@
 // tgstation-server DMAPI
 // The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in IETF RFC 2119.
 
-#define TGS_DMAPI_VERSION "7.3.2"
+#define TGS_DMAPI_VERSION "7.3.3"
 
 // All functions and datums outside this document are subject to change with any version and should not be relied on.
 

--- a/src/DMAPI/tgs/v5/api.dm
+++ b/src/DMAPI/tgs/v5/api.dm
@@ -97,7 +97,7 @@
 			if(revInfo)
 				tm.commit = revisionData[DMAPI5_REVISION_INFORMATION_COMMIT_SHA]
 				tm.origin_commit = revisionData[DMAPI5_REVISION_INFORMATION_ORIGIN_COMMIT_SHA]
-				tm.timestamp = revisionData[DMAPI5_TEST_MERGE_REVISION]
+				tm.timestamp = revisionData[DMAPI5_REVISION_INFORMATION_TIMESTAMP]
 			else
 				TGS_WARNING_LOG("Failed to decode [DMAPI5_TEST_MERGE_REVISION] from test merge #[tm.number]!")
 

--- a/src/Tgstation.Server.Host/Components/InstanceFactory.cs
+++ b/src/Tgstation.Server.Host/Components/InstanceFactory.cs
@@ -292,6 +292,7 @@ namespace Tgstation.Server.Host.Components
 				platformIdentifier,
 				fileTransferService,
 				loggerFactory.CreateLogger<StaticFiles.Configuration>(),
+				metadata,
 				generalConfiguration,
 				sessionConfiguration);
 			var eventConsumer = new EventConsumer(configuration);

--- a/src/Tgstation.Server.Host/Components/StaticFiles/Configuration.cs
+++ b/src/Tgstation.Server.Host/Components/StaticFiles/Configuration.cs
@@ -125,6 +125,11 @@ namespace Tgstation.Server.Host.Components.StaticFiles
 		readonly ILogger<Configuration> logger;
 
 		/// <summary>
+		/// The <see cref="Api.Models.Instance"/> the <see cref="Configuration"/> belongs to.
+		/// </summary>
+		readonly Models.Instance metadata;
+
+		/// <summary>
 		/// The <see cref="GeneralConfiguration"/> for <see cref="Configuration"/>.
 		/// </summary>
 		readonly GeneralConfiguration generalConfiguration;
@@ -159,6 +164,7 @@ namespace Tgstation.Server.Host.Components.StaticFiles
 		/// <param name="postWriteHandler">The value of <see cref="postWriteHandler"/>.</param>
 		/// <param name="platformIdentifier">The value of <see cref="platformIdentifier"/>.</param>
 		/// <param name="fileTransferService">The value of <see cref="fileTransferService"/>.</param>
+		/// <param name="metadata">The value of <see cref="metadata"/>.</param>
 		/// <param name="logger">The value of <see cref="logger"/>.</param>
 		/// <param name="generalConfiguration">The value of <see cref="generalConfiguration"/>.</param>
 		/// <param name="sessionConfiguration">The value of <see cref="sessionConfiguration"/>.</param>
@@ -171,6 +177,7 @@ namespace Tgstation.Server.Host.Components.StaticFiles
 			IPlatformIdentifier platformIdentifier,
 			IFileTransferTicketProvider fileTransferService,
 			ILogger<Configuration> logger,
+			Models.Instance metadata,
 			GeneralConfiguration generalConfiguration,
 			SessionConfiguration sessionConfiguration)
 		{
@@ -182,6 +189,7 @@ namespace Tgstation.Server.Host.Components.StaticFiles
 			this.platformIdentifier = platformIdentifier ?? throw new ArgumentNullException(nameof(platformIdentifier));
 			this.fileTransferService = fileTransferService ?? throw new ArgumentNullException(nameof(fileTransferService));
 			this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+			this.metadata = metadata ?? throw new ArgumentNullException(nameof(metadata));
 			this.generalConfiguration = generalConfiguration ?? throw new ArgumentNullException(nameof(generalConfiguration));
 			this.sessionConfiguration = sessionConfiguration ?? throw new ArgumentNullException(nameof(sessionConfiguration));
 
@@ -844,6 +852,10 @@ namespace Tgstation.Server.Host.Components.StaticFiles
 								return $"\"{arg}\"";
 							})),
 						cancellationToken,
+						new Dictionary<string, string>
+						{
+							{ "TGS_INSTANCE_ROOT", metadata.Path! },
+						},
 						readStandardHandles: true,
 						noShellExecute: true))
 					using (cancellationToken.Register(() => script.Terminate()))

--- a/tests/DMAPI/BasicOperation/test_event-qwer.sh
+++ b/tests/DMAPI/BasicOperation/test_event-qwer.sh
@@ -4,6 +4,13 @@ set -e
 
 echo "Running test_event script - $1 - $2"
 
+if [[ -z "${TGS_INSTANCE_ROOT}" ]]; then
+	echo "TEST ERROR: TGS_INSTANCE_ROOT env var not defined"
+	exit 1
+fi
+
+echo "TGS_INSTANCE_ROOT: ${TGS_INSTANCE_ROOT}"
+
 sleep 5
 
 cd $1

--- a/tests/Tgstation.Server.Host.Tests/Components/StaticFiles/TestConfiguration.cs
+++ b/tests/Tgstation.Server.Host.Tests/Components/StaticFiles/TestConfiguration.cs
@@ -53,6 +53,10 @@ namespace Tgstation.Server.Host.Components.StaticFiles.Tests
 					Mock.Of<IPlatformIdentifier>(),
 					Mock.Of<IFileTransferTicketProvider>(),
 					loggerFactory.CreateLogger<Configuration>(),
+					new Models.Instance
+					{
+						Path = "Some path",
+					},
 					new GeneralConfiguration(),
 					new SessionConfiguration());
 


### PR DESCRIPTION
🆑
Event scripts are now executed with the `TGS_INSTANCE_ROOT` environment variable set to the path of the main directory of the instance.
/🆑