### PR TITLE
Change nix ELF patching to use `TGS_INSTANCE_ROOT` env var

### DIFF
--- a/build/package/nix/tgstation-server.nix
+++ b/build/package/nix/tgstation-server.nix
@@ -23,12 +23,13 @@ let
 
   byond-patcher = pkgs-i686.writeShellScriptBin "EngineInstallComplete-050-TgsPatchELFByond.sh" ''
     # If the file doesn't exist, assume OD
-    if [[ ! -f ../../Byond/$1/byond/bin/DreamDaemon ]] ; then
+    BYOND_BIN_PATH="''${TGS_INSTANCE_ROOT}/Byond/$1/byond/bin/"
+    if [[ ! -f "''${BYOND_BIN_PATH}DreamDaemon" ]] ; then
       echo "DreamDaemon doesn't appear to exist. Assuming OD install"
       exit
     fi
 
-    BYOND_PATH=$(realpath ../../Byond/$1/byond/bin/)
+    BYOND_PATH=$(realpath $BYOND_BIN_PATH)
 
     ${pkgs.patchelf}/bin/patchelf --set-interpreter "$(cat ${stdenv.cc}/nix-support/dynamic-linker)" \
       --set-rpath "$BYOND_PATH:${rpath}" \


### PR DESCRIPTION
:cl:
Nix: BYOND executable patching now uses the `TGS_INSTANCE_ROOT` environment variable to navigate to the instance's Byond directory.
/:cl: