### PR TITLE
Add Discord slash command support

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,8 @@ Create an `appsettings.Production.yml` file next to `appsettings.yml`. This will
 
 - `General:GitHubAccessToken`: Specify a classic GitHub personal access token with no scopes here to highly mitigate the possiblity of 429 response codes from GitHub requests
 
+- `General:DiscordSlashCommandName`: The Discord slash command name for TGS chat commands. Defaults to `tgs`; use 1-32 letters, digits, `-`, `_`, or apostrophes, without the leading `/`. Restart is required.
+
 - `General:SkipAddingByondFirewallException`: Set to `true` if you have Windows firewall disabled
 
 - `General:AdditionalEventScriptsDirectories`: An array of directories that are considered to contain EventScripts alongside instance directories. Working directory for executed scripts will remain the instance EventScripts directory.
@@ -624,11 +626,20 @@ TGS supports creating infinite chat bots for notifying staff or players of thing
 
 - Internet Relay Chat (IRC)
 - Discord
-  - NOTE: Bot MUST have Message Content Intent enabled
+  - The Message Content Intent enables `!tgs` and mention commands in guild channels.
+  - Without the intent, use the `/tgs` slash command in guild channels. Its required **command** argument autocompletes built-in and active DMAPI command names; **arguments** is optional.
+  - Set `General:DiscordSlashCommandName` to change the slash command name from its default, `/tgs`.
+  - To use Discord without the Message Content Intent, configure the bot in the Developer Portal:
+    1. Open the app and go to **OAuth2 - URL Generator**.
+    2. Select the `bot` and `applications.commands` scopes.
+    3. Grant the bot at least these channel permissions already used by TGS:
+       - `View Channels`
+       - `Send Messages`
+       - `Read Message History` for normal reply/history behavior.
 
 More can be added by providing a new implementation of the [IProvider](src/Tgstation.Server.Host/Components/Chat/Providers/IProvider.cs) interface
 
-Bots have a set of built-in commands that can be triggered via `!tgs`, mentioning, or private messaging them. Along with these, custom commands can be defined using the DMAPI by creating a subtype of the `/datum/tgs_chat_command` type (See `tgs.dm` for details). Invocation for custom commands can be restricted to certain channels.
+Bots have a set of built-in commands that can be triggered via `!tgs`, `/tgs`, or mentioning them. Along with these, custom commands can be defined using the DMAPI by creating a subtype of the `/datum/tgs_chat_command` type (See `tgs.dm` for details). Invocation for custom commands can be restricted to certain channels.
 
 #### Static Files
 

--- a/src/Tgstation.Server.Host/Components/Chat/ChatManager.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/ChatManager.cs
@@ -297,7 +297,7 @@ namespace Tgstation.Server.Host.Components.Chat
 					disconnectTask = Task.CompletedTask;
 				if (newSettingsEnabled)
 				{
-					provider = providerFactory.CreateProvider(newSettings);
+					provider = providerFactory.CreateProvider(newSettings, GetCommandNames);
 					providers.Add(newSettingsId, provider);
 				}
 			}
@@ -593,6 +593,26 @@ namespace Tgstation.Server.Host.Components.Chat
 					Text = message,
 				},
 				cancellationToken);
+		}
+
+		/// <summary>
+		/// Gets the currently available chat command names.
+		/// </summary>
+		/// <returns>The command names.</returns>
+		IReadOnlyList<string> GetCommandNames()
+		{
+			var commands = new List<string> { "help" };
+			commands.AddRange(builtinCommands.Values.Select(command => command.Name));
+			lock (trackingContexts)
+				commands.AddRange(
+					trackingContexts
+						.Where(trackingContext => trackingContext.Active)
+						.SelectMany(trackingContext => trackingContext.CustomCommands.Select(command => command.Name)));
+
+			return commands
+				.Distinct(StringComparer.OrdinalIgnoreCase)
+				.OrderBy(command => command, StringComparer.OrdinalIgnoreCase)
+				.ToList();
 		}
 
 		/// <summary>

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordForwardingResponder.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordForwardingResponder.cs
@@ -32,5 +32,8 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 
 		/// <inheritdoc />
 		public Task<Result> RespondAsync(IReady gatewayEvent, CancellationToken ct) => targetResponder.RespondAsync(gatewayEvent, ct);
+
+		/// <inheritdoc />
+		public Task<Result> RespondAsync(IInteractionCreate gatewayEvent, CancellationToken ct) => targetResponder.RespondAsync(gatewayEvent, ct);
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordMessage.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordMessage.cs
@@ -9,6 +9,16 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 	sealed class DiscordMessage : Message
 	{
 		/// <summary>
+		/// The Discord application ID, if the source was an interaction.
+		/// </summary>
+		public Snowflake? ApplicationId { get; }
+
+		/// <summary>
+		/// The Discord interaction token, if the source was an interaction.
+		/// </summary>
+		public string? InteractionToken { get; }
+
+		/// <summary>
 		/// The <see cref="IMessageReference"/> of the source <see cref="Message"/>.
 		/// </summary>
 		public Optional<IMessageReference> MessageReference { get; set; }
@@ -19,12 +29,16 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		/// <param name="user">The value of <see cref="Message.User"/>.</param>
 		/// <param name="content">The value of <see cref="Message.Content"/>.</param>
 		/// <param name="messageReference">The value of <see cref="MessageReference"/>.</param>
-		public DiscordMessage(ChatUser user, string content, Optional<IMessageReference> messageReference)
+		/// <param name="applicationId">The value of <see cref="ApplicationId"/>.</param>
+		/// <param name="interactionToken">The value of <see cref="InteractionToken"/>.</param>
+		public DiscordMessage(ChatUser user, string content, Optional<IMessageReference> messageReference, Snowflake? applicationId = null, string? interactionToken = null)
 			: base(
 				  user,
 				  content)
 		{
 			MessageReference = messageReference;
+			ApplicationId = applicationId;
+			InteractionToken = interactionToken;
 		}
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/DiscordProvider.cs
@@ -11,6 +11,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
+using OneOf;
+
 using Remora.Discord.API.Abstractions.Gateway.Commands;
 using Remora.Discord.API.Abstractions.Gateway.Events;
 using Remora.Discord.API.Abstractions.Objects;
@@ -57,6 +59,109 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		}
 
 		/// <summary>
+		/// The default Discord slash command name.
+		/// </summary>
+		const string DefaultSlashCommandName = "tgs";
+
+		/// <summary>
+		/// The description of the TGS slash command.
+		/// </summary>
+		const string SlashCommandDescription = "Run a TGS chat command.";
+
+		/// <summary>
+		/// The Discord slash command text option name.
+		/// </summary>
+		const string SlashCommandOptionName = "command";
+
+		/// <summary>
+		/// The Discord slash command arguments option name.
+		/// </summary>
+		const string SlashCommandArgumentsOptionName = "arguments";
+
+		/// <summary>
+		/// The maximum amount of Discord autocomplete choices.
+		/// </summary>
+		const int MaxAutocompleteChoices = 25;
+
+		/// <summary>
+		/// Builds the existing chat command text for a Discord slash command.
+		/// </summary>
+		/// <param name="commandName">The slash command name.</param>
+		/// <param name="arguments">The slash command arguments.</param>
+		/// <returns>The chat command text.</returns>
+		internal static string BuildSlashCommandMessageContent(string commandName, string? arguments = null)
+		{
+			var trimmedArguments = arguments?.Trim();
+			return String.IsNullOrWhiteSpace(trimmedArguments)
+				? $"{ChatManager.CommonMention} {commandName.Trim()}"
+				: $"{ChatManager.CommonMention} {commandName.Trim()} {trimmedArguments}";
+		}
+
+		/// <summary>
+		/// Normalizes a configured Discord slash command name.
+		/// </summary>
+		/// <param name="commandName">The configured command name.</param>
+		/// <returns>The normalized slash command name.</returns>
+		internal static string NormalizeSlashCommandName(string? commandName)
+		{
+			var normalized = commandName?.Trim();
+			if (String.IsNullOrWhiteSpace(normalized))
+				return DefaultSlashCommandName;
+
+#pragma warning disable CA1308 // Discord slash command names must be lowercase.
+			normalized = normalized.ToLowerInvariant();
+#pragma warning restore CA1308
+
+			if (normalized.Length > 32 || normalized.Any(character => !Char.IsLetterOrDigit(character) && character is not '-' and not '_' and not '\''))
+				throw new ArgumentException("DiscordSlashCommandName must be 1-32 letters, numbers, '-', '_' or apostrophes without a leading '/'.", nameof(commandName));
+
+			return normalized;
+		}
+
+		/// <summary>
+		/// Checks if an application can request message content.
+		/// </summary>
+		/// <param name="applicationFlags">The <see cref="ApplicationFlags"/> to check.</param>
+		/// <returns><see langword="true"/> if the message content gateway intent is available.</returns>
+		internal static bool HasMessageContentIntent(ApplicationFlags applicationFlags)
+			=> applicationFlags.HasFlag(ApplicationFlags.GatewayMessageContent)
+				|| applicationFlags.HasFlag(ApplicationFlags.GatewayMessageContentLimited);
+
+		/// <summary>
+		/// Checks if an application command is a registered TGS slash command that should be removed from a stale scope.
+		/// </summary>
+		/// <param name="command">The application command.</param>
+		/// <param name="configuredCommandName">The configured slash command name.</param>
+		/// <returns><see langword="true"/> if the command is stale.</returns>
+		internal static bool IsTgsSlashCommand(IApplicationCommand command, string configuredCommandName)
+		{
+			ArgumentNullException.ThrowIfNull(command);
+			ArgumentNullException.ThrowIfNull(configuredCommandName);
+
+			return command.Type == ApplicationCommandType.ChatInput
+				&& !command.Name.Equals(configuredCommandName, StringComparison.OrdinalIgnoreCase)
+				&& String.Equals(command.Description, SlashCommandDescription, StringComparison.Ordinal);
+		}
+
+		/// <summary>
+		/// Gets a string option from <paramref name="commandData"/>.
+		/// </summary>
+		/// <param name="commandData">The command data.</param>
+		/// <param name="optionName">The option name.</param>
+		/// <returns>The string option value, if any.</returns>
+		static string? GetStringOption(IApplicationCommandData commandData, string optionName)
+		{
+			var option = commandData.Options.HasValue
+				? commandData.Options.Value.FirstOrDefault(option => option.Name.Equals(optionName, StringComparison.Ordinal))
+				: null;
+
+			if (option == null || !option.Value.HasValue || !option.Value.Value.IsT0)
+				return null;
+
+			return option.Value.Value.AsT0;
+		}
+
+		/// <summary>
 		/// The <see cref="ChannelType"/>s supported by the <see cref="DiscordProvider"/> for mapping.
 		/// </summary>
 		static readonly ChannelType[] SupportedGuildChannelTypes =
@@ -65,6 +170,23 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 			ChannelType.GuildAnnouncement,
 			ChannelType.PrivateThread,
 			ChannelType.PublicThread,
+		];
+
+		/// <summary>
+		/// The Discord slash command options.
+		/// </summary>
+		static readonly IReadOnlyList<IApplicationCommandOption> SlashCommandOptions =
+		[
+			new ApplicationCommandOption(
+				ApplicationCommandOptionType.String,
+				SlashCommandOptionName,
+				"The TGS command name.",
+				IsRequired: true,
+				EnableAutocomplete: true),
+			new ApplicationCommandOption(
+				ApplicationCommandOptionType.String,
+				SlashCommandArgumentsOptionName,
+				"The TGS command arguments."),
 		];
 
 		/// <summary>
@@ -81,6 +203,11 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		/// The <see cref="ServiceProvider"/> containing Discord services.
 		/// </summary>
 		readonly ServiceProvider serviceProvider;
+
+		/// <summary>
+		/// Gets the currently available chat command names.
+		/// </summary>
+		readonly Func<IReadOnlyList<string>> commandNamesFactory;
 
 		/// <summary>
 		/// <see cref="List{T}"/> of mapped channel <see cref="Snowflake"/>s.
@@ -101,6 +228,16 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		/// The <see cref="DiscordDMOutputDisplayType"/>.
 		/// </summary>
 		readonly DiscordDMOutputDisplayType outputDisplayType;
+
+		/// <summary>
+		/// The Discord slash command name.
+		/// </summary>
+		readonly string slashCommandName;
+
+		/// <summary>
+		/// If Discord message contents are available.
+		/// </summary>
+		bool messageContentsAvailable;
 
 		/// <summary>
 		/// The <see cref="CancellationTokenSource"/> for the <see cref="gatewayTask"/>.
@@ -141,19 +278,48 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		/// <param name="asyncDelayer">The <see cref="IAsyncDelayer"/> for the <see cref="Provider"/>.</param>
 		/// <param name="logger">The <see cref="ILogger"/> for the <see cref="Provider"/>.</param>
 		/// <param name="assemblyInformationProvider">The value of <see cref="assemblyInformationProvider"/>.</param>
-		/// <param name="chatBot">The <see cref="ChatBot"/> for the <see cref="Provider"/>.</param>
 		/// <param name="generalConfigurationOptions">The value of <see cref="generalConfigurationOptions"/>.</param>
+		/// <param name="chatBot">The <see cref="ChatBot"/> for the <see cref="Provider"/>.</param>
+		/// <param name="commandNamesFactory">Gets the currently available chat command names.</param>
 		public DiscordProvider(
 			IJobManager jobManager,
 			IAsyncDelayer asyncDelayer,
 			ILogger<DiscordProvider> logger,
 			IAssemblyInformationProvider assemblyInformationProvider,
 			IOptionsMonitor<GeneralConfiguration> generalConfigurationOptions,
-			ChatBot chatBot)
+			ChatBot chatBot,
+			Func<IReadOnlyList<string>> commandNamesFactory)
+			: this(jobManager, asyncDelayer, logger, assemblyInformationProvider, generalConfigurationOptions, chatBot, commandNamesFactory, null)
+		{
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="DiscordProvider"/> class.
+		/// </summary>
+		/// <param name="jobManager">The <see cref="IJobManager"/> for the <see cref="Provider"/>.</param>
+		/// <param name="asyncDelayer">The <see cref="IAsyncDelayer"/> for the <see cref="Provider"/>.</param>
+		/// <param name="logger">The <see cref="ILogger"/> for the <see cref="Provider"/>.</param>
+		/// <param name="assemblyInformationProvider">The value of <see cref="assemblyInformationProvider"/>.</param>
+		/// <param name="generalConfigurationOptions">The value of <see cref="generalConfigurationOptions"/>.</param>
+		/// <param name="chatBot">The <see cref="ChatBot"/> for the <see cref="Provider"/>.</param>
+		/// <param name="commandNamesFactory">Gets the currently available chat command names.</param>
+		/// <param name="serviceProviderOverride">The optional service provider override for tests.</param>
+		internal DiscordProvider(
+			IJobManager jobManager,
+			IAsyncDelayer asyncDelayer,
+			ILogger<DiscordProvider> logger,
+			IAssemblyInformationProvider assemblyInformationProvider,
+			IOptionsMonitor<GeneralConfiguration> generalConfigurationOptions,
+			ChatBot chatBot,
+			Func<IReadOnlyList<string>>? commandNamesFactory,
+			ServiceProvider? serviceProviderOverride)
 			: base(jobManager, asyncDelayer, logger, chatBot)
 		{
 			this.assemblyInformationProvider = assemblyInformationProvider ?? throw new ArgumentNullException(nameof(assemblyInformationProvider));
 			this.generalConfigurationOptions = generalConfigurationOptions ?? throw new ArgumentNullException(nameof(generalConfigurationOptions));
+			this.commandNamesFactory = commandNamesFactory ?? (() => Array.Empty<string>());
+			slashCommandName = NormalizeSlashCommandName(generalConfigurationOptions.CurrentValue?.DiscordSlashCommandName);
+			Logger.LogInformation("Discord slash command configured as /{slashCommandName}.", slashCommandName);
 
 			mappedChannels = new List<ulong>();
 			connectDisconnectLock = new object();
@@ -163,9 +329,8 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 			outputDisplayType = csb.DMOutputDisplay;
 			deploymentBranding = csb.DeploymentBranding;
 
-			serviceProvider = new ServiceCollection()
+			serviceProvider = serviceProviderOverride ?? new ServiceCollection()
 				.AddDiscordGateway(serviceProvider => botToken)
-				.Configure<DiscordGatewayClientOptions>(options => options.Intents |= GatewayIntents.MessageContents)
 				.AddSingleton(serviceProvider => (IDiscordResponders)this)
 				.AddResponder<DiscordForwardingResponder>()
 				.BuildServiceProvider();
@@ -216,7 +381,63 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 
 			var embeds = ConvertEmbed(message.Embed);
 
+			if (replyTo is DiscordMessage { InteractionToken: { } interactionToken, ApplicationId: { } applicationId })
+			{
+				try
+				{
+					var interactionClient = serviceProvider.GetRequiredService<IDiscordRestInteractionAPI>();
+					Optional<IReadOnlyList<IEmbed>?> interactionEmbeds = embeds.HasValue
+						? new Optional<IReadOnlyList<IEmbed>?>(embeds.Value)
+						: default;
+					Optional<IAllowedMentions?> interactionAllowedMentions = allowedMentions.HasValue
+						? new Optional<IAllowedMentions?>(allowedMentions.Value)
+						: default;
+					var content = message.Text;
+					if (content == null)
+					{
+						Logger.LogWarning(
+							"Failed to send interaction response to channel {channelId}: Message was null!",
+							channelId);
+
+						content = "TGS: Could not send message to Discord. Message was `null`!";
+					}
+
+					var response = await interactionClient.EditOriginalInteractionResponseAsync(
+						applicationId,
+						interactionToken,
+						content,
+						embeds: interactionEmbeds,
+						allowedMentions: interactionAllowedMentions,
+						ct: cancellationToken);
+
+					if (!response.IsSuccess)
+					{
+						Logger.LogWarning(
+							"Failed to send interaction response to channel {channelId}: {result}",
+							channelId,
+							response.LogFormat());
+
+						if (response.Error is RestResultError<RestError> restError && restError.Error.Code == DiscordError.InvalidFormBody)
+							await interactionClient.EditOriginalInteractionResponseAsync(
+								applicationId,
+								interactionToken,
+								"TGS: Could not send message to Discord. Body was malformed or too long",
+								ct: cancellationToken);
+					}
+				}
+				catch (Exception e) when (e is not OperationCanceledException)
+				{
+					Logger.LogWarning(
+						e,
+						"Error sending interaction response to channel {channelId}",
+						channelId);
+				}
+
+				return;
+			}
+
 			var channelsClient = serviceProvider.GetRequiredService<IDiscordRestChannelAPI>();
+
 			async ValueTask SendToChannel(Snowflake channelId)
 			{
 				if (message.Text == null)
@@ -484,6 +705,9 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		{
 			ArgumentNullException.ThrowIfNull(messageCreateEvent);
 
+			if (!messageContentsAvailable && messageCreateEvent.GuildID.HasValue)
+				return Result.FromSuccess();
+
 			if ((messageCreateEvent.Type != MessageType.Default
 				&& messageCreateEvent.Type != MessageType.InlineReply)
 				|| messageCreateEvent.Author.ID == currentUserId)
@@ -571,6 +795,127 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		}
 
 		/// <inheritdoc />
+		public async Task<Result> RespondAsync(IInteractionCreate interactionCreateEvent, CancellationToken cancellationToken)
+		{
+			ArgumentNullException.ThrowIfNull(interactionCreateEvent);
+
+			var interactionData = interactionCreateEvent.Data;
+			if ((interactionCreateEvent.Type != InteractionType.ApplicationCommand
+					&& interactionCreateEvent.Type != InteractionType.ApplicationCommandAutocomplete)
+				|| !interactionData.HasValue
+				|| !interactionData.Value.IsT0
+				|| !interactionData.Value.AsT0.Name.Equals(slashCommandName, StringComparison.OrdinalIgnoreCase))
+				return Result.FromSuccess();
+
+			var commandData = interactionData.Value.AsT0;
+			var interactionClient = serviceProvider.GetRequiredService<IDiscordRestInteractionAPI>();
+			Task RespondWithError(string message)
+				=> interactionClient.EditOriginalInteractionResponseAsync(
+					interactionCreateEvent.ApplicationID,
+					interactionCreateEvent.Token,
+					message,
+					ct: cancellationToken);
+
+			if (interactionCreateEvent.Type == InteractionType.ApplicationCommandAutocomplete)
+				return await RespondAutocomplete(interactionCreateEvent, commandData, interactionClient, cancellationToken);
+
+			var deferResponse = await interactionClient.CreateInteractionResponseAsync(
+				interactionCreateEvent.ID,
+				interactionCreateEvent.Token,
+				new InteractionResponse(InteractionCallbackType.DeferredChannelMessageWithSource),
+				ct: cancellationToken);
+			if (!deferResponse.IsSuccess)
+			{
+				Logger.LogWarning(
+					"Failed to defer slash command response {interactionId}: {result}",
+					interactionCreateEvent.ID,
+					deferResponse.LogFormat());
+				return Result.FromSuccess();
+			}
+
+			var commandText = GetStringOption(commandData, SlashCommandOptionName);
+			if (String.IsNullOrWhiteSpace(commandText))
+			{
+				await RespondWithError("TGS: No command text supplied.");
+				return Result.FromSuccess();
+			}
+
+			var arguments = GetStringOption(commandData, SlashCommandArgumentsOptionName);
+
+			if (!interactionCreateEvent.Channel.HasValue || !interactionCreateEvent.Channel.Value.ID.HasValue)
+			{
+				await RespondWithError("TGS: Processing error, check logs!");
+				return Result.FromSuccess();
+			}
+
+			var channelId = interactionCreateEvent.Channel.Value.ID.Value;
+			var channelsClient = serviceProvider.GetRequiredService<IDiscordRestChannelAPI>();
+			var channelResponse = await channelsClient.GetChannelAsync(channelId, cancellationToken);
+			if (!channelResponse.IsSuccess)
+			{
+				Logger.LogWarning(
+					"Failed to get channel {channelId} in response to interaction {interactionId}: {result}",
+					channelId,
+					interactionCreateEvent.ID,
+					channelResponse.LogFormat());
+
+				await RespondWithError("TGS: Processing error, check logs!");
+				return Result.FromSuccess();
+			}
+
+			var pm = channelResponse.Entity.Type == ChannelType.DM || channelResponse.Entity.Type == ChannelType.GroupDM;
+			var shouldNotAnswer = !pm;
+			if (shouldNotAnswer)
+				lock (mappedChannels)
+					shouldNotAnswer = !mappedChannels.Contains(channelId.Value) && !mappedChannels.Contains(0);
+
+			if (shouldNotAnswer)
+			{
+				await RespondWithError("TGS: This channel is not mapped.");
+				return Result.FromSuccess();
+			}
+
+			string guildName = "UNKNOWN";
+			if (!pm)
+			{
+				var guildsClient = serviceProvider.GetRequiredService<IDiscordRestGuildAPI>();
+				var guildResponse = await guildsClient.GetGuildAsync(interactionCreateEvent.GuildID.Value, false, cancellationToken);
+				if (guildResponse.IsSuccess)
+					guildName = guildResponse.Entity.Name;
+				else
+					Logger.LogWarning(
+						"Failed to get guild {guildId} in response to interaction {interactionId}: {result}",
+						interactionCreateEvent.GuildID.Value,
+						interactionCreateEvent.ID,
+						guildResponse.LogFormat());
+			}
+
+			var user = interactionCreateEvent.Member.HasValue && interactionCreateEvent.Member.Value.User.HasValue
+				? interactionCreateEvent.Member.Value.User.Value
+				: interactionCreateEvent.User.Value;
+			var result = new DiscordMessage(
+				new ChatUser(
+					new ChannelRepresentation(
+						pm ? user.Username : guildName,
+						channelResponse.Entity.Name.Value!,
+						channelId.Value)
+					{
+						IsPrivateChannel = pm,
+						EmbedsSupported = true,
+					},
+					user.Username,
+					NormalizeMentions($"<@{user.ID}>"),
+					user.ID.Value),
+				BuildSlashCommandMessageContent(commandText, arguments),
+				default,
+				interactionCreateEvent.ApplicationID,
+				interactionCreateEvent.Token);
+
+			EnqueueMessage(result);
+			return Result.FromSuccess();
+		}
+
+		/// <inheritdoc />
 		public Task<Result> RespondAsync(IReady readyEvent, CancellationToken cancellationToken)
 		{
 			ArgumentNullException.ThrowIfNull(readyEvent);
@@ -594,34 +939,61 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 				}
 
 				var gatewayCancellationToken = gatewayCts.Token;
-				var gatewayClient = serviceProvider.GetRequiredService<DiscordGatewayClient>();
+				Task<Result>? localGatewayTask = null;
+				using var localCombinedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, gatewayCancellationToken);
+				var localCombinedCancellationToken = localCombinedCts.Token;
 
-				Task<Result> localGatewayTask;
-				gatewayReadyTcs = new TaskCompletionSource();
-
-				using var gatewayConnectionAbortRegistration = cancellationToken.Register(() => gatewayReadyTcs.TrySetCanceled(cancellationToken));
-				gatewayCancellationToken.Register(() => Logger.LogTrace("Stopping gateway client..."));
-
-				// reconnects keep happening until we stop or it faults, our auto-reconnector will handle the latter
-				localGatewayTask = gatewayClient.RunAsync(gatewayCancellationToken);
 				try
 				{
+					var applicationClient = serviceProvider.GetRequiredService<IDiscordRestApplicationAPI>();
+					var currentApplicationResponse = await applicationClient.GetCurrentApplicationAsync(localCombinedCancellationToken);
+					if (currentApplicationResponse.IsSuccess)
+					{
+						var application = currentApplicationResponse.Entity;
+						SetMessageContentsAvailable(application.Flags.HasValue && HasMessageContentIntent(application.Flags.Value));
+						await RegisterSlashCommand(application.ID, localCombinedCancellationToken);
+					}
+					else
+					{
+						localCombinedCancellationToken.ThrowIfCancellationRequested();
+						Logger.LogWarning(
+							"Unable to retrieve current Discord application. Retrying connection: {result}",
+							currentApplicationResponse.LogFormat());
+						throw new JobException(
+							ErrorCode.ChatCannotConnectProvider,
+							new InvalidOperationException($"Discord application request failed: {currentApplicationResponse.LogFormat()}"));
+					}
+
+					var gatewayClient = serviceProvider.GetRequiredService<DiscordGatewayClient>();
+
+					gatewayReadyTcs = new TaskCompletionSource();
+
+					using var gatewayConnectionAbortRegistration = cancellationToken.Register(() => gatewayReadyTcs.TrySetCanceled(cancellationToken));
+					gatewayCancellationToken.Register(() => Logger.LogTrace("Stopping gateway client..."));
+
+					// reconnects keep happening until we stop or it faults, our auto reconnector will handle the latter
+					localGatewayTask = gatewayClient.RunAsync(gatewayCancellationToken);
 					await Task.WhenAny(gatewayReadyTcs.Task, localGatewayTask);
 
 					cancellationToken.ThrowIfCancellationRequested();
 					if (localGatewayTask.IsCompleted)
-						throw new JobException(ErrorCode.ChatCannotConnectProvider);
+					{
+						var gatewayResult = await localGatewayTask;
+						Logger.LogWarning("Discord gateway stopped before becoming ready: {result}", gatewayResult.LogFormat());
+						throw new JobException(
+							ErrorCode.ChatCannotConnectProvider,
+							new InvalidOperationException($"Discord gateway failed: {gatewayResult.LogFormat()}"));
+					}
 
 					var userClient = serviceProvider.GetRequiredService<IDiscordRestUserAPI>();
-
-					using var localCombinedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, gatewayCancellationToken);
-					var localCombinedCancellationToken = localCombinedCts.Token;
 					var currentUserResult = await userClient.GetCurrentUserAsync(localCombinedCancellationToken);
 					if (!currentUserResult.IsSuccess)
 					{
 						localCombinedCancellationToken.ThrowIfCancellationRequested();
 						Logger.LogWarning("Unable to retrieve current user: {result}", currentUserResult.LogFormat());
-						throw new JobException(ErrorCode.ChatCannotConnectProvider);
+						throw new JobException(
+							ErrorCode.ChatCannotConnectProvider,
+							new InvalidOperationException($"Discord current-user request failed: {currentUserResult.LogFormat()}"));
 					}
 
 					currentUserId = currentUserResult.Entity.ID;
@@ -652,7 +1024,10 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 				gatewayTask = null;
 				gatewayCts = null;
 				if (localGatewayTask == null)
+				{
+					localGatewayCts?.Dispose();
 					return;
+				}
 			}
 
 			localGatewayCts.Cancel();
@@ -840,6 +1215,20 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		}
 
 		/// <summary>
+		/// Sets if message contents are available and updates the gateway options.
+		/// </summary>
+		/// <param name="available">If message contents are available.</param>
+		void SetMessageContentsAvailable(bool available)
+		{
+			messageContentsAvailable = available;
+			var gatewayOptions = serviceProvider.GetRequiredService<IOptions<DiscordGatewayClientOptions>>().Value;
+			if (available)
+				gatewayOptions.Intents |= GatewayIntents.MessageContents;
+			else
+				gatewayOptions.Intents &= ~GatewayIntents.MessageContents;
+		}
+
+		/// <summary>
 		/// Get all text <see cref="IChannel"/>s accessible to and supported by the bot.
 		/// </summary>
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
@@ -896,6 +1285,93 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 				.Where(guildChannel => SupportedGuildChannelTypes.Contains(guildChannel.Type));
 
 			return allAccessibleChannels;
+		}
+
+		/// <summary>
+		/// Responds to a Discord slash command autocomplete interaction.
+		/// </summary>
+		/// <param name="interactionCreateEvent">The interaction event.</param>
+		/// <param name="commandData">The command data.</param>
+		/// <param name="interactionClient">The interaction API.</param>
+		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
+		/// <returns>A <see cref="Result"/> representing the command's result.</returns>
+		async Task<Result> RespondAutocomplete(
+			IInteractionCreate interactionCreateEvent,
+			IApplicationCommandData commandData,
+			IDiscordRestInteractionAPI interactionClient,
+			CancellationToken cancellationToken)
+		{
+			var focusedCommand = commandData.Options.HasValue
+				? commandData.Options.Value.FirstOrDefault(option => option.Name.Equals(SlashCommandOptionName, StringComparison.Ordinal) && option.IsFocused.HasValue && option.IsFocused.Value)
+				: null;
+			var focusedValue = focusedCommand != null && focusedCommand.Value.HasValue && focusedCommand.Value.Value.IsT0
+				? focusedCommand.Value.Value.AsT0
+				: String.Empty;
+
+			var choices = commandNamesFactory()
+				.Where(command => String.IsNullOrEmpty(focusedValue) || command.StartsWith(focusedValue, StringComparison.OrdinalIgnoreCase))
+				.Take(MaxAutocompleteChoices)
+				.Select(command => (IApplicationCommandOptionChoice)new ApplicationCommandOptionChoice(command, OneOf<string, int, double>.FromT0(command)))
+				.ToList();
+
+			var response = await interactionClient.CreateInteractionResponseAsync(
+				interactionCreateEvent.ID,
+				interactionCreateEvent.Token,
+				new InteractionResponse(
+					InteractionCallbackType.ApplicationCommandAutocompleteResult,
+					new Optional<OneOf<IInteractionMessageCallbackData, IInteractionAutocompleteCallbackData, IInteractionModalCallbackData>>(
+						OneOf<IInteractionMessageCallbackData, IInteractionAutocompleteCallbackData, IInteractionModalCallbackData>.FromT1(
+							new InteractionAutocompleteCallbackData(choices)))),
+				ct: cancellationToken);
+
+			if (!response.IsSuccess)
+				Logger.LogWarning(
+					"Failed to respond to slash command autocomplete {interactionId}: {result}",
+					interactionCreateEvent.ID,
+					response.LogFormat());
+
+			return Result.FromSuccess();
+		}
+
+		/// <summary>
+		/// Registers the configured slash command.
+		/// </summary>
+		/// <param name="applicationId">The Discord application ID.</param>
+		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
+		/// <returns>A <see cref="ValueTask"/> representing the running operation.</returns>
+		async ValueTask RegisterSlashCommand(Snowflake applicationId, CancellationToken cancellationToken)
+		{
+			var applicationClient = serviceProvider.GetRequiredService<IDiscordRestApplicationAPI>();
+			var updateResponse = await applicationClient.CreateGlobalApplicationCommandAsync(
+				applicationId,
+				slashCommandName,
+				SlashCommandDescription,
+				new Optional<IReadOnlyList<IApplicationCommandOption>>(SlashCommandOptions),
+				ct: cancellationToken);
+
+			if (!updateResponse.IsSuccess)
+			{
+				cancellationToken.ThrowIfCancellationRequested();
+				Logger.LogWarning("Unable to register Discord slash command: {result}", updateResponse.LogFormat());
+				throw new JobException(
+					ErrorCode.ChatCannotConnectProvider,
+					new InvalidOperationException($"Discord slash-command registration failed: {updateResponse.LogFormat()}"));
+			}
+
+			Logger.LogInformation("Registered global Discord slash command /{slashCommandName}.", slashCommandName);
+
+			var globalCommandsResponse = await applicationClient.GetGlobalApplicationCommandsAsync(applicationId, ct: cancellationToken);
+			if (globalCommandsResponse.IsSuccess)
+				foreach (var command in globalCommandsResponse.Entity.Where(command => IsTgsSlashCommand(command, slashCommandName)))
+				{
+					var deleteResponse = await applicationClient.DeleteGlobalApplicationCommandAsync(applicationId, command.ID, cancellationToken);
+					if (!deleteResponse.IsSuccess)
+						Logger.LogWarning("Unable to remove stale global Discord slash command {commandId}: {result}", command.ID, deleteResponse.LogFormat());
+					else
+						Logger.LogInformation("Removed stale global Discord slash command /{commandName}.", command.Name);
+				}
+			else
+				Logger.LogWarning("Unable to inspect global Discord slash commands for stale entries: {result}", globalCommandsResponse.LogFormat());
 		}
 
 		/// <summary>

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/IDiscordResponders.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/IDiscordResponders.cs
@@ -6,7 +6,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 	/// <summary>
 	/// Combined interface for the <see cref="IResponder"/> types used by TGS.
 	/// </summary>
