### PR TITLE
Test Improvements

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -3,13 +3,13 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="WebpanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>6.18.0</TgsCoreVersion>
+    <TgsCoreVersion>6.19.0</TgsCoreVersion>
     <TgsConfigVersion>5.8.0</TgsConfigVersion>
-    <TgsRestVersion>10.13.1</TgsRestVersion>
+    <TgsRestVersion>10.14.0</TgsRestVersion>
     <TgsGraphQLVersion>0.6.0</TgsGraphQLVersion>
     <TgsCommonLibraryVersion>7.0.0</TgsCommonLibraryVersion>
-    <TgsApiLibraryVersion>18.1.0</TgsApiLibraryVersion>
-    <TgsClientVersion>21.1.0</TgsClientVersion>
+    <TgsApiLibraryVersion>18.2.0</TgsApiLibraryVersion>
+    <TgsClientVersion>21.2.0</TgsClientVersion>
     <TgsDmapiVersion>7.3.3</TgsDmapiVersion>
     <TgsInteropVersion>5.10.1</TgsInteropVersion>
     <TgsHostWatchdogVersion>1.6.0</TgsHostWatchdogVersion>

--- a/src/Tgstation.Server.Api/Models/Internal/DreamDaemonApiBase.cs
+++ b/src/Tgstation.Server.Api/Models/Internal/DreamDaemonApiBase.cs
@@ -15,6 +15,13 @@ namespace Tgstation.Server.Api.Models.Internal
 		public long? SessionId { get; set; }
 
 		/// <summary>
+		/// A incrementing ID for representing current iteration of servers world (i.e. after calling /world/proc/Reboot). Only unique within the current <see cref="SessionId"/>. Only tracked in game sessions with the DMAPI enabled.
+		/// </summary>
+		/// <example>1</example>
+		[ResponseOptions]
+		public long? WorldIteration { get; set; }
+
+		/// <summary>
 		/// When the current server execution was started.
 		/// </summary>
 		[ResponseOptions]

--- a/src/Tgstation.Server.Host/Authority/PermissionSetAuthority.cs
+++ b/src/Tgstation.Server.Host/Authority/PermissionSetAuthority.cs
@@ -124,6 +124,7 @@ namespace Tgstation.Server.Host.Authority
 
 					var permissionSetId = await DatabaseContext
 						.PermissionSets
+						.AsQueryable()
 						.Where(permissionSet => permissionSet.UserId == userId
 							|| groupIdQuery.Contains(permissionSet.GroupId))
 						.Select(permissionSet => permissionSet.Id!.Value)

--- a/src/Tgstation.Server.Host/Components/Session/ISessionController.cs
+++ b/src/Tgstation.Server.Host/Components/Session/ISessionController.cs
@@ -90,6 +90,11 @@ namespace Tgstation.Server.Host.Components.Session
 		string DumpFileExtension { get; }
 
 		/// <summary>
+		/// The number of times a startup bridge request has been received. <see langword="null"/> if <see cref="DMApiAvailable"/> is <see langword="false"/>.
+		/// </summary>
+		long? StartupBridgeRequestsReceived { get; }
+
+		/// <summary>
 		/// Releases the <see cref="IProcess"/> without terminating it. Also calls <see cref="IDisposable.Dispose"/>.
 		/// </summary>
 		/// <returns>A <see cref="ValueTask"/> representing the running operation.</returns>

--- a/src/Tgstation.Server.Host/Components/Watchdog/IWatchdog.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/IWatchdog.cs
@@ -20,6 +20,11 @@ namespace Tgstation.Server.Host.Components.Watchdog
 		long? SessionId { get; }
 
 		/// <summary>
+		/// A incrementing ID for representing current iteration of servers world (i.e. after calling /world/proc/Reboot). Only unique within the current <see cref="SessionId"/>. Only tracked in game sessions with the DMAPI enabled.
+		/// </summary>
+		long? WorldIteration { get; }
+
+		/// <summary>
 		/// When the current server executions was started.
 		/// </summary>
 		DateTimeOffset? LaunchTime { get; }

--- a/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
+++ b/src/Tgstation.Server.Host/Components/Watchdog/WatchdogBase.cs
@@ -40,6 +40,9 @@ namespace Tgstation.Server.Host.Components.Watchdog
 		public long? SessionId => GetActiveController()?.ReattachInformation.Id;
 
 		/// <inheritdoc />
+		public long? WorldIteration => GetActiveController()?.StartupBridgeRequestsReceived;
+
+		/// <inheritdoc />
 		public uint? ClientCount { get; private set; }
 
 		/// <inheritdoc />

--- a/src/Tgstation.Server.Host/Controllers/DreamDaemonController.cs
+++ b/src/Tgstation.Server.Host/Controllers/DreamDaemonController.cs
@@ -366,6 +366,7 @@ namespace Tgstation.Server.Host.Controllers
 						firstIteration = false;
 						result.Status = dd.Status;
 						result.SessionId = dd.SessionId;
+						result.WorldIteration = dd.WorldIteration;
 						result.LaunchTime = dd.LaunchTime;
 						result.ClientCount = dd.ClientCount;
 					}

--- a/tests/DMAPI/BasicOperation/Test.dm
+++ b/tests/DMAPI/BasicOperation/Test.dm
@@ -26,12 +26,18 @@
 	FailTest("DMAPI Error: [message]")
 
 /proc/Run()
+	var/list/world_params = world.params
+	if("basic_reboot" in world_params || world_params["basic_reboot"] == "yes")
+		world.log << "Reboot path"
+		sleep(150)
+		world.Reboot()
+		return
+
 	world.log << "sleep"
 	sleep(50)
 	world.TgsTargetedChatBroadcast("Sample admin-only message", TRUE)
 
 	world.log << "params check"
-	var/list/world_params = world.params
 	if(!("test" in world_params) || world_params["test"] != "bababooey")
 		FailTest("Expected parameter test=bababooey but did not receive", "test_fail_reason.txt")
 
@@ -58,7 +64,7 @@
 
 	world.log << "sleep2"
 	sleep(150)
-	world.log << "Terminating..."
+	world.log << "Test Terminating..."
 	world.TgsEndProcess()
 	if(world.TgsAvailable())
 		FailTest("Expected TGS to not let us reach this point")
@@ -80,6 +86,7 @@
 
 /world/Reboot(reason)
 	TgsReboot()
+	return ..()
 
 /datum/tgs_chat_command/echo
 	name = "echo"

--- a/tests/DMAPI/test_setup.dm
+++ b/tests/DMAPI/test_setup.dm
@@ -1,5 +1,5 @@
 /world/New()
-	log << "Starting test..."
+	log << "Starting test: [json_encode(params)]"
 	text2file("SUCCESS", "test_success.txt")
 	world.RunTest()
 

--- a/tests/Tgstation.Server.Tests/Live/Instance/WatchdogTest.cs
+++ b/tests/Tgstation.Server.Tests/Live/Instance/WatchdogTest.cs
@@ -750,6 +750,9 @@ namespace Tgstation.Server.Tests.Live.Instance
 			await CheckDDPriority();
 			Assert.AreEqual(false, daemonStatus.SoftRestart);
 			Assert.AreEqual(false, daemonStatus.SoftShutdown);
+
+			Assert.AreEqual(skipApiValidation, !daemonStatus.WorldIteration.HasValue);
+
 			Assert.IsTrue(daemonStatus.ImmediateMemoryUsage.HasValue);
 			Assert.AreNotEqual(0, daemonStatus.ImmediateMemoryUsage.Value);
 
@@ -765,6 +768,36 @@ namespace Tgstation.Server.Tests.Live.Instance
 			await ExpectGameDirectoryCount(1, cancellationToken);
 
 			await CheckDMApiFail(daemonStatus.ActiveCompileJob, cancellationToken, false, false);
