### PR TITLE
Don't require https for OpenIDConnect

### DIFF
--- a/src/Tgstation.Server.Host/Core/Application.cs
+++ b/src/Tgstation.Server.Host/Core/Application.cs
@@ -940,10 +940,7 @@ namespace Tgstation.Server.Host.Core
 							options.Scope.Add(OpenIdConnectScope.OpenId);
 							options.Scope.Add(OpenIdConnectScope.OfflineAccess);
 
-#if DEBUG
 							options.RequireHttpsMetadata = false;
-#endif
-
 							options.SaveTokens = true;
 							options.ResponseType = OpenIdConnectResponseType.Code;
 							options.MapInboundClaims = false;


### PR DESCRIPTION
This setting is now just always false to allow you to utilize an openid authority that isn't HTTPS.

🆑
HTTPS is no longer mandatory for an OpenIDConnect authority.
/🆑