-	interface IDiscordResponders : IResponder<IMessageCreate>, IResponder<IReady>
+	interface IDiscordResponders : IResponder<IMessageCreate>, IResponder<IReady>, IResponder<IInteractionCreate>
 	{
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/IProviderFactory.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/IProviderFactory.cs
@@ -1,4 +1,7 @@
-﻿using Tgstation.Server.Host.Models;
+﻿using System;
+using System.Collections.Generic;
+
+using Tgstation.Server.Host.Models;
 
 namespace Tgstation.Server.Host.Components.Chat.Providers
 {
@@ -11,7 +14,8 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		/// Create a <see cref="IProvider"/>.
 		/// </summary>
 		/// <param name="settings">The <see cref="ChatBot"/> containing settings for the new provider.</param>
+		/// <param name="commandNamesFactory">Gets the currently available chat command names.</param>
 		/// <returns>A new <see cref="IProvider"/>.</returns>
-		IProvider CreateProvider(ChatBot settings);
+		IProvider CreateProvider(ChatBot settings, Func<IReadOnlyList<string>> commandNamesFactory);
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Chat/Providers/ProviderFactory.cs
+++ b/src/Tgstation.Server.Host/Components/Chat/Providers/ProviderFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 
 using Microsoft.Extensions.Logging;
@@ -71,9 +72,10 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 		}
 
 		/// <inheritdoc />
-		public IProvider CreateProvider(Models.ChatBot settings)
+		public IProvider CreateProvider(Models.ChatBot settings, Func<IReadOnlyList<string>> commandNamesFactory)
 		{
 			ArgumentNullException.ThrowIfNull(settings);
+			ArgumentNullException.ThrowIfNull(commandNamesFactory);
 			return settings.Provider switch
 			{
 				ChatProvider.Irc => new IrcProvider(
@@ -89,7 +91,8 @@ namespace Tgstation.Server.Host.Components.Chat.Providers
 					loggerFactory.CreateLogger<DiscordProvider>(),
 					assemblyInformationProvider,
 					generalConfigurationOptions,
-					settings),
+					settings,
+					commandNamesFactory),
 				_ => throw new InvalidOperationException(String.Format(CultureInfo.InvariantCulture, "Invalid ChatProvider: {0}", settings.Provider)),
 			};
 		}

--- a/src/Tgstation.Server.Host/Configuration/GeneralConfiguration.cs
+++ b/src/Tgstation.Server.Host/Configuration/GeneralConfiguration.cs
@@ -133,6 +133,11 @@ namespace Tgstation.Server.Host.Configuration
 		public bool UseBasicWatchdog { get; set; }
 
 		/// <summary>
+		/// The Discord slash command name for TGS chat commands.
+		/// </summary>
+		public string DiscordSlashCommandName { get; set; } = "tgs";
+
+		/// <summary>
 		/// If the swagger documentation and UI should be made avaiable.
 		/// </summary>
 		public bool HostApiDocumentation { get; set; }

--- a/src/Tgstation.Server.Host/appsettings.yml
+++ b/src/Tgstation.Server.Host/appsettings.yml
@@ -10,6 +10,7 @@ General:
   ApiPort: 5000 # Port the HTTP API is hosted on
   PrometheusPort: null # Port Prometheus metrics are published on under /metrics. This can be set to the same value as the ApiPort, just note that accessing it does not require authentication.
   UseBasicWatchdog: false # The basic watchdog hard restarts DreamDaemon when /world/proc/TgsReboot() is called in the DMAPI if a new deployment is available
+  DiscordSlashCommandName: tgs # Discord slash command name used for TGS chat commands.
   UserLimit: 100 # Maximum number of allowed users
   UserGroupLimit: 25 # Maximum number of allowed groups
   InstanceLimit: 10 # Maximum number of allowed instances

--- a/tests/Tgstation.Server.Host.Tests/Components/Chat/Providers/TestDiscordProvider.cs
+++ b/tests/Tgstation.Server.Host.Tests/Components/Chat/Providers/TestDiscordProvider.cs
@@ -1,15 +1,27 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Moq;
 
+using OneOf;
+
+using Remora.Discord.API.Abstractions.Gateway.Events;
+using Remora.Discord.API.Abstractions.Objects;
+using Remora.Discord.API.Abstractions.Rest;
+using Remora.Rest.Core;
+using Remora.Results;
+
 using Tgstation.Server.Api.Models;
+using Tgstation.Server.Host.Components.Interop;
 using Tgstation.Server.Host.Configuration;
 using Tgstation.Server.Host.Jobs;
 using Tgstation.Server.Host.Models;
@@ -50,6 +62,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers.Tests
 		[TestMethod]
 		public async Task TestConstructionAndDisposal()
 		{
+			Func<IReadOnlyList<string>> commandNamesFactory = () => Array.Empty<string>();
 			var bot = new ChatBot
 			{
 				ConnectionString = "fake_token",
@@ -57,17 +70,236 @@ namespace Tgstation.Server.Host.Components.Chat.Providers.Tests
 				Instance = new Models.Instance(),
 			};
 
-			Assert.ThrowsExactly<ArgumentNullException>(() => new DiscordProvider(null, null, null, null, null, null));
-			Assert.ThrowsExactly<ArgumentNullException>(() => new DiscordProvider(mockJobManager, null, null, null, null, null));
+			Assert.ThrowsExactly<ArgumentNullException>(() => new DiscordProvider(null, null, null, null, null, null, commandNamesFactory));
+			Assert.ThrowsExactly<ArgumentNullException>(() => new DiscordProvider(mockJobManager, null, null, null, null, null, commandNamesFactory));
 			var mockDel = Mock.Of<IAsyncDelayer>();
-			Assert.ThrowsExactly<ArgumentNullException>(() => new DiscordProvider(mockJobManager, mockDel, null, null, null, null));
+			Assert.ThrowsExactly<ArgumentNullException>(() => new DiscordProvider(mockJobManager, mockDel, null, null, null, null, commandNamesFactory));
 			var mockLogger = Mock.Of<ILogger<DiscordProvider>>();
-			Assert.ThrowsExactly<ArgumentNullException>(() => new DiscordProvider(mockJobManager, mockDel, mockLogger, null, null, null));
+			Assert.ThrowsExactly<ArgumentNullException>(() => new DiscordProvider(mockJobManager, mockDel, mockLogger, null, null, null, commandNamesFactory));
 			var mockAss = Mock.Of<IAssemblyInformationProvider>();
-			Assert.ThrowsExactly<ArgumentNullException>(() => new DiscordProvider(mockJobManager, mockDel, mockLogger, mockAss, null, null));
-			var mockGen = Mock.Of<IOptionsMonitor<GeneralConfiguration>>();
-			Assert.ThrowsExactly<ArgumentNullException>(() => new DiscordProvider(mockJobManager, mockDel, mockLogger, mockAss, mockGen, null));
-			await new DiscordProvider(mockJobManager, mockDel, mockLogger, mockAss, mockGen, bot).DisposeAsync();
+			Assert.ThrowsExactly<ArgumentNullException>(() => new DiscordProvider(mockJobManager, mockDel, mockLogger, mockAss, null, null, commandNamesFactory));
+			var mockGen = new Mock<IOptionsMonitor<GeneralConfiguration>>();
+			mockGen.SetupGet(x => x.CurrentValue).Returns(new GeneralConfiguration());
+			Assert.ThrowsExactly<ArgumentNullException>(() => new DiscordProvider(mockJobManager, mockDel, mockLogger, mockAss, mockGen.Object, null, commandNamesFactory));
+			await new DiscordProvider(mockJobManager, mockDel, mockLogger, mockAss, mockGen.Object, bot, commandNamesFactory).DisposeAsync();
+		}
+
+		[TestMethod]
+		public async Task TestSlashCommandInteraction()
+		{
+			const ulong applicationId = 1;
+			const ulong channelId = 2;
+			const ulong userId = 3;
+			var channelSnowflake = new Snowflake(channelId);
+
+			var interactionApi = new Mock<IDiscordRestInteractionAPI>();
+			interactionApi
+				.Setup(x => x.CreateInteractionResponseAsync(
+					It.IsAny<Snowflake>(),
+					It.IsAny<string>(),
+					It.IsAny<IInteractionResponse>(),
+					It.IsAny<Optional<IReadOnlyList<OneOf<FileData, IPartialAttachment>>>>(),
+					It.IsAny<CancellationToken>()))
+				.ReturnsAsync(Result.FromSuccess());
+			interactionApi
+				.Setup(x => x.EditOriginalInteractionResponseAsync(
+					It.IsAny<Snowflake>(),
+					It.IsAny<string>(),
+					It.IsAny<Optional<string>>(),
+					It.IsAny<Optional<IReadOnlyList<IEmbed>>>(),
+					It.IsAny<Optional<IAllowedMentions>>(),
+					It.IsAny<Optional<IReadOnlyList<IMessageComponent>>>(),
+					It.IsAny<Optional<IReadOnlyList<OneOf<FileData, IPartialAttachment>>>>(),
+					It.IsAny<Optional<MessageFlags>>(),
+					It.IsAny<CancellationToken>()))
+				.ReturnsAsync(Result<IMessage>.FromSuccess(Mock.Of<IMessage>()));
+
+			var channel = new Mock<IChannel>();
+			channel.SetupGet(x => x.ID).Returns(new Snowflake(channelId));
+			channel.SetupGet(x => x.Type).Returns(ChannelType.DM);
+			channel.SetupGet(x => x.Name).Returns(new Optional<string>("test-channel"));
+			var channelApi = new Mock<IDiscordRestChannelAPI>();
+			channelApi
+				.Setup(x => x.GetChannelAsync(channelSnowflake, default(CancellationToken)))
+				.ReturnsAsync(Result<IChannel>.FromSuccess(channel.Object));
+
+			var user = new Mock<IUser>();
+			user.SetupGet(x => x.ID).Returns(new Snowflake(userId));
+			user.SetupGet(x => x.Username).Returns("test-user");
+
+			var option = new Mock<IApplicationCommandInteractionDataOption>();
+			option.SetupGet(x => x.Name).Returns("command");
+			option.SetupGet(x => x.Value).Returns(
+				new Optional<OneOf<string, long, bool, Snowflake, double>>(
+					OneOf<string, long, bool, Snowflake, double>.FromT0("info")));
+			var argumentsOption = new Mock<IApplicationCommandInteractionDataOption>();
+			argumentsOption.SetupGet(x => x.Name).Returns("arguments");
+			argumentsOption.SetupGet(x => x.Value).Returns(
+				new Optional<OneOf<string, long, bool, Snowflake, double>>(
+					OneOf<string, long, bool, Snowflake, double>.FromT0("--verbose")));
+
+			var commandData = new Mock<IApplicationCommandData>();
+			commandData.SetupGet(x => x.Name).Returns("tgs");
+			commandData.SetupGet(x => x.Options).Returns(
+				new Optional<IReadOnlyList<IApplicationCommandInteractionDataOption>>(
+					new List<IApplicationCommandInteractionDataOption> { option.Object, argumentsOption.Object }));
+
+			var partialChannel = new Mock<IPartialChannel>();
+			partialChannel.SetupGet(x => x.ID).Returns(new Snowflake(channelId));
+			var interaction = new Mock<IInteractionCreate>();
+			interaction.SetupGet(x => x.ID).Returns(new Snowflake(4));
+			interaction.SetupGet(x => x.ApplicationID).Returns(new Snowflake(applicationId));
+			interaction.SetupGet(x => x.Type).Returns(InteractionType.ApplicationCommand);
+			interaction.SetupGet(x => x.Data).Returns(
+				new Optional<OneOf<IApplicationCommandData, IMessageComponentData, IModalSubmitData>>(
+					OneOf<IApplicationCommandData, IMessageComponentData, IModalSubmitData>.FromT0(commandData.Object)));
+			interaction.SetupGet(x => x.Channel).Returns(new Optional<IPartialChannel>(partialChannel.Object));
+			interaction.SetupGet(x => x.User).Returns(new Optional<IUser>(user.Object));
+			interaction.SetupGet(x => x.Token).Returns("interaction-token");
+
+			var serviceProvider = new ServiceCollection()
+				.AddSingleton<IDiscordRestInteractionAPI>(interactionApi.Object)
+				.AddSingleton<IDiscordRestChannelAPI>(channelApi.Object)
+				.BuildServiceProvider();
+			await using var provider = new DiscordProvider(
+				mockJobManager,
+				Mock.Of<IAsyncDelayer>(),
+				Mock.Of<ILogger<DiscordProvider>>(),
+				Mock.Of<IAssemblyInformationProvider>(),
+				Mock.Of<IOptionsMonitor<GeneralConfiguration>>(),
+				new ChatBot
+				{
+					ConnectionString = "fake_token",
+					Instance = new Models.Instance(),
+				},
+				() => new List<string> { "info" },
+				serviceProvider);
+
+			var nextMessage = provider.NextMessage(CancellationToken.None);
+			var result = await provider.RespondAsync(interaction.Object, CancellationToken.None);
+			var message = await nextMessage;
+
+			Assert.IsTrue(result.IsSuccess);
+			Assert.IsNotNull(message);
+			Assert.AreEqual("!tgs info --verbose", message.Content);
+			Assert.AreEqual(channelId, message.User.Channel.RealId);
+			Assert.AreEqual(userId, message.User.RealId);
+			Assert.IsTrue(message.User.Channel.IsPrivateChannel);
+			Assert.AreEqual(new Snowflake(applicationId), ((DiscordMessage)message).ApplicationId.Value);
+			Assert.AreEqual("interaction-token", ((DiscordMessage)message).InteractionToken);
+			await provider.SendMessage(message, new MessageContent { Text = "reply" }, channelId, CancellationToken.None);
+			interactionApi.Verify(
+					x => x.CreateInteractionResponseAsync(
+						It.IsAny<Snowflake>(),
+						It.IsAny<string>(),
+						It.IsAny<IInteractionResponse>(),
+						It.IsAny<Optional<IReadOnlyList<OneOf<FileData, IPartialAttachment>>>>(),
+						It.IsAny<CancellationToken>()),
+				Times.Once);
+			var editInvocation = interactionApi.Invocations.Single(
+				invocation => invocation.Method.Name == nameof(IDiscordRestInteractionAPI.EditOriginalInteractionResponseAsync));
+			Assert.AreEqual(new Snowflake(applicationId), editInvocation.Arguments[0]);
+			Assert.AreEqual("interaction-token", editInvocation.Arguments[1]);
+			Assert.AreEqual("reply", ((Optional<string>)editInvocation.Arguments[2]).Value);
+		}
+
+		[TestMethod]
+		public async Task TestSlashCommandAutocomplete()
+		{
+			var interactionApi = new Mock<IDiscordRestInteractionAPI>();
+			interactionApi
+				.Setup(x => x.CreateInteractionResponseAsync(
+					It.IsAny<Snowflake>(),
+					It.IsAny<string>(),
+					It.IsAny<IInteractionResponse>(),
+					It.IsAny<Optional<IReadOnlyList<OneOf<FileData, IPartialAttachment>>>>(),
+					It.IsAny<CancellationToken>()))
+				.ReturnsAsync(Result.FromSuccess());
+
+			var option = new Mock<IApplicationCommandInteractionDataOption>();
+			option.SetupGet(x => x.Name).Returns("command");
+			option.SetupGet(x => x.IsFocused).Returns(new Optional<bool>(true));
+			option.SetupGet(x => x.Value).Returns(
+				new Optional<OneOf<string, long, bool, Snowflake, double>>(
+					OneOf<string, long, bool, Snowflake, double>.FromT0("re")));
+
+			var commandData = new Mock<IApplicationCommandData>();
+			commandData.SetupGet(x => x.Name).Returns("tgs");
+			commandData.SetupGet(x => x.Options).Returns(
+				new Optional<IReadOnlyList<IApplicationCommandInteractionDataOption>>(
+					new List<IApplicationCommandInteractionDataOption> { option.Object }));
+
+			var interaction = new Mock<IInteractionCreate>();
+			interaction.SetupGet(x => x.ID).Returns(new Snowflake(1));
+			interaction.SetupGet(x => x.Type).Returns(InteractionType.ApplicationCommandAutocomplete);
+			interaction.SetupGet(x => x.Data).Returns(
+				new Optional<OneOf<IApplicationCommandData, IMessageComponentData, IModalSubmitData>>(
+					OneOf<IApplicationCommandData, IMessageComponentData, IModalSubmitData>.FromT0(commandData.Object)));
+			interaction.SetupGet(x => x.Token).Returns("interaction-token");
+
+			var serviceProvider = new ServiceCollection()
+				.AddSingleton<IDiscordRestInteractionAPI>(interactionApi.Object)
+				.BuildServiceProvider();
+			await using var provider = new DiscordProvider(
+				mockJobManager,
+				Mock.Of<IAsyncDelayer>(),
+				Mock.Of<ILogger<DiscordProvider>>(),
+				Mock.Of<IAssemblyInformationProvider>(),
+				Mock.Of<IOptionsMonitor<GeneralConfiguration>>(),
+				new ChatBot
+				{
+					ConnectionString = "fake_token",
+					Instance = new Models.Instance(),
+				},
+				() => new List<string> { "info", "restart", "revision" },
+				serviceProvider);
+
+			var result = await provider.RespondAsync(interaction.Object, CancellationToken.None);
+
+			Assert.IsTrue(result.IsSuccess);
+			var response = (IInteractionResponse)interactionApi.Invocations.Single().Arguments[2];
+			Assert.AreEqual(InteractionCallbackType.ApplicationCommandAutocompleteResult, response.Type);
+			CollectionAssert.AreEqual(
+				new[] { "restart", "revision" },
+				response.Data.Value.AsT1.Choices.Select(choice => choice.Name).ToArray());
+			Assert.AreEqual("tgs", DiscordProvider.NormalizeSlashCommandName("TGS"));
+		}
+
+		[TestMethod]
+		public void TestSlashCommandOptionEnablesAutocomplete()
+		{
+			var options = (IReadOnlyList<IApplicationCommandOption>)typeof(DiscordProvider)
+				.GetField("SlashCommandOptions", BindingFlags.Static | BindingFlags.NonPublic)!
+				.GetValue(null)!;
+
+			Assert.IsTrue(options[0].IsRequired.HasValue && options[0].IsRequired.Value);
+			Assert.IsTrue(options[0].EnableAutocomplete.HasValue && options[0].EnableAutocomplete.Value);
+			Assert.IsFalse(options[0].IsDefault.HasValue);
+		}
+
+		[TestMethod]
+		public void TestSlashCommandNameMustNotContainSlash()
+		{
+			Assert.AreEqual("tgs", DiscordProvider.NormalizeSlashCommandName("TGS"));
+			Assert.AreEqual("тгс", DiscordProvider.NormalizeSlashCommandName("ТГС"));
+			Assert.ThrowsExactly<ArgumentException>(() => DiscordProvider.NormalizeSlashCommandName("/tgs"));
+		}
+
+		[TestMethod]
+		public void TestRegisteredTgsSlashCommandsAreStale()
+		{
+			static IApplicationCommand CreateCommand(string name, string description)
+			{
+				var command = new Mock<IApplicationCommand>();
+				command.SetupGet(x => x.Name).Returns(name);
+				command.SetupGet(x => x.Type).Returns(ApplicationCommandType.ChatInput);
+				command.SetupGet(x => x.Description).Returns(description);
+				return command.Object;
+			}
+
+			Assert.IsTrue(DiscordProvider.IsTgsSlashCommand(CreateCommand("custom-a", "Run a TGS chat command."), "custom-b"));
+			Assert.IsFalse(DiscordProvider.IsTgsSlashCommand(CreateCommand("custom-b", "Run a TGS chat command."), "custom-b"));
+			Assert.IsFalse(DiscordProvider.IsTgsSlashCommand(CreateCommand("custom-a", "Unrelated command."), "custom-b"));
 		}
 
 		static ValueTask InvokeConnect(IProvider provider, CancellationToken cancellationToken = default) => (ValueTask)provider.GetType().GetMethod("Connect", BindingFlags.Instance | BindingFlags.NonPublic).Invoke(provider, new object[] { cancellationToken });