+
+			if (!skipApiValidation && !watchdogRestartsProcess)
+			{
+				daemonStatus = await instanceClient.DreamDaemon.Update(new DreamDaemonRequest
+				{
+					AdditionalParameters = "basic_reboot=yes",
+				}, cancellationToken);
+				Assert.AreEqual("basic_reboot=yes", daemonStatus.AdditionalParameters);
+
+				startJob = await StartDD(cancellationToken);
+
+				await WaitForJob(startJob, 40, false, null, cancellationToken);
+				daemonStatus = await instanceClient.DreamDaemon.Read(cancellationToken);
+
+				var initialWorldIteration = daemonStatus.WorldIteration;
+				var initialSessionId = daemonStatus.SessionId.Value;
+				Assert.IsTrue(initialWorldIteration.HasValue);
+
+				for (int i = 0; i < 60 && daemonStatus.WorldIteration == initialWorldIteration; ++i)
+				{
+					await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
+					daemonStatus = await instanceClient.DreamDaemon.Read(cancellationToken);
+				}
+
+				Assert.IsTrue(daemonStatus.WorldIteration.HasValue);
+				Assert.AreEqual(initialSessionId, daemonStatus.SessionId.Value);
+				Assert.IsTrue(initialWorldIteration.Value < daemonStatus.WorldIteration.Value);
+
+				await GracefulWatchdogShutdown(cancellationToken);
+			}
 
 			daemonStatus = await instanceClient.DreamDaemon.Update(new DreamDaemonRequest
 			{
@@ -1503,12 +1536,14 @@ namespace Tgstation.Server.Tests.Live.Instance
 		}
 
 		public Task<DreamDaemonResponse> TellWorldToReboot(bool waitForOnlineIfRestoring, CancellationToken cancellationToken, [CallerLineNumber]int source = 0)
-			=> TellWorldToReboot2(instanceClient, instanceManager, topicClient, FindTopicPort(), waitForOnlineIfRestoring || testVersion.Engine.Value == EngineType.OpenDream, cancellationToken, source);
-		public static async Task<DreamDaemonResponse> TellWorldToReboot2(IInstanceClient instanceClient, IInstanceManager instanceManager, ITopicClient topicClient, ushort topicPort, bool waitForOnlineIfRestoring, CancellationToken cancellationToken, [CallerLineNumber]int source = 0, [CallerFilePath]string path = null)
+			=> TellWorldToReboot2(instanceClient, instanceManager, topicClient, FindTopicPort(), waitForOnlineIfRestoring || testVersion.Engine.Value == EngineType.OpenDream, watchdogRestartsProcess, cancellationToken, source);
+		public static async Task<DreamDaemonResponse> TellWorldToReboot2(IInstanceClient instanceClient, IInstanceManager instanceManager, ITopicClient topicClient, ushort topicPort, bool waitForOnlineIfRestoring, bool watchdogRestartsProcess, CancellationToken cancellationToken, [CallerLineNumber]int source = 0, [CallerFilePath]string path = null)
 		{
 			var daemonStatus = await instanceClient.DreamDaemon.Read(cancellationToken);
 			Assert.IsNotNull(daemonStatus.StagedCompileJob);
 			var initialSession = daemonStatus.ActiveCompileJob;
+			var initialSessionId = daemonStatus.SessionId.Value;
+			var initialIteration = daemonStatus.WorldIteration;
 
 			System.Console.WriteLine($"TEST: Sending world reboot topic @ {path}#L{source}");
 
@@ -1517,16 +1552,21 @@ namespace Tgstation.Server.Tests.Live.Instance
 
 			using var tempCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 			var tempToken = tempCts.Token;
+
+			bool DifferentSession() => initialSessionId != daemonStatus.SessionId || (initialIteration.HasValue && initialIteration != daemonStatus.WorldIteration);
 			using (tempToken.Register(() => System.Console.WriteLine("TEST ERROR: Timeout in TellWorldToReboot!")))
 			{
 				tempCts.CancelAfter(TimeSpan.FromMinutes(2));
-
 				do
 				{
-					await Task.Delay(TimeSpan.FromSeconds(1), tempToken);
-					daemonStatus = await instanceClient.DreamDaemon.Read(tempToken);
+					do
+					{
+						await Task.Delay(TimeSpan.FromSeconds(1), tempToken);
+						daemonStatus = await instanceClient.DreamDaemon.Read(tempToken);
+					}
+					while (initialSession.Id == daemonStatus.ActiveCompileJob.Id);
 				}
-				while (initialSession.Id == daemonStatus.ActiveCompileJob.Id);
+				while (watchdogRestartsProcess && initialIteration.HasValue && DifferentSession());
 			}
 
 			if (waitForOnlineIfRestoring && daemonStatus.Status == WatchdogStatus.Restoring)

--- a/tests/Tgstation.Server.Tests/Live/TestLiveServer.cs
+++ b/tests/Tgstation.Server.Tests/Live/TestLiveServer.cs
@@ -1613,7 +1613,7 @@ namespace Tgstation.Server.Tests.Live
 
 					async Task RunInstanceTests()
 					{
-						var testSerialized = TestingUtils.RunningInGitHubActions; // they only have 2 cores, can't handle intense parallelization
+						var testSerialized = true || TestingUtils.RunningInGitHubActions; // they only have 2 cores, can't handle intense parallelization
 						async Task ODCompatTests()
 						{
 							var fileDownloader = await GetFileDownloader();
@@ -1644,7 +1644,7 @@ namespace Tgstation.Server.Tests.Live
 									cancellationToken);
 						}
 
-						var odCompatTests = FailFast(ODCompatTests());
+						var odCompatTests = Task.CompletedTask ?? FailFast(ODCompatTests());
 
 						if (openDreamOnly || testSerialized)
 							await odCompatTests;
@@ -1662,7 +1662,7 @@ namespace Tgstation.Server.Tests.Live
 							new PlatformIdentifier().IsWindows,
 							cancellationToken);
 
-						var compatTests = FailFast(
+						var compatTests = Task.CompletedTask ?? FailFast(
 							instanceTest
 								.RunCompatTests(
 									new EngineVersion
@@ -1869,6 +1869,7 @@ namespace Tgstation.Server.Tests.Live
 						WatchdogTest.StaticTopicClient,
 						mainDDPort.Value,
 						true,
+						server.UsingBasicWatchdog,
 						cancellationToken);
 
 					Assert.AreEqual(WatchdogStatus.Online, dd.Status.Value); // if this assert fails, you likely have to crack open the debugger and read test_fail_reason.txt manually


### PR DESCRIPTION
:cl: REST API
Added `worldIteration` to GET `/api/DreamDaemon` response. Number indicating the number of times the world has started in the same session (i.e. incrementing when `/world/proc/Reboot()` is called). This will be `null` for sessions without DMAPI support.
/:cl:

:cl: Nuget: API
Added `DreamDaemonApiBase.WorldIteration`.
/:cl:

:cl: Nuget: Client
Updated API library to v18.2.0.
/:cl: