### PR TITLE
package.nix: avoid IFD, parse XML with regexps 😈

### DIFF
--- a/build/package/nix/package.nix
+++ b/build/package/nix/package.nix
@@ -4,36 +4,15 @@
 }:
 
 let
-  inherit (pkgs) stdenv lib;
+  inherit (pkgs) lib;
 
-  versionParse = stdenv.mkDerivation {
-    pname = "tgstation-server-version-parse";
-    version = "1.0.0";
-
-    meta = with pkgs.lib; {
-      description = "Version parser for tgstation-server";
-      homepage = "https://github.com/tgstation/tgstation-server";
-      changelog = "https://github.com/tgstation/tgstation-server/blob/gh-pages/changelog.yml";
-      license = licenses.agpl3Plus;
-      platforms = platforms.x86_64;
-    };
-
-    nativeBuildInputs = with pkgs; [
-      xmlstarlet
-    ];
-
-    src = ./../..;
-
-    installPhase = ''
-      mkdir -p $out
-      xmlstarlet sel -N X="http://schemas.microsoft.com/developer/msbuild/2003" --template --value-of /X:Project/X:PropertyGroup/X:TgsCoreVersion ./Version.props > $out/tgs_version.txt
-      xmlstarlet sel -N X="http://schemas.microsoft.com/developer/msbuild/2003" --template --value-of /X:Project/X:PropertyGroup/X:TgsHostWatchdogVersion ./Version.props > $out/watchdog_version.txt
-    '';
-  };
+  versionFile = builtins.readFile ../../Version.props;
+  extractVersion = s: lib.head (lib.match ".*<${s}>([0-9]+(\.[0-9]+)*)</${s}>.*" versionFile);
+  versions = lib.genAttrs [ "TgsCoreVersion" "TgsHostWatchdogVersion" ] extractVersion;
 
   tgstation-server-host-console = pkgs.buildDotnetModule {
     pname = "Tgstation.Server.Host.Console";
-    version =  (builtins.readFile "${versionParse}/watchdog_version.txt"); # Be careful, this influences the assembly version
+    version = versions.TgsHostWatchdogVersion;
 
     src = ./../../..;
 
@@ -50,7 +29,7 @@ let
 in
 stdenv.mkDerivation {
   pname = "tgstation-server";
-  version = (builtins.readFile "${versionParse}/tgs_version.txt");
+  version = versions.TgsCoreVersion;
 
   meta = with pkgs.lib; {
     description = "A production scale tool for DreamMaker server management";


### PR DESCRIPTION
import-from-derivation is likely a major source of slowdowns for
tgstation-operations/infrastructure, and various [/tg/station] repos use a
“read parsed version from drv output” pattern which is intrinsically IFD.

Similar to tgstation/tgstation#97139 but those version numbers may matter,
so I “parsed” them with the best, slop-free regexps.  ;3

🆑
Optimize nix evaluation time somewhat.
/🆑

[Why]: @RigglePrime told me (your) NixOS eval times sucked ass (and not in a yuri way)

[/tg/station]: https://github.com/tgstation