@@ -81,7 +313,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers.Tests
 				ReconnectionInterval = 1,
 				ConnectionString = "asdf",
 				Instance = new Models.Instance(),
-			});
+			}, () => Array.Empty<string>());
 			await Assert.ThrowsExactlyAsync<JobException>(async () => await InvokeConnect(provider));
 			Assert.IsFalse(provider.Connected);
 		}
@@ -96,7 +328,7 @@ namespace Tgstation.Server.Host.Components.Chat.Providers.Tests
 				Assert.Fail("TGS_TEST_DISCORD_TOKEN is not a valid Discord connection string!");
 
 			var mockLogger = new Mock<ILogger<DiscordProvider>>();
-			await using var provider = new DiscordProvider(mockJobManager, Mock.Of<IAsyncDelayer>(), mockLogger.Object, Mock.Of<IAssemblyInformationProvider>(), Mock.Of<IOptionsMonitor<GeneralConfiguration>>(), testToken1);
+			await using var provider = new DiscordProvider(mockJobManager, Mock.Of<IAsyncDelayer>(), mockLogger.Object, Mock.Of<IAssemblyInformationProvider>(), Mock.Of<IOptionsMonitor<GeneralConfiguration>>(), testToken1, () => Array.Empty<string>());
 			Assert.IsFalse(provider.Connected);
 			await InvokeConnect(provider);
 			Assert.IsTrue(provider.Connected);

--- a/tests/Tgstation.Server.Tests/Live/DummyChatProviderFactory.cs
+++ b/tests/Tgstation.Server.Tests/Live/DummyChatProviderFactory.cs
@@ -64,10 +64,11 @@ namespace Tgstation.Server.Tests.Live
 			}; // hope you get the reference
 		}
 
-		public IProvider CreateProvider(ChatBot settings)
+		public IProvider CreateProvider(ChatBot settings, Func<IReadOnlyList<string>> commandNamesFactory)
 		{
 			logger.LogTrace("CreateProvider");
 			ArgumentNullException.ThrowIfNull(settings);
+			ArgumentNullException.ThrowIfNull(commandNamesFactory);
 
 			var provider = settings.Provider;
 			switch (provider)


### PR DESCRIPTION
[Base Branch]: dev

[Release Notes]: # (Your PR should contain a detailed list of notable changes, titled appropriately. This includes any observable changes to the server or DMAPI. See examples below.)

🆑 Core
Added a global Discord slash command for TGS chat bot commands.
Added autocomplete for built-in and active DMAPI chat command names in the slash command's required command field.
Added an optional arguments field to the Discord slash command.
/🆑

🆑 Configuration
Added `General:DiscordSlashCommandName` to configure the Discord slash command name, defaulting to `tgs`.
/🆑

[Why]:

Closes #2437

Discord's Message Content Intent is privileged and may be unavailable preventing normal message commands such as `!tgs` and bot mentions from being used. The slash command provides a supported command interface without requiring that intent, while autocomplete makes the available built-in and active DMAPI commands discoverable.

<img width="1078" height="487" alt="image" src="https://github.com/user-attachments/assets/ba0f9a19-6601-4ed3-bda6-cc2e8cd086b3" />
<img width="1139" height="456" alt="Screenshot 2026-08-15 191809" src="https://github.com/user-attachments/assets/1f1e48bc-7dab-4fe3-9cb5-e6384b4ad443" />
<img width="1146" height="127" alt="Screenshot 2026-08-15 191823" src="https://github.com/user-attachments/assets/4d356a80-559e-45e2-bd01-29e6c38b68bb" />


