### PR TITLE
libcurl4 for byond 1664

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -59,7 +59,7 @@ RUN export TGS_TELEMETRY_KEY_FILE="../../${TGS_TELEMETRY_KEY_FILE}" \
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim
 
 #needed for byond, curl for healthchecks
-RUN pkg --add-architecture i386 \
+RUN dpkg --add-architecture i386 \
 	&& apt-get update \
 	&& apt-get install -y \
 		gcc-multilib \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -59,11 +59,13 @@ RUN export TGS_TELEMETRY_KEY_FILE="../../${TGS_TELEMETRY_KEY_FILE}" \
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim
 
 #needed for byond, curl for healthchecks
-RUN apt-get update \
+RUN pkg --add-architecture i386 \
+	&& apt-get update \
 	&& apt-get install -y \
 		gcc-multilib \
 		gdb \
 		curl \
+		libcurl4:i386 \
 	&& rm -rf /var/lib/apt/lists/*
 
 EXPOSE 5000

--- a/build/package/deb/debian/control
+++ b/build/package/deb/debian/control
@@ -21,6 +21,7 @@ Depends:
  libstdc++6:i386 [amd64],
  libstdc++6 [i386],
  gcc-multilib [amd64],
+ libcurl4 [i386],
 Recommends:
  libsystemd0,
  gdb,


### PR DESCRIPTION
[Base Branch]: # (Please set the base branch of your pull request appropriately. If you only made a patch, code improvement, non-server code change, or comment/documentation update please target the `master` branch. Otherwise, target the `dev` branch.)

[Release Notes]: # (Your PR should contain a detailed list of notable changes, titled appropriately. This includes any observable changes to the server or DMAPI. See examples below.)

🆑
adds libcurl4:i386 for byond 1664
/🆑

Byond 1664 requires libcurl4:i386 to compile.

Best check if  those edits are in the right places.
